### PR TITLE
Implement internal event bus

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -638,6 +638,7 @@
 
     <!-- Scripts -->
     <script src="js/constants.js"></script>
+    <script src="js/eventBus.js"></script>
     <script src="js/errors.js"></script>
     <script src="js/version.js"></script>
     <script src="js/data.js"></script>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -57,7 +57,8 @@ class STOToolsKeybindManager {
             
             stoUI.showToast('STO Tools Keybind Manager loaded successfully', 'success');
             
-            // Dispatch app ready event
+            // Dispatch app ready event through eventBus and DOM for compatibility
+            eventBus.emit('sto-app-ready', { app: this });
             const readyEvent = new CustomEvent('sto-app-ready', {
                 detail: { app: this }
             });
@@ -69,7 +70,8 @@ class STOToolsKeybindManager {
                 stoUI.showToast('Failed to load application', 'error');
             }
             
-            // Dispatch error event
+            // Dispatch error event through eventBus and DOM for compatibility
+            eventBus.emit('sto-app-error', { error });
             const errorEvent = new CustomEvent('sto-app-error', {
                 detail: { error }
             });
@@ -3269,7 +3271,7 @@ const app = new STOToolsKeybindManager();
 window.app = app;
 
 // Initialize other modules after app is ready
-window.addEventListener('sto-app-ready', () => {
+eventBus.on('sto-app-ready', () => {
     if (typeof stoProfiles !== 'undefined') {
         stoProfiles.init();
     }

--- a/src/js/eventBus.js
+++ b/src/js/eventBus.js
@@ -1,0 +1,29 @@
+(function(global){
+  const listeners = {};
+
+  function on(event, handler) {
+    if (!listeners[event]) {
+      listeners[event] = new Set();
+    }
+    listeners[event].add(handler);
+  }
+
+  function off(event, handler) {
+    if (listeners[event]) {
+      listeners[event].delete(handler);
+    }
+  }
+
+  function emit(event, detail) {
+    if (!listeners[event]) return;
+    for (const handler of listeners[event]) {
+      try {
+        handler(detail);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  }
+
+  global.eventBus = { on, off, emit };
+})(typeof window !== 'undefined' ? window : this);

--- a/tests/browser-setup.js
+++ b/tests/browser-setup.js
@@ -141,6 +141,7 @@ async function loadApplication() {
   // Then load the scripts
   const scripts = [
     '/src/js/constants.js',
+    '/src/js/eventBus.js',
     '/src/js/errors.js',
     '/src/js/version.js',
     '/src/js/data.js',

--- a/tests/integration/app-workflow.test.js
+++ b/tests/integration/app-workflow.test.js
@@ -39,6 +39,7 @@ describe('App Workflow Integration', () => {
     await import('../../src/js/keybinds.js')
     await import('../../src/js/export.js')
     await import('../../src/js/ui.js')
+    await import('../../src/js/eventBus.js')
     await import('../../src/js/app.js')
     
     // Get global instances

--- a/tests/unit/app.test.js
+++ b/tests/unit/app.test.js
@@ -11,6 +11,7 @@ import '../../src/js/storage.js'
 import '../../src/js/profiles.js'
 import '../../src/js/keybinds.js'
 import '../../src/js/ui.js'
+import '../../src/js/eventBus.js'
 import '../../src/js/app.js'
 
 /**

--- a/tests/unit/export.test.js
+++ b/tests/unit/export.test.js
@@ -8,6 +8,7 @@ import '../../src/js/storage.js'
 import '../../src/js/profiles.js'
 import '../../src/js/keybinds.js'
 import '../../src/js/ui.js'
+import '../../src/js/eventBus.js'
 import '../../src/js/app.js'
 // Load the export module (it creates a global instance)
 import '../../src/js/export.js'


### PR DESCRIPTION
## Summary
- create simple `eventBus` with `on`, `off` and `emit`
- include bus in `index.html`
- use the bus in `app.js` instead of DOM-based `CustomEvent`
- load `eventBus.js` during tests and still dispatch DOM events for compatibility

## Testing
- `npm test` *(fails: Not implemented: navigation (except hash changes))*
- `npx vitest run --project=browser tests/browser/user-workflows.test.js` *(passes with unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_6854b0e51bf083259eca43f938eef407