### PR TITLE
Add modal manager and refactor modal usage

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -642,6 +642,7 @@
     <script src="js/data.js"></script>
     <script src="js/vertigo_data.js"></script>
     <script src="js/storage.js"></script>
+    <script src="js/modalManager.js"></script>
     <script src="js/ui.js"></script>
     <script src="js/commands.js"></script>
     <script src="js/keybinds.js"></script>

--- a/src/js/aliases.js
+++ b/src/js/aliases.js
@@ -54,7 +54,7 @@ class STOAliasManager {
     // Alias Manager Modal
     showAliasManager() {
         this.renderAliasList();
-        stoUI.showModal('aliasManagerModal');
+        modalManager.show('aliasManagerModal');
     }
 
     renderAliasList() {
@@ -179,8 +179,8 @@ class STOAliasManager {
         }
 
         this.updateAliasPreview();
-        stoUI.hideModal('aliasManagerModal');
-        stoUI.showModal('editAliasModal');
+        modalManager.hide('aliasManagerModal');
+        modalManager.show('editAliasModal');
     }
 
     editAlias(aliasName) {
@@ -228,7 +228,7 @@ class STOAliasManager {
         };
 
         app.addCommand(app.selectedKey, command);
-        stoUI.hideModal('aliasManagerModal');
+        modalManager.hide('aliasManagerModal');
         stoUI.showToast(`Alias "${aliasName}" added to ${app.selectedKey}`, 'success');
     }
 
@@ -287,7 +287,7 @@ class STOAliasManager {
         const action = this.currentAlias ? 'updated' : 'created';
         stoUI.showToast(`Alias "${name}" ${action}`, 'success');
         
-        stoUI.hideModal('editAliasModal');
+        modalManager.hide('editAliasModal');
         this.showAliasManager();
     }
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1367,7 +1367,7 @@ class STOToolsKeybindManager {
         
         // Command management
         document.getElementById('addCommandBtn')?.addEventListener('click', () => {
-            stoUI.showModal('addCommandModal');  
+            modalManager.show('addCommandModal');
         });
         
         document.getElementById('addFromTemplateBtn')?.addEventListener('click', () => {
@@ -1450,7 +1450,7 @@ class STOToolsKeybindManager {
             const keyName = document.getElementById('newKeyName')?.value.trim();
             if (keyName) {
                 this.addKey(keyName);
-                stoUI.hideModal('addKeyModal');
+                modalManager.hide('addKeyModal');
             }
         });
         
@@ -1475,7 +1475,7 @@ class STOToolsKeybindManager {
             btn.addEventListener('click', (e) => {
                 const modalId = e.target.dataset.modal || e.target.closest('button').dataset.modal;
                 if (modalId) {
-                    stoUI.hideModal(modalId);
+                    modalManager.hide(modalId);
                     
                     // Handle Vertigo modal cancellation - rollback to initial state
                     if (modalId === 'vertigoModal') {
@@ -1692,7 +1692,7 @@ class STOToolsKeybindManager {
 
     showWelcomeMessage() {
         localStorage.setItem('sto_keybind_manager_visited', 'true');
-        stoUI.showModal('aboutModal');
+        modalManager.show('aboutModal');
     }
 
     // Additional Methods
@@ -1863,7 +1863,7 @@ class STOToolsKeybindManager {
         }
         
         this.addCommand(this.selectedKey, command);
-        stoUI.hideModal('addCommandModal');
+        modalManager.hide('addCommandModal');
     }
     
     // Parameter Modal for Customizable Commands
@@ -1879,7 +1879,7 @@ class STOToolsKeybindManager {
         this.populateParameterModal(commandDef);
         
         // Show modal
-        stoUI.showModal('parameterModal');
+        modalManager.show('parameterModal');
     }
     
     createParameterModal() {
@@ -1939,7 +1939,7 @@ class STOToolsKeybindManager {
         }
         
         // Hide modal
-        stoUI.hideModal('parameterModal');
+        modalManager.hide('parameterModal');
     }
     
     populateParameterModal(commandDef) {
@@ -2395,7 +2395,7 @@ class STOToolsKeybindManager {
                 this.addCommand(this.selectedKey, command);
             }
             
-            stoUI.hideModal('parameterModal');
+            modalManager.hide('parameterModal');
             this.currentParameterCommand = null;
             
             // Reset modal button text
@@ -2520,7 +2520,7 @@ class STOToolsKeybindManager {
         document.getElementById('saveParameterCommandBtn').textContent = 'Update Command';
         
         // Show modal
-        stoUI.showModal('parameterModal');
+        modalManager.show('parameterModal');
     }
     
     populateParameterModalForEdit(commandDef, existingParams) {
@@ -2658,7 +2658,7 @@ class STOToolsKeybindManager {
 
     showKeySelectionModal() {
         this.setupKeySelectionModal();
-        stoUI.showModal('keySelectionModal');
+        modalManager.show('keySelectionModal');
     }
 
     setupKeySelectionModal() {
@@ -2846,7 +2846,7 @@ class STOToolsKeybindManager {
     }
 
     selectKeyFromModal(keyName) {
-        stoUI.hideModal('keySelectionModal');
+        modalManager.hide('keySelectionModal');
         this.selectKey(keyName);
     }
 
@@ -2882,7 +2882,7 @@ class STOToolsKeybindManager {
         
         this.populateVertigoModal();
         this.setupVertigoEventListeners();
-        stoUI.showModal('vertigoModal');
+        modalManager.show('vertigoModal');
     }
 
     populateVertigoModal() {
@@ -3215,7 +3215,7 @@ class STOToolsKeybindManager {
         this.vertigoSaving = true;
 
         // Close modal and show success message
-        stoUI.hideModal('vertigoModal');
+        modalManager.hide('vertigoModal');
         stoUI.showToast(`Generated ${addedCount} Vertigo alias${addedCount > 1 ? 'es' : ''}! Check the Alias Manager to bind them to keys.`, 'success');
     }
 

--- a/src/js/modalManager.js
+++ b/src/js/modalManager.js
@@ -1,0 +1,45 @@
+class STOModalManager {
+    constructor() {
+        this.overlayId = 'modalOverlay';
+    }
+
+    getOverlay() {
+        return document.getElementById(this.overlayId);
+    }
+
+    show(id) {
+        const modal = typeof id === 'string' ? document.getElementById(id) : id;
+        const overlay = this.getOverlay();
+        if (overlay && modal) {
+            overlay.classList.add('active');
+            modal.classList.add('active');
+            document.body.classList.add('modal-open');
+
+            const firstInput = modal.querySelector('input, textarea, select');
+            if (firstInput) {
+                setTimeout(() => firstInput.focus(), 100);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    hide(id) {
+        const modal = typeof id === 'string' ? document.getElementById(id) : id;
+        const overlay = this.getOverlay();
+        if (overlay && modal) {
+            modal.classList.remove('active');
+
+            // Hide overlay if no other modals are active
+            if (!document.querySelector('.modal.active')) {
+                overlay.classList.remove('active');
+                document.body.classList.remove('modal-open');
+            }
+            return true;
+        }
+        return false;
+    }
+}
+
+// Global instance
+window.modalManager = new STOModalManager();

--- a/src/js/profiles.js
+++ b/src/js/profiles.js
@@ -91,7 +91,7 @@ class STOProfileManager {
         });
 
         document.getElementById('aboutBtn')?.addEventListener('click', () => {
-            stoUI.showModal('aboutModal');
+            modalManager.show('aboutModal');
         });
 
         document.getElementById('themeToggleBtn')?.addEventListener('click', () => {
@@ -124,7 +124,7 @@ class STOProfileManager {
         }
 
         this.currentModal = 'new';
-        stoUI.showModal('profileModal');
+        modalManager.show('profileModal');
     }
 
     showCloneProfileModal() {
@@ -149,7 +149,7 @@ class STOProfileManager {
         }
 
         this.currentModal = 'clone';
-        stoUI.showModal('profileModal');
+        modalManager.show('profileModal');
     }
 
     showRenameProfileModal() {
@@ -174,7 +174,7 @@ class STOProfileManager {
         }
 
         this.currentModal = 'rename';
-        stoUI.showModal('profileModal');
+        modalManager.show('profileModal');
     }
 
     handleProfileSave() {
@@ -224,7 +224,7 @@ class STOProfileManager {
                     break;
             }
 
-            stoUI.hideModal('profileModal');
+            modalManager.hide('profileModal');
             this.currentModal = null;
         } catch (error) {
             stoUI.showToast('Failed to save profile: ' + error.message, 'error');

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -86,60 +86,38 @@ class STOUIManager {
 
     // Modal Management
     showModal(modalId, data = null) {
-        const overlay = document.getElementById('modalOverlay');
         const modal = document.getElementById(modalId);
-        
-        if (overlay && modal) {
-            overlay.classList.add('active');
-            modal.classList.add('active');
-            document.body.classList.add('modal-open');
-            
-            // Focus first input if available
-            const firstInput = modal.querySelector('input, textarea, select');
-            if (firstInput) {
-                setTimeout(() => firstInput.focus(), 100);
-            }
+
+        if (modalManager.show(modalId)) {
             
             // Populate modal data if provided
             if (data) {
                 this.populateModalData(modalId, data);
             }
-            
             return true;
         }
         return false;
     }
 
     hideModal(modalId) {
-        const overlay = document.getElementById('modalOverlay');
         const modal = document.getElementById(modalId);
-        
-        if (overlay && modal) {
-            overlay.classList.remove('active');
-            modal.classList.remove('active');
-            document.body.classList.remove('modal-open');
+
+        if (modalManager.hide(modalId)) {
             
             // Clear modal data
             this.clearModalData(modalId);
-            
+
             return true;
         }
         return false;
     }
 
     hideAllModals() {
-        const overlay = document.getElementById('modalOverlay');
         const modals = document.querySelectorAll('.modal.active');
-        
-        if (overlay) {
-            overlay.classList.remove('active');
-        }
-        
+
         modals.forEach(modal => {
-            modal.classList.remove('active');
+            modalManager.hide(modal.id);
         });
-        
-        document.body.classList.remove('modal-open');
     }
 
     populateModalData(modalId, data) {
@@ -210,36 +188,26 @@ class STOUIManager {
     async confirm(message, title = 'Confirm', type = 'warning') {
         return new Promise((resolve) => {
             const confirmModal = this.createConfirmModal(message, title, type);
+            const confirmId = 'confirmModal';
+            confirmModal.id = confirmId;
             document.body.appendChild(confirmModal);
-            
-            // Use the global modal overlay
-            const overlay = document.getElementById('modalOverlay');
-            if (overlay) {
-                overlay.classList.add('active');
-            }
-            document.body.classList.add('modal-open');
-            
+
             const handleConfirm = (result) => {
-                // Clean up modal and overlay
-                if (overlay) {
-                    overlay.classList.remove('active');
-                }
-                document.body.classList.remove('modal-open');
+                modalManager.hide(confirmId);
                 document.body.removeChild(confirmModal);
                 resolve(result);
             };
-            
+
             confirmModal.querySelector('.confirm-yes').addEventListener('click', () => {
                 handleConfirm(true);
             });
-            
+
             confirmModal.querySelector('.confirm-no').addEventListener('click', () => {
                 handleConfirm(false);
             });
-            
-            // Show modal
+
             requestAnimationFrame(() => {
-                confirmModal.classList.add('active');
+                modalManager.show(confirmId);
             });
         });
     }


### PR DESCRIPTION
## Summary
- implement `modalManager.js` with `show()` and `hide()` helpers
- update `ui.js` modal methods to delegate to `modalManager`
- refactor aliases, profiles and app modules to use the new manager
- include `modalManager.js` in `index.html`

## Testing
- `npm test` *(fails: browser binaries missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854437384f483258817afc03e708f36