### PR TITLE
Add ESLint and Prettier with project formatting

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+    node: true
+  },
+  extends: ['standard', 'plugin:prettier/recommended'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  rules: {}
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": false,
+  "trailingComma": "es5"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,18 @@
         "@vitest/coverage-istanbul": "^1.6.1",
         "@vitest/coverage-v8": "^1.0.4",
         "@vitest/ui": "^1.0.4",
+        "eslint": "^8.57.1",
+        "eslint-config-prettier": "^10.1.5",
+        "eslint-config-standard": "^17.1.0",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-n": "^16.6.2",
+        "eslint-plugin-prettier": "^5.5.0",
+        "eslint-plugin-promise": "^6.6.0",
         "happy-dom": "^18.0.1",
         "http-server": "^14.1.1",
         "jsdom": "^23.0.1",
         "playwright": "^1.40.1",
+        "prettier": "^3.5.3",
         "rollup": "^4.44.0",
         "vitest": "^1.0.4"
       },
@@ -825,6 +833,123 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -946,6 +1071,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
+      "integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@polka/url": {
@@ -1306,6 +1444,13 @@
         "win32"
       ]
     },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1316,6 +1461,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1341,6 +1493,13 @@
       "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@vitest/browser": {
       "version": "1.6.1",
@@ -1528,6 +1687,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
@@ -1550,6 +1719,33 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1564,6 +1760,135 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/assertion-error": {
@@ -1582,12 +1907,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1683,6 +2034,29 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/builtins": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.1.0.tgz",
+      "integrity": "sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1690,6 +2064,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -1721,6 +2114,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1924,6 +2327,60 @@
         "node": ">=18"
       }
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -1960,6 +2417,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -1968,6 +2432,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -1987,6 +2487,19 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/dunder-proto": {
@@ -2022,6 +2535,75 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-define-property": {
@@ -2073,6 +2655,37 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -2121,6 +2734,482 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-compat-utils": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
+      "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-config-standard": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.1.0.tgz",
+      "integrity": "sha512-IwHwmaBNtDK4zDHQukFDW5u/aTb8+meQWZvNFWkiGmbWjD6bqyuSSBxxXKkCftCUzc1zwCH2m/baCNDLGmuO5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.1",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
+        "eslint-plugin-promise": "^6.0.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-es-x": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
+      "integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/ota-meshi",
+        "https://opencollective.com/eslint"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.11.0",
+        "eslint-compat-utils": "^0.5.1"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
+      "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.8",
+        "array.prototype.findlastindex": "^1.2.5",
+        "array.prototype.flat": "^1.3.2",
+        "array.prototype.flatmap": "^1.3.2",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.0",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.15.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.0",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.8",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-n": {
+      "version": "16.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.6.2.tgz",
+      "integrity": "sha512-6TyDmZ1HXoFQXnhCTUjVFULReoBPOAjpuiKELMkeP40yffI/1ZRO+d9ug/VC6fqISo2WkuIBk3cvuRPALaWlOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es-x": "^7.5.0",
+        "get-tsconfig": "^4.7.0",
+        "globals": "^13.24.0",
+        "ignore": "^5.2.4",
+        "is-builtin-module": "^3.2.1",
+        "is-core-module": "^2.12.1",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.2",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.0.tgz",
+      "integrity": "sha512-8qsOYwkkGrahrgoUv76NZi23koqXOGiiEzXMrT8Q7VcYaUISR+5MorIUxfWqYXN0fN/31WbSrxCxFkVQ43wwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.11.7"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-promise": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.6.0.tgz",
+      "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2128,6 +3217,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eventemitter3": {
@@ -2160,6 +3259,20 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -2176,6 +3289,20 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -2194,6 +3321,19 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2205,6 +3345,38 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
     "node_modules/flatted": {
@@ -2233,6 +3405,22 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/form-data": {
@@ -2278,6 +3466,37 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2353,6 +3572,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -2398,6 +3648,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2410,6 +3677,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/happy-dom": {
       "version": "18.0.1",
@@ -2436,6 +3710,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2444,6 +3731,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -2611,6 +3927,43 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2630,6 +3983,121 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -2638,6 +4106,41 @@
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2656,6 +4159,41 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2669,12 +4207,38 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -2686,12 +4250,87 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-stream": {
       "version": "3.0.0",
@@ -2704,6 +4343,110 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2788,6 +4531,19 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsdom": {
       "version": "23.2.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.2.0.tgz",
@@ -2868,6 +4624,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -2879,6 +4656,30 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/local-pkg": {
@@ -2896,6 +4697,29 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "2.3.7",
@@ -3120,6 +4944,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -3167,6 +4998,90 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3202,6 +5117,42 @@
         "opener": "bin/opener-bin.js"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/p-limit": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
@@ -3217,6 +5168,64 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -3228,6 +5237,16 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
@@ -3353,6 +5372,16 @@
         "node": ">= 10.12"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -3379,6 +5408,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-format": {
@@ -3490,6 +5558,50 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3528,6 +5640,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -3537,6 +5669,23 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {
@@ -3609,12 +5758,67 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -3664,6 +5868,55 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/shebang-command": {
@@ -3845,6 +6098,102 @@
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "license": "MIT"
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
@@ -3852,6 +6201,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3902,6 +6264,22 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/synckit": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
+      "integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.4"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
     "node_modules/terser": {
       "version": "5.43.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
@@ -3935,6 +6313,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -4012,6 +6397,45 @@
         "node": ">=18"
       }
     },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
@@ -4021,11 +6445,121 @@
         "node": ">=4"
       }
     },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ufo": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "license": "MIT"
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -4085,6 +6619,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/url-join": {
@@ -4349,6 +6893,95 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4363,6 +6996,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "test:unit": "vitest run --project=unit --workspace=vitest.workspace.js",
     "test:browser": "vitest run --project=browser --workspace=vitest.workspace.js",
     "test:browser:ui": "vitest --ui --project=browser --workspace=vitest.workspace.js",
-    "test:all": "vitest run --workspace=vitest.workspace.js"
+    "test:all": "vitest run --workspace=vitest.workspace.js",
+    "lint": "eslint \"{src,tests}/**/*.js\"",
+    "format": "prettier --write \"{src,tests}/**/*.{js,css,html}\""
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^16.0.1",
@@ -27,10 +29,18 @@
     "@vitest/coverage-istanbul": "^1.6.1",
     "@vitest/coverage-v8": "^1.0.4",
     "@vitest/ui": "^1.0.4",
+    "eslint": "^8.57.1",
+    "eslint-config-prettier": "^10.1.5",
+    "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-n": "^16.6.2",
+    "eslint-plugin-prettier": "^5.5.0",
+    "eslint-plugin-promise": "^6.6.0",
     "happy-dom": "^18.0.1",
     "http-server": "^14.1.1",
     "jsdom": "^23.0.1",
     "playwright": "^1.40.1",
+    "prettier": "^3.5.3",
     "rollup": "^4.44.0",
     "vitest": "^1.0.4"
   },

--- a/src/dist/bundle.js
+++ b/src/dist/bundle.js
@@ -1,1 +1,7884 @@
-const e="v2025.06.20-preview-1",t={};function a(e,a){t[e]||(t[e]=new Set),t[e].add(a)}function n(e,a){t[e]&&t[e].delete(a)}function o(e,a){if(t[e])for(const n of t[e])try{n(a)}catch(e){console.error(e)}}var i={on:a,off:n,emit:o,onDom:function(e,t,i,r){if("string"==typeof e&&(e=document.getElementById(e)),!e||!e.addEventListener)return()=>{};"function"==typeof i&&(r=i,i=t),i||(i=t);const s=e=>o(i,e);return e.addEventListener(t,s),r&&a(i,r),()=>{e.removeEventListener(t,s),r&&n(i,r)}}};const r={commands:{targeting:{name:"Targeting",icon:"fas fa-crosshairs",description:"Target selection and management",commands:{target:{name:"Target by Name",command:"Target",description:"Target entity by name (requires quotes)",syntax:'Target "EntityName"',icon:"🎯",customizable:!0,parameters:{entityName:{type:"text",default:"EntityName",placeholder:"Enter entity name"}}},target_enemy_near:{name:"Target Nearest Enemy",command:"Target_Enemy_Near",description:"Target the nearest enemy in view",syntax:"Target_Enemy_Near",icon:"🎯"},target_friend_near:{name:"Target Nearest Friend",command:"Target_Friend_Near",description:"Target the nearest friendly entity",syntax:"Target_Friend_Near",icon:"🤝"},target_self:{name:"Target Self",command:"Target_Self",description:"Target your own ship/character",syntax:"Target_Self",icon:"👤"},target_clear:{name:"Clear Target",command:"Target_Clear",description:"Remove current target lock",syntax:"Target_Clear",icon:"❌"},target_teammate_1:{name:"Target Teammate 1",command:"Target_Teammate 1",description:"Target first team member",syntax:"Target_Teammate 1",icon:"👥"},target_teammate_2:{name:"Target Teammate 2",command:"Target_Teammate 2",description:"Target second team member",syntax:"Target_Teammate 2",icon:"👥"},target_teammate_3:{name:"Target Teammate 3",command:"Target_Teammate 3",description:"Target third team member",syntax:"Target_Teammate 3",icon:"👥"},target_teammate_4:{name:"Target Teammate 4",command:"Target_Teammate 4",description:"Target fourth team member",syntax:"Target_Teammate 4",icon:"👥"}}},combat:{name:"Combat",icon:"fas fa-fire",description:"Weapon firing and combat actions",commands:{fire_all:{name:"Fire All Weapons",command:"FireAll",description:"Fire all weapons",syntax:"FireAll",environment:"space",icon:"🔥",warning:"Not recommended on spam bars as it interferes with firing cycles"},fire_phasers:{name:"Fire Energy Weapons",command:"FirePhasers",description:"Fire all Energy Weapons",syntax:"FirePhasers",environment:"space",icon:"⚡",warning:"Not recommended on spam bars as it interferes with firing cycles"},fire_torps:{name:"Fire Torpedoes",command:"FireTorps",description:"Fire all Torpedos",syntax:"FireTorps",environment:"space",icon:"🚀",warning:"Not recommended on spam bars as it interferes with firing cycles"},fire_mines:{name:"Fire Mines",command:"FireMines",description:"Fire all Mines",syntax:"FireMines",environment:"space",icon:"💣",warning:"Not recommended on spam bars as it interferes with firing cycles"},fire_phasers_torps:{name:"Fire Phasers & Torpedoes",command:"FirePhasersTorps",description:"Fire phasers & torpedos",syntax:"FirePhasersTorps",environment:"space",icon:"💥",warning:"Not recommended on spam bars as it interferes with firing cycles"},fire_projectiles:{name:"Fire Projectiles",command:"FireProjectiles",description:"Fire torpedos & mines",syntax:"FireProjectiles",environment:"space",icon:"🎯",warning:"Not recommended on spam bars as it interferes with firing cycles"}}},tray:{name:"Tray Execution",icon:"fas fa-th",description:"Execute abilities from action trays",commands:{custom_tray:{name:"Tray Execution",command:"+STOTrayExecByTray 0 0",description:"Execute specific tray slot",syntax:"+STOTrayExecByTray <tray> <slot>",icon:"⚡",customizable:!0,parameters:{tray:{type:"number",min:0,max:9,default:0},slot:{type:"number",min:0,max:9,default:0},command_type:{type:"select",options:["STOTrayExecByTray","TrayExecByTray"],default:"STOTrayExecByTray"}}},tray_with_backup:{name:"Tray Execution with Backup",command:"TrayExecByTrayWithBackup 1 0 0 0 0",description:"Execute specific tray slot with backup ability",syntax:"TrayExecByTrayWithBackup <active> <tray> <slot> <backup_tray> <backup_slot>",icon:"⚡",customizable:!0,parameters:{active:{type:"number",min:0,max:1,default:1},tray:{type:"number",min:0,max:9,default:0},slot:{type:"number",min:0,max:9,default:0},backup_tray:{type:"number",min:0,max:9,default:0},backup_slot:{type:"number",min:0,max:9,default:0}}},tray_range:{name:"Tray Range Execution",command:"+STOTrayExecByTray 0 0",description:"Execute a range of tray slots",syntax:"+STOTrayExecByTray <tray> <slot> $$ ... (range)",icon:"⚡",customizable:!0,parameters:{start_tray:{type:"number",min:0,max:9,default:0},start_slot:{type:"number",min:0,max:9,default:0},end_tray:{type:"number",min:0,max:9,default:0},end_slot:{type:"number",min:0,max:9,default:0},command_type:{type:"select",options:["STOTrayExecByTray","TrayExecByTray"],default:"STOTrayExecByTray"}}},tray_range_with_backup:{name:"Tray Range with Backup",command:"TrayExecByTrayWithBackup 1 0 0 0 0",description:"Execute a range of tray slots with backup abilities",syntax:"TrayExecByTrayWithBackup <active> <tray> <slot> <backup_tray> <backup_slot> $$ ... (range)",icon:"⚡",customizable:!0,parameters:{active:{type:"number",min:0,max:1,default:1},start_tray:{type:"number",min:0,max:9,default:0},start_slot:{type:"number",min:0,max:9,default:0},end_tray:{type:"number",min:0,max:9,default:0},end_slot:{type:"number",min:0,max:9,default:0},backup_start_tray:{type:"number",min:0,max:9,default:0},backup_start_slot:{type:"number",min:0,max:9,default:0},backup_end_tray:{type:"number",min:0,max:9,default:0},backup_end_slot:{type:"number",min:0,max:9,default:0}}},whole_tray:{name:"Whole Tray Execution",command:"+STOTrayExecByTray 0 0",description:"Execute all slots in a tray",syntax:"+STOTrayExecByTray <tray> <slot> $$ ... (all slots)",icon:"⚡",customizable:!0,parameters:{tray:{type:"number",min:0,max:9,default:0},command_type:{type:"select",options:["STOTrayExecByTray","TrayExecByTray"],default:"STOTrayExecByTray"}}},whole_tray_with_backup:{name:"Whole Tray with Backup",command:"TrayExecByTrayWithBackup 1 0 0 0 0",description:"Execute all slots in a tray with backup tray",syntax:"TrayExecByTrayWithBackup <active> <tray> <slot> <backup_tray> <backup_slot> $$ ... (all slots)",icon:"⚡",customizable:!0,parameters:{active:{type:"number",min:0,max:1,default:1},tray:{type:"number",min:0,max:9,default:0},backup_tray:{type:"number",min:0,max:9,default:0}}}}},power:{name:"Shield Management",icon:"fas fa-shield-alt",description:"Shield power and distribution management",commands:{distribute_shields:{name:"Distribute Shields",command:"+power_exec Distribute_Shields",description:"Evenly distributes shields as if clicking in the middle of the ship and shields icon",syntax:"+power_exec Distribute_Shields",environment:"space",icon:"🛡️",warning:"Not recommended on spam bars as it interferes with firing cycles"},reroute_shields_rear:{name:"Reroute Shields Rear",command:"+power_exec reroute_shields_rear",description:"Route shield power to rear facing",syntax:"+power_exec reroute_shields_rear",environment:"space",icon:"🛡️"},reroute_shields_left:{name:"Reroute Shields Left",command:"+power_exec reroute_shields_left",description:"Route shield power to left side",syntax:"+power_exec reroute_shields_left",environment:"space",icon:"🛡️"},reroute_shields_right:{name:"Reroute Shields Right",command:"+power_exec reroute_shields_right",description:"Route shield power to right side",syntax:"+power_exec reroute_shields_right",environment:"space",icon:"🛡️"},reroute_shields_forward:{name:"Reroute Shields Forward",command:"+power_exec reroute_shields_forward",description:"Route shield power to forward facing",syntax:"+power_exec reroute_shields_forward",environment:"space",icon:"🛡️"}}},movement:{name:"Movement",icon:"fas fa-arrows-alt",description:"Ship movement and navigation",commands:{full_impulse:{name:"Full Impulse",command:"+fullimpulse",description:"Engage full impulse drive",syntax:"+fullimpulse",environment:"space",icon:"🚀"},reverse:{name:"Reverse",command:"+reverse",description:"Reverse engines",syntax:"+reverse",icon:"⬅️"},throttle_adjust:{name:"Throttle Adjust",command:"ThrottleAdjust",description:"Increase or decrease the throttle by amount",syntax:"ThrottleAdjust <amount>",icon:"⚡",customizable:!0,parameters:{amount:{type:"number",min:-1,max:1,default:.25,step:.05}}},throttle_set:{name:"Throttle Set",command:"ThrottleSet",description:"Set the throttle to a specific position (negative = reverse, 0 = stop)",syntax:"ThrottleSet <position>",icon:"🎛️",customizable:!0,parameters:{position:{type:"number",min:-1,max:1,default:1,step:.1}}},throttle_toggle:{name:"Throttle Toggle",command:"ThrottleToggle",description:"Alternates between full throttle and full stop",syntax:"ThrottleToggle",icon:"🔄"},turn_left:{name:"Turn Left",command:"+turnleft",description:"Turn ship left (continuous while held)",syntax:"+turnleft",icon:"↪️"},turn_right:{name:"Turn Right",command:"+turnright",description:"Turn ship right (continuous while held)",syntax:"+turnright",icon:"↩️"},pitch_up:{name:"Pitch Up",command:"+up",description:"Pitch ship nose up (space altitude change)",syntax:"+up",icon:"⬆️"},pitch_down:{name:"Pitch Down",command:"+down",description:"Pitch ship nose down (space altitude change)",syntax:"+down",icon:"⬇️"},strafe_left:{name:"Strafe Left",command:"+left",description:"Strafe ship left",syntax:"+left",icon:"⬅️"},strafe_right:{name:"Strafe Right",command:"+right",description:"Strafe ship right",syntax:"+right",icon:"➡️"},forward:{name:"Forward",command:"+forward",description:"Move forward",syntax:"+forward",icon:"⬆️"},backward:{name:"Backward",command:"+backward",description:"Move backward",syntax:"+backward",icon:"⬇️"},auto_forward:{name:"Auto Forward",command:"autoForward",description:"Character moves forward until given new movement commands",syntax:"autoForward",environment:"ground",icon:"🏃"},follow:{name:"Follow Target",command:"Follow",description:"Follow the targeted entity",syntax:"Follow",icon:"👥"},follow_cancel:{name:"Cancel Follow",command:"Follow_Cancel",description:"Stop following and forget about the target",syntax:"Follow_Cancel",icon:"❌"}}},camera:{name:"Camera",icon:"fas fa-video",description:"Camera control and view management",commands:{zoom_in:{name:"Zoom In",command:"Camzoomin",description:"Zoom the camera in",syntax:"Camzoomin",icon:"🔍"},zoom_out:{name:"Zoom Out",command:"Camzoomout",description:"Zoom the camera out",syntax:"Camzoomout",icon:"🔎"},zoom_in_small:{name:"Zoom In Small",command:"Camzoominsmall",description:"Zoom the camera in slightly",syntax:"Camzoominsmall",icon:"🔍"},zoom_out_small:{name:"Zoom Out Small",command:"Camzoomoutsmall",description:"Zoom the camera out slightly",syntax:"Camzoomoutsmall",icon:"🔎"},cam_distance:{name:"Set Camera Distance",command:"camdist",description:"Sets the camera distance from the player",syntax:"camdist <distance>",icon:"📏",customizable:!0,parameters:{distance:{type:"number",min:1,max:500,default:50}}},cam_reset:{name:"Reset Camera",command:"CamReset",description:"Reset the camera position to default",syntax:"CamReset",icon:"🔄"},cam_target_lock:{name:"Lock Camera to Target",command:"Camsetlocktotarget",description:"Lock or unlock the camera to the target",syntax:"Camsetlocktotarget",icon:"🎯"},cam_cycle_distance:{name:"Cycle Camera Distance",command:"camCycleDist",description:"Cycle the camera distance between several preset values",syntax:"camCycleDist",icon:"🔄"},cam_mouse_look:{name:"Mouse Look",command:"+camMouseLook",description:"Enable mouse look camera control",syntax:"+camMouseLook",icon:"🖱️"},cam_turn_to_face:{name:"Turn to Face Camera",command:"+camTurnToFace",description:"Turn ship to face camera direction",syntax:"+camTurnToFace",icon:"↪️"},look_up:{name:"Look Up",command:"lookUp",description:"Change point of view to look straight up",syntax:"lookUp",icon:"⬆️"},look_down:{name:"Look Down",command:"lookDown",description:"Change point of view to look straight down",syntax:"lookDown",icon:"⬇️"}}},communication:{name:"Communication",icon:"fas fa-comments",description:"Chat and team communication",commands:{team_message:{name:"Team Message",command:"team",description:"Send message to team",syntax:"team message",icon:"💬",customizable:!0,parameters:{message:{type:"text",default:"Message text here"}}},local_message:{name:"Local Message",command:"say",description:"Send message to local area",syntax:"say message",icon:"📢",customizable:!0,parameters:{message:{type:"text",default:"Message text here"}}},zone_message:{name:"Zone Message",command:"zone",description:"Send message to zone",syntax:"zone message",icon:"📡",customizable:!0,parameters:{message:{type:"text",default:"Message text here"}}}}},system:{name:"System",icon:"fas fa-cog",description:"UI and system commands",commands:{toggle_hud:{name:"Toggle HUD",command:"+GenToggleHUD",description:"Toggle HUD visibility",syntax:"+GenToggleHUD",icon:"👁️"},screenshot:{name:"Screenshot",command:"screenshot",description:"Take a screenshot",syntax:"screenshot",icon:"📷"},screenshot_jpg:{name:"Screenshot JPG",command:"screenshot_jpg",description:"Save a screenshot as JPG",syntax:"screenshot_jpg",icon:"📷"},autofire_toggle:{name:"Toggle Autofire",command:"+GenToggleAutofire",description:"Toggle weapon autofire",syntax:"+GenToggleAutofire",icon:"🔁"},bind_save_file:{name:"Save Binds to File",command:"bind_save_file",description:"Save all your binds to a text file",syntax:"bind_save_file <filename>",icon:"💾",customizable:!0,parameters:{filename:{type:"text",default:"my_binds.txt"}}},bind_load_file:{name:"Load Binds from File",command:"bind_load_file",description:"Load a bind file into the client",syntax:"bind_load_file <filename>",icon:"📁",customizable:!0,parameters:{filename:{type:"text",default:"my_binds.txt"}}},combat_log:{name:"Toggle Combat Log",command:"CombatLog",description:"Turn combat log recording on/off (1=on, 0=off)",syntax:"CombatLog <1/0>",icon:"📊",customizable:!0,parameters:{state:{type:"number",min:0,max:1,default:1}}},missions:{name:"Show/Hide Missions",command:"missions",description:"Show/hide the mission journal",syntax:"missions",icon:"📋"},inventory:{name:"Show/Hide Inventory",command:"Inventory",description:"Show/hide your inventory",syntax:"Inventory",icon:"🎒"},map:{name:"Show/Hide Map",command:"Map",description:"Show/hide the map window",syntax:"Map",icon:"🗺️"}}}},templates:{space_combat:{basic_attack:{name:"Basic Attack Sequence",description:"Target enemy and fire all weapons",commands:["Target_Enemy_Near","FireAll"]},defensive_sequence:{name:"Defensive Sequence",description:"Target self and activate defensive abilities",commands:["Target_Self","+power_exec Distribute_Shields"]},alpha_strike:{name:"Alpha Strike",description:"Full offensive sequence with buffs",commands:["Target_Enemy_Near","FireAll"]},healing_sequence:{name:"Emergency Healing",description:"Self-healing and damage control",commands:["Target_Self","+power_exec Distribute_Shields"]}},ground_combat:{basic_ground_attack:{name:"Basic Ground Attack",description:"Target and attack sequence for ground combat",commands:["Target_Enemy_Near","+STOTrayExecByTray 0 0"]}}},defaultProfiles:{default_space:{name:"Default Space",description:"Basic space combat configuration",currentEnvironment:"space",builds:{space:{keys:{Space:[{command:"Target_Enemy_Near",type:"targeting",icon:"🎯",text:"Target nearest enemy",id:"cmd_1"},{command:"FireAll",type:"combat",icon:"🔥",text:"Fire all weapons",id:"cmd_2"}]},aliases:{AttackCall:{description:"Call out attack target to team",commands:"team Attacking [$Target] - focus fire!"},TargetReport:{description:"Report current target to team",commands:"team Current target: [$Target]"},HealCall:{description:"Request healing for target",commands:"team Need healing on [$Target]!"}}},ground:{keys:{Space:[{command:"Target_Enemy_Near",type:"targeting",icon:"🎯",text:"Target nearest enemy",id:"cmd_g1"},{command:"+STOTrayExecByTray 0 0",type:"tray",icon:"⚡",text:"Primary attack",id:"cmd_g2"}]},aliases:{}}}},tactical_space:{name:"Tactical Space",description:"Aggressive DPS-focused space build",currentEnvironment:"space",builds:{space:{keys:{Space:[{command:"Target_Enemy_Near",type:"targeting",icon:"🎯",text:"Target nearest enemy",id:"cmd_1"},{command:"+STOTrayExecByTray 0 0",type:"tray",icon:"⚡",text:"Execute Tray 1 Slot 1",id:"cmd_2"},{command:"FireAll",type:"combat",icon:"🔥",text:"Fire all weapons",id:"cmd_3"},{command:"+power_exec Distribute_Shields",type:"power",icon:"🛡️",text:"Distribute shields",id:"cmd_4"}],1:[{command:"+STOTrayExecByTray 1 0",type:"tray",icon:"⚡",text:"Execute Tray 2 Slot 1",id:"cmd_5"}],F1:[{command:"Target_Self",type:"targeting",icon:"👤",text:"Target self",id:"cmd_6"},{command:"+STOTrayExecByTray 2 0",type:"tray",icon:"⚡",text:"Execute Tray 3 Slot 1",id:"cmd_7"}]},aliases:{}},ground:{keys:{Space:[{command:"Target_Enemy_Near",type:"targeting",icon:"🎯",text:"Target nearest enemy",id:"cmd_g1"},{command:"+STOTrayExecByTray 0 0",type:"tray",icon:"⚡",text:"Primary attack",id:"cmd_g2"}],1:[{command:"+STOTrayExecByTray 0 1",type:"tray",icon:"⚡",text:"Secondary attack",id:"cmd_g3"}],F1:[{command:"Target_Self",type:"targeting",icon:"👤",text:"Target self",id:"cmd_g4"},{command:"+STOTrayExecByTray 1 0",type:"tray",icon:"💊",text:"Heal self",id:"cmd_g5"}]},aliases:{}}}}},keys:{common:{name:"Common Keys",description:"Most frequently used keys",keys:[{key:"Space",description:"Spacebar"},{key:"1",description:"Number 1"},{key:"2",description:"Number 2"},{key:"3",description:"Number 3"},{key:"4",description:"Number 4"},{key:"5",description:"Number 5"},{key:"F1",description:"Function Key 1"},{key:"F2",description:"Function Key 2"},{key:"F3",description:"Function Key 3"},{key:"F4",description:"Function Key 4"},{key:"Tab",description:"Tab"},{key:"enter",description:"Main Enter Key"},{key:"Shift",description:"Shift"},{key:"Control",description:"Control"},{key:"ALT",description:"Alt"}]},letters:{name:"Letter Keys",description:"A-Z keyboard letters",keys:[{key:"A",description:"Key A"},{key:"B",description:"Key B"},{key:"C",description:"Key C"},{key:"D",description:"Key D"},{key:"E",description:"Key E"},{key:"F",description:"Key F"},{key:"G",description:"Key G"},{key:"H",description:"Key H"},{key:"I",description:"Key I"},{key:"J",description:"Key J"},{key:"K",description:"Key K"},{key:"L",description:"Key L"},{key:"M",description:"Key M"},{key:"N",description:"Key N"},{key:"O",description:"Key O"},{key:"P",description:"Key P"},{key:"Q",description:"Key Q"},{key:"R",description:"Key R"},{key:"S",description:"Key S"},{key:"T",description:"Key T"},{key:"U",description:"Key U"},{key:"V",description:"Key V"},{key:"W",description:"Key W"},{key:"X",description:"Key X"},{key:"Y",description:"Key Y"},{key:"Z",description:"Key Z"}]},numbers:{name:"Number Keys",description:"Number row and numpad",keys:[{key:"0",description:"Number 0"},{key:"6",description:"Number 6"},{key:"7",description:"Number 7"},{key:"8",description:"Number 8"},{key:"9",description:"Number 9"},{key:"numpad0",description:"Numerical Keypad 0"},{key:"numpad1",description:"Numerical Keypad 1"},{key:"numpad2",description:"Numerical Keypad 2"},{key:"numpad3",description:"Numerical Keypad 3"},{key:"numpad4",description:"Numerical Keypad 4"},{key:"numpad5",description:"Numerical Keypad 5"},{key:"numpad6",description:"Numerical Keypad 6"},{key:"numpad7",description:"Numerical Keypad 7"},{key:"numpad8",description:"Numerical Keypad 8"},{key:"numpad9",description:"Numerical Keypad 9"},{key:"Decimal",description:"Numerical Keypad Decimal"},{key:"Divide",description:"Numerical Keypad Divide"},{key:"Multiply",description:"Multiply (*)"},{key:"Subtract",description:"Subtract (-)"},{key:"Add",description:"Add (+)"},{key:"numpadenter",description:"Numerical Keypad Enter"}]},function:{name:"Function Keys",description:"F1-F24 function keys",keys:[{key:"F5",description:"Function Key 5"},{key:"F6",description:"Function Key 6"},{key:"F7",description:"Function Key 7"},{key:"F8",description:"Function Key 8"},{key:"F9",description:"Function Key 9"},{key:"F10",description:"Function Key 10"},{key:"F11",description:"Function Key 11"},{key:"F12",description:"Function Key 12"},{key:"F13",description:"Function Key 13"},{key:"F14",description:"Function Key 14"},{key:"F15",description:"Function Key 15"},{key:"F16",description:"Function Key 16"},{key:"F17",description:"Function Key 17"},{key:"F18",description:"Function Key 18"},{key:"F19",description:"Function Key 19"},{key:"F20",description:"Function Key 20"},{key:"F21",description:"Function Key 21"},{key:"F22",description:"Function Key 22"},{key:"F23",description:"Function Key 23"},{key:"F24",description:"Function Key 24"}]},arrows:{name:"Arrow & Navigation",description:"Arrow keys and navigation",keys:[{key:"Up",description:"Arrow Key: Up"},{key:"Down",description:"Arrow Key: Down"},{key:"Left",description:"Arrow Key: Left"},{key:"Right",description:"Arrow Key: Right"},{key:"Home",description:"Home"},{key:"End",description:"End"},{key:"PageUp",description:"Page Up"},{key:"PageDown",description:"Page Down"},{key:"insert",description:"Insert"},{key:"delete",description:"Delete"}]},modifiers:{name:"Modifier Keys",description:"Shift, Ctrl, Alt variations",keys:[{key:"LALT",description:"Alt (Left)"},{key:"RALT",description:"Alt (Right)"},{key:"LCTRL",description:"Control (Left)"},{key:"RCTRL",description:"Control (Right)"}]},symbols:{name:"Symbol Keys",description:"Punctuation and symbols",keys:[{key:"[",description:"["},{key:"]",description:"]"},{key:"\\",description:"\\"},{key:",",description:"Comma (,)"},{key:".",description:"Period (.)"},{key:"/",description:"Divide (/)"},{key:"`",description:"Tilda Key (~)"}]},mouse:{name:"Mouse Controls",description:"Mouse buttons and scroll",keys:[{key:"Lbutton",description:"Mouse Left Press"},{key:"Rbutton",description:"Mouse Right Press"},{key:"Middleclick",description:"Mouse Middle Click"},{key:"Button1",description:"Mouse Button 1"},{key:"Button2",description:"Mouse Button 2"},{key:"Button3",description:"Mouse Button 3"},{key:"Button4",description:"Mouse Button 4"},{key:"Button5",description:"Mouse Button 5"},{key:"Button6",description:"Mouse Button 6"},{key:"Button7",description:"Mouse Button 7"},{key:"Button8",description:"Mouse Button 8"},{key:"Button9",description:"Mouse Button 9"},{key:"Button10",description:"Mouse Button 10"},{key:"Wheelplus",description:"Mouse Scroll Up"},{key:"Wheelminus",description:"Mouse Scroll Down"}]},gamepad:{name:"Xbox Controller",description:"Xbox/Gamepad controls",keys:[{key:"Joy1",description:"XBOX Contr [Start]"},{key:"Joy2",description:"XBOX Contr [Back]"},{key:"Joy3",description:"XBOX Contr [L Thumb depress]"},{key:"Joy4",description:"XBOX Contr [R Thumb depress]"},{key:"Joy5",description:"XBOX Contr [Left Bumper]"},{key:"Joy6",description:"XBOX Contr [Right Bumper]"},{key:"Joy7",description:"XBOX Contr [Left Trigger]"},{key:"Joy8",description:"XBOX Contr [Right Trigger]"},{key:"Joy9",description:"XBOX Contr [A Button]"},{key:"Joy10",description:"XBOX Contr [B Button]"},{key:"Joy11",description:"XBOX Contr [X Button]"},{key:"Joy12",description:"XBOX Contr [Y Button]"},{key:"Joypad_up",description:"XBOX Contr [Pad up]"},{key:"Joypad_down",description:"XBOX Contr [Pad down]"},{key:"Joypad_left",description:"XBOX Contr [Pad left]"},{key:"Joypad_right",description:"XBOX Contr [Pad right]"},{key:"Lstick_up",description:"XBOX Contr [Left Stick up]"},{key:"Lstick_down",description:"XBOX Contr [Left Stick down]"},{key:"Lstick_left",description:"XBOX Contr [Left Stick left]"},{key:"Lstick_right",description:"XBOX Contr [Left Stick right]"},{key:"Rstick_up",description:"XBOX Contr [Right Stick up]"},{key:"Rstick_down",description:"XBOX Contr [Right Stick down]"},{key:"Rstick_left",description:"XBOX Contr [Right Stick left]"},{key:"Rstick_right",description:"XBOX Contr [Right Stick right]"}]}},validation:{keyNamePattern:/^[a-zA-Z0-9_+\-\s]+$/,aliasNamePattern:/^[a-zA-Z_][a-zA-Z0-9_]*$/,maxCommandsPerKey:20,maxKeysPerProfile:100},settings:{version:"1.0.0",autoSave:!0,maxUndoSteps:50,defaultMode:"space"},variables:{target:{variable:"$Target",description:"Replaced with the name of your current target",example:"team Target [$Target]",usableIn:["communication","custom","aliases"],notes:"If your target's name is 'froggyMonster', this will output 'Target [froggyMonster]'"}}};window.STO_DATA=r,window.COMMAND_CATEGORIES=r.commands,window.COMMANDS={},Object.entries(r.commands).forEach(([e,t])=>{Object.entries(t.commands).forEach(([t,a])=>{window.COMMANDS[t]={...a,category:e,key:t}})}),window.KEY_LAYOUTS=r.keyLayouts||{qwerty:{name:"QWERTY",rows:[[{key:"Escape",display:"Esc"},{key:"F1",display:"F1"},{key:"F2",display:"F2"},{key:"F3",display:"F3"},{key:"F4",display:"F4"},{key:"F5",display:"F5"},{key:"F6",display:"F6"},{key:"F7",display:"F7"},{key:"F8",display:"F8"},{key:"F9",display:"F9"},{key:"F10",display:"F10"},{key:"F11",display:"F11"},{key:"F12",display:"F12"}],[{key:"`",display:"`"},{key:"1",display:"1"},{key:"2",display:"2"},{key:"3",display:"3"},{key:"4",display:"4"},{key:"5",display:"5"},{key:"6",display:"6"},{key:"7",display:"7"},{key:"8",display:"8"},{key:"9",display:"9"},{key:"0",display:"0"},{key:"-",display:"-"},{key:"=",display:"="},{key:"Backspace",display:"Backspace"}],[{key:"Tab",display:"Tab"},{key:"Q",display:"Q"},{key:"W",display:"W"},{key:"E",display:"E"},{key:"R",display:"R"},{key:"T",display:"T"},{key:"Y",display:"Y"},{key:"U",display:"U"},{key:"I",display:"I"},{key:"O",display:"O"},{key:"P",display:"P"},{key:"[",display:"["},{key:"]",display:"]"},{key:"\\",display:"\\"}],[{key:"CapsLock",display:"Caps"},{key:"A",display:"A"},{key:"S",display:"S"},{key:"D",display:"D"},{key:"F",display:"F"},{key:"G",display:"G"},{key:"H",display:"H"},{key:"J",display:"J"},{key:"K",display:"K"},{key:"L",display:"L"},{key:";",display:";"},{key:"'",display:"'"},{key:"Enter",display:"Enter"}],[{key:"Shift",display:"Shift"},{key:"Z",display:"Z"},{key:"X",display:"X"},{key:"C",display:"C"},{key:"V",display:"V"},{key:"B",display:"B"},{key:"N",display:"N"},{key:"M",display:"M"},{key:",",display:","},{key:".",display:"."},{key:"/",display:"/"},{key:"Shift",display:"Shift"}],[{key:"Ctrl",display:"Ctrl"},{key:"Alt",display:"Alt"},{key:"Space",display:"Space"},{key:"Alt",display:"Alt"},{key:"Ctrl",display:"Ctrl"}]]}},window.DEFAULT_SETTINGS={keyLayout:"qwerty",autoSave:r.settings?.autoSave||!0,showTooltips:!0,exportFormat:"txt",maxUndoSteps:r.settings?.maxUndoSteps||50,defaultMode:r.settings?.defaultMode||"space"},window.SAMPLE_PROFILES=Object.values(r.defaultProfiles).map(e=>({id:e.name.toLowerCase().replace(/\s+/g,"_"),name:e.name,description:e.description,currentEnvironment:e.currentEnvironment||"space",builds:e.builds||{space:{keys:{}},ground:{keys:{}}},mode:e.currentEnvironment||"space",keybinds:e.builds?.space?.keys||{},aliases:e.builds?.space?.aliases||{},created:(new Date).toISOString(),modified:(new Date).toISOString()})),window.SAMPLE_ALIASES={attack_sequence:{name:"Attack Sequence",commands:["Target_Enemy_Near","FireAll"],description:"Target and attack nearest enemy"},defensive_sequence:{name:"Defensive Sequence",commands:["Target_Self","+power_exec Distribute_Shields"],description:"Self-target and activate defensive abilities"},heal_sequence:{name:"Healing Sequence",commands:["Target_Self","+STOTrayExecByTray 3 0 $$ +STOTrayExecByTray 3 1"],description:"Emergency healing and repair sequence"}},window.TRAY_CONFIG={maxTrays:10,slotsPerTray:10,defaultTray:0,maxCommandsPerSlot:1},window.getCommandsByCategory=function(e){return e&&r.commands[e]?Object.values(r.commands[e].commands):[]};class s extends Error{constructor(e,t="STO_ERROR"){super(e),this.name="STOError",this.code=t}}class c extends s{constructor(e,t="VFX_ERROR"){super(e,t),this.name="VertigoError"}}"undefined"!=typeof window&&(window.STOError=s,window.VertigoError=c,window.InvalidEnvironmentError=class extends c{constructor(e){super(`Invalid environment '${e}'. Valid environments are: space, ground`,"INVALID_ENVIRONMENT"),this.environment=e}},window.InvalidEffectError=class extends c{constructor(e,t){super(`Invalid effect '${e}' for environment '${t}'`,"INVALID_EFFECT"),this.effectName=e,this.environment=t}});const l=new Proxy({currentProfile:null,currentMode:"space",currentEnvironment:"space",selectedKey:null,isModified:!1,undoStack:[],redoStack:[],maxUndoSteps:50,commandIdCounter:0},{set:(e,t,a)=>(e[t]=a,i&&i.emit&&i.emit(`store:${t}`,a),!0)}),d={space:[{label:"Advanced inhibiting turret shield bubble",effect:"Fx_Rep_Temporal_Ship_Chroniton_Stabilization_Proc"},{label:"Approaching Agony",effect:"Cfx_Lockboxfx_Cb29_Ship_Agony_Field"},{label:"Attack Pattern Alpha",effect:"Fx_Ship_Tac_Attackpatternalpha"},{label:"Attack Pattern Beta",effect:"Fx_Ship_Tac_Attackpatternbeta"},{label:"Attack Pattern Delta",effect:"Fx_Ship_Tac_Attackpatterndelta"},{label:"Attack Pattern Omega",effect:"Fx_Ship_Tac_Attackpatternomega"},{label:"Beacon of Kahless",effect:"Fx_Er_Bbs_Beacon_Of_Kahless_Flash"},{label:"Boost Morale",effect:"Fx_Ship_Spec_Powers_Command_Boost_Morale_Bufffx,Cfx_Ship_Spec_Powers_Command_Boost_Morale_Activate"},{label:"Brace for Impact",effect:"Fx_Bop_Braceforimpact,Cfx_Ship_Sci_Hazardemitter_Buff"},{label:"Breath of the Dragon",effect:"Fx_Ship_Cp_T6_Hysperian_Dragonbreath"},{label:"Call Emergency Artillery",effect:"Fx_Ships_Boffs_Cmd_Callartillery_Activate,Fx_Ships_Boffs_Cmd_Callartillery_Explosion"},{label:"Competitive Engine Buff Effect",effect:"Fx_Ship_Mod_Haste_Buff_Gen"},{label:"Co-opt Energy Weapons",effect:"Fx_Capt_Powers_Ship_Sci_Coopt_Energy_Wep_Aoe,Cfx_Capt_Powers_Ship_Sci_Coopt_Energy_Wep_Area"},{label:"Concentrate Fire Power",effect:"Fx_Ships_Boff_Cmd_Confire_Activatefx,Cfx_Ships_Boff_Cmd_Confire_Mark"},{label:"Cnidarian Jellyfish AoE",effect:"Cfx_Ship_Sp_T6_Jellyfish_Cnidarian_Defense_Aoe"},{label:"Dark Matter Anomaly",effect:"Cfx_Ship_Console_Dark_Matter_Anamoly_Costumefx"},{label:"Delphic Tear",effect:"Fx_Ships_Consoles_Cb21_Delphictear"},{label:"Destabilising Resonance Beam",effect:"P_Er_Ship_Destabilizing_Resonance_Beam_Aoe_Particles"},{label:"Elachi Walker Combat Pet (3 effects)",effect:"Soundfx_Elachiwalker_Footstep_Pet,Fx_Er_Tfo_Elachi_Walker_Combat_Pet_Deathfx,Soundfx_Elachiwalker_Petsummon"},{label:"Electrified Anomalies Trait",effect:"Fx_Tp_Ship_T6_Risian_Science_Electrified_Anomalies_Arc_Foe,Fx_Tp_Ship_T6_Risian_Science_Electrified_Anomalies_Arc_Friend"},{label:"Emergency Pwr to Shields",effect:"Fx_Ship_Eng_Emergencypowershields"},{label:"Emergency Pwr to Wep",effect:"Fx_Ship_Eng_Emergencypowerweapons"},{label:"Engineering Fleet III",effect:"Fx_Ship_Boff_Fleet_Capt_Engineering_Teambuff"},{label:"Engineering Team",effect:"Cfx_Ship_Crewteam_Engineeringteam_Buff"},{label:"EPS Power Transfer",effect:"Cfx_Ship_Eng_Epspowertransfer_Target"},{label:"Focus Frenzy",effect:"Fx_Skilltree_Ship_Ffrenzy_Activatefx"},{label:"Go Down Fighting",effect:"Fx_Bop_Godownfighting"},{label:"Hangar Pet Rank Up",effect:"Fx_Ship_Levelup_Fighter_Rankup"},{label:"Hazard Emitters",effect:"Cfx_Ship_Sci_Hazardemitter_Buff"},{label:"Intel Fleet III",effect:"Fx_Ship_Boff_Fleet_Capt_Intel_Teambuff"},{label:"Intel Team (uses 3 effects)",effect:"Cfx_Ship_Cruiser_Auras_Taunt,Cfx_Spc_Boffpowers_Intel_Intelteam_Buff,Fx_Ships_Intel_Lyinginwait"},{label:"Kemocite on ship animation",effect:"C1_E_Ship_Xindi_Lockboxcb15_Kemocite_Weaponry_Bufffx"},{label:"Kemocite HitFX ring",effect:"Fx_Ship_Xindi_Lockboxcb15_Kemocite_Weaponry_Aoe_Proc"},{label:"Kentari Ferocity Weapons Glow",effect:"P_Trait_Powers_Ship_Lukari_Colony_Kentari_Ferocity_Weapons_Glow"},{label:"Kobayashi Maru powerup silenced",effect:"Fx_Evr_Kmaru_Ship_Dev_Resupply_Drop_Powerup_Bufffx,Fx_Evr_Kmaru_Ship_Dev_Resupply_Drop_Powerup"},{label:"Less Obvious Loot Drop Common",effect:"Cfx_Space_Loot_Drop_Common_Costumefx"},{label:"Less Obvious Loot Drop Uncommon",effect:"Cfx_Space_Loot_Drop_Uncommon_Costumefx"},{label:"Less Obvious Loot Drop Rare",effect:"Cfx_Space_Loot_Drop_Rare_Costumefx"},{label:"Less Obvious Loot Drop Very Rare",effect:"Cfx_Space_Loot_Drop_Veryrare_Costumefx"},{label:"Less Obvious Loot Drop Lock Box",effect:"Cfx_Space_Loot_Drop_Chancebox_Costumefx"},{label:"Less Obvious Loot Drop Dilithium",effect:"Cfx_Space_Loot_Drop_Dilithium_Costumefx"},{label:"Miraculous Repairs",effect:"Fx_Bop_Miracleworker"},{label:"MW - Align Shield Frequencies",effect:"Fx_Spc_Boffpowers_Miracleworker_Alignshieldfrequencies_Hitfx"},{label:"MW - Destabilize Warp Core",effect:"Fx_Spc_Boffpowers_Miracleworker_Destabilizewarpcore"},{label:"MW - Exceed rated limits",effect:"Fx_Spc_Boffpowers_Miracleworker_Energyweaponsexceedratedlimits_Dot_Hitfx,Fx_Spc_Boffpowers_Miracleworker_Energyweaponsexceedratedlimits"},{label:"MW - Fix em up (and other green glows)",effect:"Fx_Ship_Mod_Damage_Buff"},{label:"MW - Mixed Armaments Synergy",effect:"Fx_Spc_Boffpowers_Miracleworker_Mixedarmamentssynergy"},{label:"MW - Narrow Sensor Bands",effect:"Fx_Spc_Boffpowers_Miracleworker_Narrowsensorbands"},{label:"MW - Null Pointer Flood",effect:"Fx_Spc_Boffpowers_Miracleworker_Nullpointerflood"},{label:"MW - Reroute shilds to Hull containment",effect:"Fx_Spc_Boffpowers_Miracleworker_Rerouteshieldstohullcontainment,Cfx_Spc_Boffpowers_Miracleworker_Rerouteshieldstohullcontainment"},{label:"Nadion Inversion",effect:"Fx_Bop_Nadioinversion"},{label:"Nanoprobe Shield Generator (Dyson Rep)",effect:"Cfx_Rp_Dyson_Ship_Reactive_Shielding"},{label:"Neutronic Eddies",effect:"Cfx_Ships_Cp_T6_Risian_Science_Neutronic_Edides_Costumefx"},{label:"Overwhelm Emitters",effect:"Fx_Ships_Boff_Cmd_Owemitters_Activatefx"},{label:"Photonic Officer",effect:"Fx_Bop_Photonicofficer_activate"},{label:"PILOT - Clean Getaway",effect:"Fx_Spc_Boff_Pilot_Cleangetaway_Activate"},{label:"PILOT - Coolant Ignition (mostly)",effect:"Fx_Spc_Boff_Pilot_Coolantinjection_Ignite,Fx_Spc_Boff_Pilot_Coolantinjection_Costumefx"},{label:"PILOT - Deploy Countermeasures",effect:"Fx_Spc_Boff_Pilot_Deploycm"},{label:"PILOT - Fly her apart",effect:"Cfx_Spc_Boff_Pilot_Flyapart_Dot"},{label:"PILOT - Form Up (mostly)",effect:"Fx_Spc_Boff_Pilot_Formup_Teleport,Fx_Spc_Boff_Pilot_Formup_Buff_Wepbuff"},{label:"PILOT - hold Together",effect:"Cfx_Spc_Boff_Pilot_Holdtogether"},{label:"PILOT - Lambda",effect:"Fx_Ship_Mod_Damage_Buff,Fx_Spc_Boff_Pilot_Aplambda_Bufffx,Fx_Spc_Boff_Pilot_Aplambda"},{label:"PILOT - Lock Trajectory",effect:"Fx_Spc_Boff_Pilot_Flares_Switch,Cfx_Spc_Boff_Pilot_Locktrajectory"},{label:"PILOT - Pilot Team",effect:"Cfx_Spc_Boff_Pilot_Pilotteam_Buff"},{label:"PILOT - Reroute Reserves to Weapons",effect:"Fx_Spc_Boff_Pilot_Reroute_Wepbuff,Fx_Spc_Boff_Pilot_Reroute_Activate"},{label:"PILOT - Subspace Boom",effect:"Cfx_Spc_Boff_Pilot_Ssboom_Costumefx_Neverdie,Fx_Spc_Boff_Pilot_Ssboom_Boom"},{label:"Plasma Storm",effect:"Cfx_Ship_Cp_Cb27_Generate_Plasma_Storm_Costumefx"},{label:"Rally Point Marker",effect:"Cfx_Ships_Boff_Cmd_Rallypoint_Marker"},{label:"Reverse Shield Polarity",effect:"Cfx_Ship_Eng_Reverseshieldpolarity_Buff"},{label:"Scattering Field",effect:"Cfx_Ship_Sci_Dampeningfield_Aoe,Cfx_Ship_Sci_Dampeningfield_Shield_Buff"},{label:"Science Team",effect:"Cfx_Ship_Crewteam_Scienceteam_Buff"},{label:"Science Fleet III",effect:"Fx_Ship_Boff_Fleet_Capt_Science_Teambuff"},{label:"Soliton Wave Generator (uses 4 effects)",effect:"Cfx_Ship_Risa_Loot_Soliton_Wave_Suckfx_Target,Cfx_Ship_Risa_Loot_Soliton_Wave_Suckfx,Cfx_Ship_Risa_Loot_Soliton_Wave_Out,Cfx_Ship_Risa_Loot_Soliton_Wave_In"},{label:"Spore Infused Anomalies",effect:"Fx_Trait_Powers_Ship_T6_Somerville_Sia_Blast"},{label:"Subspace Vortex Teleport Effect",effect:"Fx_Ship_Xindi_Lockboxcb15_Subspace_Vortex_Teleport"},{label:"Suppression Barrage",effect:"Cfx_Ships_Boff_Cmd_Sbarrage_Buff"},{label:"Surgical Strikes",effect:"Fx_Spc_Boffpowers_Int_Sstrikes_Buff"},{label:"Tactical Fleet III",effect:"Fx_Ship_Boff_Fleet_Capt_Tactical_Teambuff"},{label:"Tactical Initiative",effect:"Fx_Bop_Tacticalinitiative"},{label:"Tactical Team",effect:"Cfx_Ship_Crewteam_Tacticalteam_Buff"},{label:"Target Rich Environment",effect:"Fx_Ship_Trait_Cb20_Targetrichenvironment"},{label:"Temporal Anchor",effect:"Cfx_Ship_Trait_Temporal_Anchor_Costumefx"},{label:"Temporal Vortex Probe",effect:"C1_Eventreward_Fcd_Temporal_Vortex_Costumefx,Fx_Eventreward_Fcd_Temporal_Vortex_Blast"},{label:"Timeline Collapse (5 effects!)",effect:"Cfx_Ship_Temp_Tcollapse_Costume,Fx_Ship_Temp_Tcollapse_Hitfx,Fx_Ship_Temp_Tcollapse_Explode,Fx_Ship_Temp_Tcollapse_Beamhitfx,Fx_Ship_Temp_Tcollapse"},{label:"V'Ger Torpedo (Volatile Digital Transformation)",effect:"Fx_Ship_Torpedo_Plasma_Vger_Anniv_Explode,Cfx_Ship_Torpedo_Vger_Disintegrate_In_Tintable"},{label:"Viral Impulse Burst",effect:"Fx_Spc_Boffpowers_int_Viralimpulse"},{label:"Vulcan Jelly Fish Eject Red Matter",effect:"Cfx_ship_jellyfish_eject_red_matter_costumefx"},{label:"Vulnerability Assessment Sweep",effect:"Fx_Capt_Powers_Ship_Tac_Vulnerability_Assessment_Sweep"}],ground:[{label:"Agony Field Generator",effect:"Fx_Ground_Lockboxfx_Cb29_Agony_Field_Generator"},{label:"Anti-time ground",effect:"Cfx_Rep_Temp_Char_Kit_Sci_Antitime_Entanglement_Field_Costumefx"},{label:"Ball Lightning",effect:"Cfx_Char_Kit_Univ_Sum_Ball_Lightning_Costumefx"},{label:"Chaos Blaze",effect:"Cfx_Char_Chaos_Blaze_Aoe"},{label:"Conussive Tachyon Emission",effect:"fx_Char_Delta_Rep_Cte_Aoe"},{label:"Disco Ball (Party Bomb)",effect:"Cfx_Char_Device_Partybomb"},{label:"Dot-7 Drone Support Field",effect:"Cfx_Er_Bbs_char_Dot7_Drone_support_Field"},{label:"Eng Proficiency (Character Glow)",effect:"Cfx_Ground_Kit_Eng_Engineeringproficiency"},{label:"Ever Watchful",effect:"Cfx_Ground_Kit_Tac_Overwatch_Bufffx,Fx_Ground_Kit_Tac_Overwatch_Activatefx"},{label:"Herald AP Beam Projector ground weapon",effect:"Fx_Char_Icoenergy_Rifle_Energyblast,Fx_Char_Icoenergy_Assault_Beam_Lockbox"},{label:"Lava Floor",effect:"Cfx_Char_Kit_Univ_Sum_The_Floor_Is_Lava_Costumefx,Cfx_Char_Kit_Univ_Sum_The_Floor_Is_Lava_Geyser"},{label:"Less Obvious Loot Drop Common",effect:"Cfx_Gnd_Loot_Drop_Common_Costumefx"},{label:"Less Obvious Loot Drop Uncommon",effect:"Cfx_Gnd_Loot_Drop_Uncommon_Costumefx"},{label:"Less Obvious Loot Drop Rare",effect:"Cfx_Gnd_Loot_Drop_Rare_Costumefx"},{label:"Less Obvious Loot Drop Very Rare",effect:"Cfx_Gnd_Loot_Drop_Veryrare_Costumefx"},{label:"Less Obvious Loot Drop Lock Box",effect:"Cfx_Gnd_Loot_Drop_Chancebox_Costumefx"},{label:"Less Obvious Loot Drop Dilithium",effect:"Cfx_Gnd_Loot_Drop_Dilithium_Costumefx"},{label:"Motivation (Tac Kit Module)",effect:"Cfx_Ground_Kit_Tac_Motivation_Buff,Fx_Ground_Kit_Tac_Motivation"},{label:"Orbital Devastation",effect:"Fx_Char_Voth_Orbitalstrike_Chasebeam"},{label:"Pahvan Crystal Prism noisy tether",effect:"Cfx_Er_Tfo_Pahvan_Crystal_Prism_Tether_Beam"},{label:"Rally Cry",effect:"Fx_Ground_Kit_Tac_Rallycry"},{label:"Red Riker Gun Sound effect",effect:"Cfx_Ep_Winterevent_Redriker_Sniper_Chargefx"},{label:"Scientific Aptitude (character glow)",effect:"Cfx_Ground_Kit_Sci_Scientificaptitude"},{label:"Solar Gateway",effect:"Fx_Char_Ico_Capt_Portal,Fx_Char_Ico_Capt_Portal_Sunbeam"},{label:"Smoke Grenade",effect:"Fx_Char_Grenade_smoke_costume,Fx_Char_Grenade_Smoke_Explode"},{label:"Sompek Energy Rebounder",effect:"Fx_Env_Gnd_Qadhos_Arena_Phaserhazard_Cylinder_Turret"},{label:"Strike Team III (character red glow)",effect:"Cfx_Ground_Kit_Tac_Striketeam"},{label:"Symphony of Lightning Char Glow",effect:"Fx_Er_Featured_Char_Kuumaarke_Wristgun_Tir_bufffx"},{label:"Symphony of Lightning Drone AoE",effect:"Cfx_Er_Featured_Char_Kuumaarke_Set_Symphony_Of_Lightning_Drone_Aoe"},{label:"Symphony of Lightning STRIKE",effect:"Fx_Er_Featured_Char_Kuumaarke_Set_Symphony_Of_Lightning_Strike"},{label:"Trajectory Bending",effect:"Cfx_Char_Xindi_Cb15_Tac_Kit_Trajectory_Bending"},{label:"Visual Dampening Field",effect:"Cfx_Char_Trait_Mirror_Vdfield"}]};document.addEventListener("DOMContentLoaded",()=>{const t=document.getElementById("appVersion");t&&(t.textContent=e);const a=document.getElementById("aboutVersion");a&&(a.textContent=e)});const m=new class{constructor(){this.storageKey="sto_keybind_manager",this.backupKey="sto_keybind_manager_backup",this.settingsKey="sto_keybind_settings",this.version="1.0.0",this.init()}init(){this.migrateData(),this.ensureStorageStructure()}getAllData(){try{const e=localStorage.getItem(this.storageKey),t=localStorage.getItem("sto_app_reset");if(!e)return t?(localStorage.removeItem("sto_app_reset"),this.getEmptyData()):this.getDefaultData();const a=JSON.parse(e);return this.isValidDataStructure(a)?a:this.getDefaultData()}catch(e){return console.error("Error loading data from storage:",e),this.getDefaultData()}}saveAllData(e){try{this.createBackup();const t={...e,version:this.version,lastModified:(new Date).toISOString(),lastBackup:(new Date).toISOString()};return localStorage.setItem(this.storageKey,JSON.stringify(t)),!0}catch(e){return console.error("Error saving data to storage:",e),!1}}getProfile(e){return this.getAllData().profiles[e]||null}saveProfile(e,t){const a=this.getAllData();return a.profiles[e]={...t,lastModified:(new Date).toISOString()},this.saveAllData(a)}deleteProfile(e){const t=this.getAllData();if(t.profiles[e]){if(delete t.profiles[e],t.currentProfile===e){const e=Object.keys(t.profiles);t.currentProfile=e.length>0?e[0]:null}return this.saveAllData(t)}return!1}getSettings(){try{const e=localStorage.getItem(this.settingsKey);return e?JSON.parse(e):this.getDefaultSettings()}catch(e){return console.error("Error loading settings:",e),this.getDefaultSettings()}}saveSettings(e){try{return localStorage.setItem(this.settingsKey,JSON.stringify(e)),!0}catch(e){return console.error("Error saving settings:",e),!1}}createBackup(){try{const e=localStorage.getItem(this.storageKey);if(e){const t={data:e,timestamp:(new Date).toISOString(),version:this.version};localStorage.setItem(this.backupKey,JSON.stringify(t))}}catch(e){console.error("Error creating backup:",e)}}restoreFromBackup(){try{const e=localStorage.getItem(this.backupKey);if(e){const t=JSON.parse(e);return localStorage.setItem(this.storageKey,t.data),!0}}catch(e){console.error("Error restoring from backup:",e)}return!1}exportData(){const e=this.getAllData();return JSON.stringify(e,null,2)}importData(e){try{const t=JSON.parse(e);return!!this.isValidDataStructure(t)&&this.saveAllData(t)}catch(t){return t instanceof SyntaxError&&e.includes("invalid")||console.error("Error importing data:",t),!1}}clearAllData(){try{return localStorage.removeItem(this.storageKey),localStorage.removeItem(this.backupKey),localStorage.removeItem(this.settingsKey),localStorage.setItem("sto_app_reset","true"),!0}catch(e){return console.error("Error clearing data:",e),!1}}getStorageInfo(){try{const e=localStorage.getItem(this.storageKey)?.length||0,t=localStorage.getItem(this.backupKey)?.length||0,a=localStorage.getItem(this.settingsKey)?.length||0;return{totalSize:e+t+a,dataSize:e,backupSize:t,settingsSize:a,available:this.getAvailableStorage()}}catch(e){return console.error("Error getting storage info:",e),null}}getDefaultData(){return{version:this.version,created:(new Date).toISOString(),lastModified:(new Date).toISOString(),currentProfile:"default_space",profiles:{default_space:{...STO_DATA.defaultProfiles.default_space},tactical_space:{...STO_DATA.defaultProfiles.tactical_space}},globalAliases:{},settings:this.getDefaultSettings()}}getEmptyData(){return{version:this.version,created:(new Date).toISOString(),lastModified:(new Date).toISOString(),currentProfile:null,profiles:{},globalAliases:{},settings:this.getDefaultSettings()}}getDefaultSettings(){return{theme:"default",autoSave:!0,showTooltips:!0,confirmDeletes:!0,maxUndoSteps:50,defaultMode:"space",compactView:!1}}isValidDataStructure(e){if(!e||"object"!=typeof e)return!1;const t=["profiles","currentProfile"];for(const a of t)if(!(a in e))return!1;if("object"!=typeof e.profiles)return!1;for(const[t,a]of Object.entries(e.profiles))if(!this.isValidProfile(a))return!1;return!0}isValidProfile(e){if(!e||"object"!=typeof e)return!1;if(e.builds){if(!e.name||"object"!=typeof e.builds)return!1;const t=e.builds;if(!t.space&&!t.ground)return!1;for(const[e,a]of Object.entries(t))if("space"===e||"ground"===e){if(!a||"object"!=typeof a)return!1;if(!a.keys||"object"!=typeof a.keys)return!1}return!0}const t=["name","mode","keys"];for(const a of t)if(!(a in e))return!1;return"object"==typeof e.keys}ensureStorageStructure(){const e=this.getAllData();e.globalAliases||(e.globalAliases={}),e.settings||(e.settings=this.getDefaultSettings()),0===Object.keys(e.profiles).length&&null!==e.currentProfile&&(e.profiles={default_space:{...STO_DATA.defaultProfiles.default_space}},e.currentProfile="default_space"),Object.keys(e.profiles).length>0&&!e.profiles[e.currentProfile]&&(e.currentProfile=Object.keys(e.profiles)[0]),this.saveAllData(e)}migrateData(){const e=this.getAllData();e.version!==this.version&&(console.log(`Migrating data from ${e.version} to ${this.version}`),e.version=this.version,this.saveAllData(e))}getAvailableStorage(){try{let e="storage_test",t="0",a=0,n=0,o=10485760;for(;n<=o;){let i=Math.floor((n+o)/2);t="0".repeat(i);try{localStorage.setItem(e,t),localStorage.removeItem(e),a=i,n=i+1}catch(e){o=i-1}}return a}catch(e){return 0}}loadDefaultData(){const e=this.getDefaultData();return this.saveAllData(e)}},p=new class{constructor(){this.currentModal=null}init(){this.setupEventListeners()}setupEventListeners(){const e=document.getElementById("profileSelect");e&&e.addEventListener("change",e=>{app.switchProfile(e.target.value)}),i.onDom("newProfileBtn","click","profile-new",()=>{this.showNewProfileModal()}),i.onDom("cloneProfileBtn","click","profile-clone",()=>{this.showCloneProfileModal()}),i.onDom("renameProfileBtn","click","profile-rename",()=>{this.showRenameProfileModal()}),i.onDom("deleteProfileBtn","click","profile-delete",()=>{this.confirmDeleteProfile()}),i.onDom("saveProfileBtn","click","profile-save",()=>{this.handleProfileSave()}),i.onDom("settingsBtn","click","settings-menu",e=>{e.stopPropagation(),this.toggleSettingsMenu()}),i.onDom("keybindsBtn","click","keybinds-menu",e=>{e.stopPropagation(),this.toggleKeybindsMenu()}),i.onDom("aliasesBtn","click","aliases-menu",e=>{e.stopPropagation(),this.toggleAliasesMenu()}),i.onDom("importKeybindsBtn","click","keybinds-import",()=>{this.importKeybinds(),this.closeKeybindsMenu()}),i.onDom("exportKeybindsBtn","click","keybinds-export",()=>{this.exportKeybinds(),this.closeKeybindsMenu()}),i.onDom("importAliasesBtn","click","aliases-import",()=>{this.importAliases(),this.closeAliasesMenu()}),i.onDom("exportAliasesBtn","click","aliases-export",()=>{this.exportAliases(),this.closeAliasesMenu()}),i.onDom("loadDefaultDataBtn","click","load-default-data",()=>{this.loadDefaultData(),this.closeSettingsMenu()}),i.onDom("resetAppBtn","click","reset-app",()=>{this.confirmResetApp(),this.closeSettingsMenu()}),i.onDom("aboutBtn","click","about-open",()=>{modalManager.show("aboutModal")}),i.onDom("themeToggleBtn","click","theme-toggle",()=>{app.toggleTheme(),this.closeSettingsMenu()}),document.addEventListener("click",()=>{this.closeSettingsMenu(),this.closeKeybindsMenu(),this.closeAliasesMenu()})}showNewProfileModal(){document.getElementById("profileModal");const e=document.getElementById("profileModalTitle"),t=document.getElementById("profileName"),a=document.getElementById("profileDescription");e&&(e.textContent="New Profile"),t&&(t.value="",t.placeholder="Enter profile name"),a&&(a.value=""),this.currentModal="new",modalManager.show("profileModal")}showCloneProfileModal(){const e=app.getCurrentProfile();if(!e)return void stoUI.showToast("No profile selected to clone","warning");document.getElementById("profileModal");const t=document.getElementById("profileModalTitle"),a=document.getElementById("profileName"),n=document.getElementById("profileDescription");t&&(t.textContent="Clone Profile"),a&&(a.value=`${e.name} Copy`,a.placeholder="Enter new profile name"),n&&(n.value=`Copy of ${e.name}`),this.currentModal="clone",modalManager.show("profileModal")}showRenameProfileModal(){const e=app.getCurrentProfile();if(!e)return void stoUI.showToast("No profile selected to rename","warning");document.getElementById("profileModal");const t=document.getElementById("profileModalTitle"),a=document.getElementById("profileName"),n=document.getElementById("profileDescription");t&&(t.textContent="Rename Profile"),a&&(a.value=e.name,a.placeholder="Enter profile name"),n&&(n.value=e.description||""),this.currentModal="rename",modalManager.show("profileModal")}handleProfileSave(){const e=document.getElementById("profileName"),t=document.getElementById("profileDescription");if(!e)return;const a=e.value.trim(),n=t?.value.trim()||"";if(!a)return stoUI.showToast("Profile name is required","error"),void e.focus();if(a.length>50)return stoUI.showToast("Profile name is too long (max 50 characters)","error"),void e.focus();const o=stoStorage.getAllData();if(Object.values(o.profiles).find(e=>e.name.toLowerCase()===a.toLowerCase()&&("rename"!==this.currentModal||e.name!==app.getCurrentProfile()?.name)))return stoUI.showToast("A profile with this name already exists","error"),void e.focus();try{switch(this.currentModal){case"new":this.createNewProfile(a,n);break;case"clone":this.cloneCurrentProfile(a,n);break;case"rename":this.renameCurrentProfile(a,n)}modalManager.hide("profileModal"),this.currentModal=null}catch(e){stoUI.showToast("Failed to save profile: "+e.message,"error")}}createNewProfile(e,t){const a=app.generateProfileId(e),n={name:e,description:t,mode:"space",keys:{},aliases:{},created:(new Date).toISOString(),lastModified:(new Date).toISOString()};if(!stoStorage.saveProfile(a,n))throw new Error("Failed to save profile");app.switchProfile(a),app.renderProfiles(),stoUI.showToast(`Profile "${e}" created`,"success")}cloneCurrentProfile(e,t){const a=app.getCurrentProfile();if(!a)throw new Error("No profile to clone");const n=app.generateProfileId(e),o={...JSON.parse(JSON.stringify(a)),name:e,description:t,created:(new Date).toISOString(),lastModified:(new Date).toISOString()};if(!stoStorage.saveProfile(n,o))throw new Error("Failed to save cloned profile");app.switchProfile(n),app.renderProfiles(),stoUI.showToast(`Profile "${e}" created from "${a.name}"`,"success")}renameCurrentProfile(e,t){const a=app.getCurrentProfile();if(!a)throw new Error("No profile to rename");const n=a.name;if(a.name=e,a.description=t,a.lastModified=(new Date).toISOString(),!stoStorage.saveProfile(l.currentProfile,a))throw new Error("Failed to save renamed profile");app.renderProfiles(),app.setModified(!0),stoUI.showToast(`Profile renamed from "${n}" to "${e}"`,"success")}async confirmDeleteProfile(){const e=app.getCurrentProfile();if(!e)return void stoUI.showToast("No profile selected to delete","warning");const t=stoStorage.getAllData();Object.keys(t.profiles).length<=1?stoUI.showToast("Cannot delete the last profile","warning"):await stoUI.confirm(`Are you sure you want to delete the profile "${e.name}"?\n\nThis action cannot be undone.`,"Delete Profile","danger")&&this.deleteCurrentProfile()}deleteCurrentProfile(){const e=app.getCurrentProfile();if(!e)return;const t=e.name;app.deleteProfile(app.currentProfile)?stoUI.showToast(`Profile "${t}" deleted`,"success"):stoUI.showToast("Failed to delete profile","error")}toggleSettingsMenu(){const e=document.getElementById("settingsBtn");if(e){const t=e.closest(".dropdown");t&&t.classList.toggle("active")}}closeSettingsMenu(){const e=document.getElementById("settingsBtn");if(e){const t=e.closest(".dropdown");t&&t.classList.remove("active")}}toggleKeybindsMenu(){this.closeSettingsMenu(),this.closeAliasesMenu();const e=document.getElementById("keybindsBtn");if(e){const t=e.closest(".dropdown");t&&t.classList.toggle("active")}}closeKeybindsMenu(){const e=document.getElementById("keybindsBtn");if(e){const t=e.closest(".dropdown");t&&t.classList.remove("active")}}toggleAliasesMenu(){this.closeSettingsMenu(),this.closeKeybindsMenu();const e=document.getElementById("aliasesBtn");if(e){const t=e.closest(".dropdown");t&&t.classList.toggle("active")}}closeAliasesMenu(){const e=document.getElementById("aliasesBtn");if(e){const t=e.closest(".dropdown");t&&t.classList.remove("active")}}importKeybinds(){const e=document.getElementById("fileInput");e&&(e.accept=".txt",e.onchange=e=>{const t=e.target.files[0];if(t){const e=new FileReader;e.onload=e=>{try{stoKeybinds.importKeybindFile(e.target.result)}catch(e){stoUI.showToast("Failed to import keybind file: "+e.message,"error")}},e.readAsText(t)}e.target.value=""},e.click())}exportKeybinds(){const e=app.getCurrentProfile();e?e.keys&&0!==Object.keys(e.keys).length?stoExport.exportSTOKeybindFile(e):stoUI.showToast("No keybinds to export","warning"):stoUI.showToast("No profile selected to export","warning")}importAliases(){const e=document.createElement("input");e.type="file",e.accept=".txt",e.onchange=e=>{const t=e.target.files[0];if(t){const e=new FileReader;e.onload=e=>{try{const t=e.target.result;stoKeybinds.importAliasFile(t),window.stoAliases&&"function"==typeof window.stoAliases.renderAliasList&&window.stoAliases.renderAliasList()}catch(e){stoUI.showToast("Failed to import aliases: "+e.message,"error")}},e.readAsText(t)}},e.click()}exportAliases(){const e=app.getCurrentProfile();e?e.aliases&&0!==Object.keys(e.aliases).length?stoExport.exportAliases(e):stoUI.showToast("No aliases to export","warning"):stoUI.showToast("No profile selected to export","warning")}async confirmResetApp(){await stoUI.confirm("Are you sure you want to reset the application?\n\nThis will delete all profiles, keybinds, and settings. This action cannot be undone.","Reset Application","danger")&&this.resetApplication()}resetApplication(){try{stoStorage.clearAllData(),app.currentProfile=null,app.selectedKey=null,app.setModified(!1),app.renderProfiles(),app.renderKeyGrid(),app.renderCommandChain(),app.updateProfileInfo(),stoUI.showToast("Application reset successfully. All data cleared.","success")}catch(e){stoUI.showToast("Failed to reset application: "+e.message,"error")}}loadDefaultData(){try{if(stoStorage.loadDefaultData()){const e=stoStorage.getAllData();app.currentProfile=e.currentProfile,app.selectedKey=null,app.setModified(!1),app.renderProfiles(),app.renderKeyGrid(),app.renderCommandChain(),app.updateProfileInfo(),stoUI.showToast("Default demo data loaded successfully","success")}else stoUI.showToast("Failed to load default data","error")}catch(e){stoUI.showToast("Failed to load default data: "+e.message,"error")}}getProfileAnalysis(e){const t={keyCount:Object.keys(e.keys).length,commandCount:0,aliasCount:Object.keys(e.aliases||{}).length,commandTypes:{},keyTypes:{function:0,number:0,letter:0,special:0,modifier:0},complexity:"Simple",recommendations:[]};return Object.entries(e.keys).forEach(([e,a])=>{t.commandCount+=a.length,/^F\d+$/.test(e)?t.keyTypes.function++:/^\d+$/.test(e)?t.keyTypes.number++:/^[A-Z]$/.test(e)?t.keyTypes.letter++:e.includes("+")?t.keyTypes.modifier++:t.keyTypes.special++,a.forEach(e=>{t.commandTypes[e.type]=(t.commandTypes[e.type]||0)+1})}),t.commandCount>50?t.complexity="Complex":t.commandCount>20&&(t.complexity="Moderate"),this.generateRecommendations(t,e),t}generateRecommendations(e,t){const a=[];e.commandTypes.targeting||e.commandTypes.combat||a.push({type:"setup",title:"Add Basic Combat Commands",description:"Consider adding targeting and firing commands for basic combat functionality.",priority:"high"}),e.commandTypes.power||a.push({type:"defensive",title:"Add Defensive Abilities",description:"Add shield management commands like shield distribution and shield routing.",priority:"medium"}),e.keyTypes.modifier<3&&e.keyCount>10&&a.push({type:"efficiency",title:"Use Modifier Keys",description:"Consider using Ctrl+, Alt+, and Shift+ combinations to access more commands efficiently.",priority:"low"}),0===e.aliasCount&&e.commandCount>15&&a.push({type:"organization",title:"Create Command Aliases",description:"Use aliases to group related commands and simplify complex sequences.",priority:"medium"});const n=["FireAll","target_nearest_enemy","+fullimpulse"],o=Object.values(t.keys).some(e=>e.some(e=>n.some(t=>e.command.includes(t))));"ground"===t.mode&&o&&a.push({type:"mode",title:"Check Profile Mode",description:"This profile contains space combat commands but is set to ground mode.",priority:"medium"}),e.recommendations=a}getProfileTemplates(){return{basic_space:{name:"Basic Space Combat",description:"Essential space combat keybinds for new players",mode:"space",keys:{Space:[{command:"target_nearest_enemy",type:"targeting",icon:"🎯",text:"Target nearest enemy"},{command:"FireAll",type:"combat",icon:"🔥",text:"Fire all weapons"}],Tab:[{command:"target_nearest_friend",type:"targeting",icon:"🤝",text:"Target nearest friend"}],F1:[{command:"target_self",type:"targeting",icon:"👤",text:"Target self"},{command:"+power_exec Distribute_Shields",type:"power",icon:"🛡️",text:"Distribute shields"}]},aliases:{}},advanced_tactical:{name:"Advanced Tactical",description:"Comprehensive DPS-focused space build",mode:"space",keys:{Space:[{command:"target_nearest_enemy",type:"targeting",icon:"🎯",text:"Target nearest enemy"},{command:"+STOTrayExecByTray 0 0",type:"tray",icon:"⚡",text:"Execute Tray 1 Slot 1"},{command:"FireAll",type:"combat",icon:"🔥",text:"Fire all weapons"}],1:[{command:"+STOTrayExecByTray 1 0",type:"tray",icon:"⚡",text:"Execute Tray 2 Slot 1"}],2:[{command:"+STOTrayExecByTray 1 1",type:"tray",icon:"⚡",text:"Execute Tray 2 Slot 2"}],F1:[{command:"target_self",type:"targeting",icon:"👤",text:"Target self"}],F2:[{command:"target_self",type:"targeting",icon:"👤",text:"Target self"}]},aliases:{AlphaStrike:{name:"AlphaStrike",commands:"target_nearest_enemy $$ +STOTrayExecByTray 0 0 $$ +STOTrayExecByTray 0 1",description:"Full alpha strike sequence"}}},ground_combat:{name:"Ground Combat",description:"Ground combat and away team keybinds",mode:"ground",keys:{Space:[{command:"target_nearest_enemy",type:"targeting",icon:"🎯",text:"Target nearest enemy"},{command:"+STOTrayExecByTray 0 0",type:"tray",icon:"⚡",text:"Primary attack"}],1:[{command:"+STOTrayExecByTray 0 1",type:"tray",icon:"⚡",text:"Secondary attack"}],2:[{command:"+STOTrayExecByTray 0 2",type:"tray",icon:"⚡",text:"Kit ability 1"}],F1:[{command:"target_self",type:"targeting",icon:"👤",text:"Target self"},{command:"+STOTrayExecByTray 1 0",type:"tray",icon:"💊",text:"Heal self"}]},aliases:{}}}}createProfileFromTemplate(e){const t=this.getProfileTemplates()[e];if(!t)return void stoUI.showToast("Template not found","error");let a=t.name,n=1;const o=stoStorage.getAllData();for(;Object.values(o.profiles).some(e=>e.name===a);)a=`${t.name} ${n}`,n++;const i=app.generateProfileId(a),r={...t,name:a,created:(new Date).toISOString(),lastModified:(new Date).toISOString()};Object.values(r.keys).forEach(e=>{e.forEach(e=>{e.id=app.generateCommandId()})}),stoStorage.saveProfile(i,r)?(app.switchProfile(i),app.renderProfiles(),stoUI.showToast(`Profile "${a}" created from template`,"success")):stoUI.showToast("Failed to create profile from template","error")}exportProfile(e){const t=stoStorage.getProfile(e);if(!t)return void stoUI.showToast("Profile not found","error");const a={version:"1.0.0",exported:(new Date).toISOString(),profile:t},n=new Blob([JSON.stringify(a,null,2)],{type:"application/json"}),o=URL.createObjectURL(n),i=document.createElement("a");i.href=o,i.download=`${t.name.replace(/[^a-zA-Z0-9]/g,"_")}_profile.json`,i.click(),URL.revokeObjectURL(o),stoUI.showToast(`Profile "${t.name}" exported`,"success")}async importProfile(e){try{const t=JSON.parse(e);if(!t.profile)throw new Error("Invalid profile file format");const a=t.profile;let n=a.name,o=1;const i=stoStorage.getAllData();for(;Object.values(i.profiles).some(e=>e.name===n);)n=`${a.name} (${o})`,o++;a.name=n,a.imported=(new Date).toISOString(),a.lastModified=(new Date).toISOString();const r=app.generateProfileId(n);if(stoStorage.saveProfile(r,a))return app.renderProfiles(),stoUI.showToast(`Profile "${n}" imported successfully`,"success"),!0;throw new Error("Failed to save imported profile")}catch(e){return stoUI.showToast("Failed to import profile: "+e.message,"error"),!1}}},u=new class{constructor(){this.keybindPatterns={standard:/^([a-zA-Z0-9_+\-\s\[\]]+)\s+"([^"]*)"(?:\s+"([^"]*)")?$/,bind:/^\/bind\s+([a-zA-Z0-9_+\-\s\[\]]+)\s+(.+)$/,alias:/^alias\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+(?:"([^"]+)"|<&\s+(.+?)\s+&>)$/,comment:/^[#;].*$/},this.validKeys=this.generateValidKeys()}init(){this.setupEventListeners()}generateValidKeys(){const e=new Set;for(let t=1;t<=12;t++)e.add(`F${t}`);for(let t=0;t<=9;t++)e.add(t.toString());for(let t=65;t<=90;t++)e.add(String.fromCharCode(t));["Space","Tab","Enter","Escape","Backspace","Delete","Insert","Home","End","PageUp","PageDown","Up","Down","Left","Right","NumPad0","NumPad1","NumPad2","NumPad3","NumPad4","NumPad5","NumPad6","NumPad7","NumPad8","NumPad9","NumPadEnter","NumPadPlus","NumPadMinus","NumPadMultiply","NumPadDivide","numpad0","numpad1","numpad2","numpad3","numpad4","numpad5","numpad6","numpad7","numpad8","numpad9","divide","multiply","Button4","Button5","Button6","Button7","Button8","Lbutton","Rbutton","Mbutton","Leftdrag","Rightdrag","Middleclick","Mousechord","Wheelplus","Wheelminus","Semicolon","Equals","Comma","Minus","Period","Slash","Grave","LeftBracket","Backslash","RightBracket","Quote","[","]"].forEach(t=>e.add(t));const t=Array.from(e);return["Ctrl","Alt","Shift","Control"].forEach(a=>{t.forEach(t=>{e.add(`${a}+${t}`)})}),e.add("Ctrl+Alt"),e.add("Ctrl+Shift"),e.add("Alt+Shift"),e.add("Control+Alt"),e.add("Control+Shift"),t.forEach(t=>{e.add(`Ctrl+Alt+${t}`),e.add(`Ctrl+Shift+${t}`),e.add(`Alt+Shift+${t}`),e.add(`Control+Alt+${t}`),e.add(`Control+Shift+${t}`)}),Array.from(e).sort()}parseKeybindFile(e){const t=e.split("\n"),a={keybinds:{},aliases:{},comments:[],errors:[]};return t.forEach((e,t)=>{const n=e.trim();if(n)try{if(this.keybindPatterns.comment.test(n))a.comments.push({line:t+1,content:n});else if(this.keybindPatterns.alias.test(n)){const e=n.match(this.keybindPatterns.alias);if(e){const[,n,o,i]=e,r=o||i;a.aliases[n]={name:n,commands:r,line:t+1}}}else if(this.keybindPatterns.standard.test(n)){const e=n.match(this.keybindPatterns.standard);if(e){const[,n,o,i]=e,r=this.parseCommandString(o);a.keybinds[n]={key:n,commands:r,line:t+1,raw:o,optionalParam:i||null}}}else if(this.keybindPatterns.bind.test(n)){const e=n.match(this.keybindPatterns.bind);if(e){const[,n,o]=e,i=o.replace(/^"(.*)"$/,"$1"),r=this.parseCommandString(i);a.keybinds[n]={key:n,commands:r,line:t+1,raw:i}}}else a.errors.push({line:t+1,content:n,error:"Invalid keybind format"})}catch(e){a.errors.push({line:t+1,content:n,error:e.message})}}),a}generateMirroredCommandString(e){if(!e||e.length<=1)return e.map(e=>e.command||e).join(" $$ ");const t=e.map(e=>e.command||e),a=[...t].reverse().slice(1);return[...t,...a].join(" $$ ")}detectAndUnmirrorCommands(e){if(!e||"string"!=typeof e)return{isMirrored:!1,originalCommands:[]};const t=e.split(" $$ ").map(e=>e.trim()).filter(e=>e);if(t.length<=1)return{isMirrored:!1,originalCommands:t};if(t.length<3||t.length%2==0)return{isMirrored:!1,originalCommands:t};const a=Math.floor(t.length/2),n=t.slice(0,a+1),o=t.slice(a+1),i=n.slice(0,-1).reverse();return o.length===i.length&&o.every((e,t)=>e===i[t])?{isMirrored:!0,originalCommands:n}:{isMirrored:!1,originalCommands:t}}parseCommandString(e){return e.split("$$").map(e=>e.trim()).map((e,t)=>{const a={command:e,type:window.stoCommands?window.stoCommands.detectCommandType(e):"custom",icon:window.stoCommands?window.stoCommands.getCommandIcon(e):"⚙️",text:window.stoCommands?window.stoCommands.getCommandText(e):e,id:`imported_${Date.now()}_${t}`};if(e.includes("+STOTrayExecByTray")){const t=e.match(/\+STOTrayExecByTray\s+(\d+)\s+(\d+)/);t&&(a.parameters={tray:parseInt(t[1]),slot:parseInt(t[2])},a.text=`Execute Tray ${parseInt(t[1])+1} Slot ${parseInt(t[2])+1}`)}else if(e.includes('"')){const t=e.match(/^(\w+)\s+"([^"]+)"$/);t&&(a.parameters={message:t[2]},a.text=`${a.text}: ${t[2]}`)}return a})}importKeybindFile(e){const t=stoStorage.getProfile(l.currentProfile);if(!t)return stoUI.showToast("No profile selected for import","warning"),{success:!1,error:"No active profile"};try{const a=this.parseKeybindFile(e),n=Object.keys(a.keybinds).length;if(0===n)return stoUI.showToast("No keybinds found in file","warning"),{success:!1,error:"No keybinds found"};t.builds||(t.builds={space:{keys:{}},ground:{keys:{}}}),t.builds[l.currentEnvironment]||(t.builds[l.currentEnvironment]={keys:{}});const o=t.builds[l.currentEnvironment].keys;Object.entries(a.keybinds).forEach(([e,a])=>{const n=a.commands.map(e=>e.command).join(" $$ "),i=this.detectAndUnmirrorCommands(n);if(i.isMirrored){o[e]=this.parseCommandString(i.originalCommands.join(" $$ "));const a=l.currentEnvironment;t.keybindMetadata||(t.keybindMetadata={}),t.keybindMetadata[a]||(t.keybindMetadata[a]={}),t.keybindMetadata[a][e]={stabilizeExecutionOrder:!0}}else o[e]=a.commands}),stoStorage.saveProfile(l.currentProfile,t),app.setModified(!0),app.renderKeyGrid();const i=`Import completed: ${n} keybinds`;return Object.keys(a.aliases).length>0?stoUI.showToast(i+` (${Object.keys(a.aliases).length} aliases ignored - use Import Aliases)`,"success"):stoUI.showToast(i,"success"),{success:!0,imported:{keys:n},errors:a.errors}}catch(e){return stoUI.showToast("Import failed: "+e.message,"error"),{success:!1,error:e.message}}}importAliasFile(e){if(!app.getCurrentProfile())return stoUI.showToast("No profile selected for import","warning"),{success:!1,error:"No active profile"};try{const t=this.parseKeybindFile(e),a=Object.keys(t.aliases).length;if(0===a)return stoUI.showToast("No aliases found in file","warning"),{success:!1,error:"No aliases found"};const n=stoStorage.getProfile(l.currentProfile);if(!n)return stoUI.showToast("Failed to get profile for import","error"),{success:!1,error:"Profile not found"};n.aliases||(n.aliases={}),Object.entries(t.aliases).forEach(([e,t])=>{n.aliases[e]={commands:t.commands,description:t.description||""}}),stoStorage.saveProfile(l.currentProfile,n),app.setModified(!0),window.stoAliases&&"function"==typeof window.stoAliases.updateCommandLibrary&&window.stoAliases.updateCommandLibrary();const o=`Import completed: ${a} aliases`;return stoUI.showToast(o,"success"),{success:!0,imported:{aliases:a},errors:t.errors}}catch(e){return stoUI.showToast("Import failed: "+e.message,"error"),{success:!1,error:e.message}}}exportProfile(e){let t="";return t+=`# ${e.name} - ${e.mode} mode\n`,t+="# Generated by STO Tools Keybind Manager\n",t+=`# ${(new Date).toLocaleString()}\n\n`,t+="# Keybind Commands\n",Object.keys(e.keys).sort(this.compareKeys.bind(this)).forEach(a=>{const n=e.keys[a];if(n&&n.length>0){let o,i=!1;if(e.keybindMetadata){const t=e.mode||"space";e.keybindMetadata[t]&&e.keybindMetadata[t][a]?i=!!e.keybindMetadata[t][a].stabilizeExecutionOrder:e.keybindMetadata[a]&&(i=!!e.keybindMetadata[a].stabilizeExecutionOrder)}o=i&&n.length>1?this.generateMirroredCommandString(n):n.map(e=>e.command).join(" $$ "),t+=`${a} "${o}" ""\n`}else t+=`${a} "" ""\n`}),t}compareKeys(e,t){const a=e.match(/^F(\d+)$/),n=t.match(/^F(\d+)$/);if(a&&n)return parseInt(a[1])-parseInt(n[1]);if(a&&!n)return-1;if(!a&&n)return 1;const o=/^\d+$/.test(e),i=/^\d+$/.test(t);if(o&&i)return parseInt(e)-parseInt(t);if(o&&!i)return-1;if(!o&&i)return 1;const r=/^[A-Z]$/.test(e),s=/^[A-Z]$/.test(t);if(r&&s)return e.localeCompare(t);if(r&&!s)return-1;if(!r&&s)return 1;const c=["Space","Tab","Enter","Escape"],l=c.indexOf(e),d=c.indexOf(t);return-1!==l&&-1!==d?l-d:-1!==l&&-1===d?-1:-1===l&&-1!==d?1:e.localeCompare(t)}isValidKey(e){return!(!e||"string"!=typeof e)&&this.validKeys.some(t=>t.toLowerCase()===e.toLowerCase())}isValidAliasName(e){return STO_DATA.validation.aliasNamePattern.test(e)}validateKeybind(e,t){const a=[];return this.isValidKey(e)||a.push(`Invalid key name: ${e}`),t&&0!==t.length?t.forEach((e,t)=>{e.command&&0!==e.command.trim().length||a.push(`Command ${t+1} is empty`)}):a.push("At least one command is required"),t&&t.length>STO_DATA.validation.maxCommandsPerKey&&a.push(`Too many commands (max ${STO_DATA.validation.maxCommandsPerKey})`),{valid:0===a.length,errors:a}}suggestKeys(e=""){const t=e.toLowerCase();return this.validKeys.filter(e=>e.toLowerCase().includes(t)).slice(0,20)}getCommonKeys(){return["Space","Tab","Enter","F1","F2","F3","F4","F5","F6","F7","F8","1","2","3","4","5","6","7","8","9","0","Ctrl+1","Ctrl+2","Ctrl+3","Ctrl+4","Alt+1","Alt+2","Alt+3","Alt+4","Shift+1","Shift+2","Shift+3","Shift+4"]}setupEventListeners(){}handleKeybindFileImport(e){const t=e.target.files[0];if(!t)return;const a=new FileReader;a.onload=e=>{try{this.importKeybindFile(e.target.result)}catch(e){stoUI.showToast("Failed to import keybind file: "+e.message,"error")}},a.readAsText(t),e.target.value=""}generateKeybindId(){return"keybind_"+Date.now()+"_"+Math.random().toString(36).substr(2,9)}cloneKeybind(e){return JSON.parse(JSON.stringify(e))}getProfileStats(e){const t={totalKeys:Object.keys(e.keys).length,totalCommands:0,totalAliases:Object.keys(e.aliases||{}).length,commandTypes:{},mostUsedCommands:{}};return Object.values(e.keys).forEach(e=>{t.totalCommands+=e.length,e.forEach(e=>{t.commandTypes[e.type]=(t.commandTypes[e.type]||0)+1,t.mostUsedCommands[e.command]=(t.mostUsedCommands[e.command]||0)+1})}),t}},y=new class{constructor(){this.currentAlias=null}init(){this.setupEventListeners(),this.updateCommandLibrary()}setupEventListeners(){i.onDom("addAliasBtn","click","alias-manager-open",()=>{this.showAliasManager()}),i.onDom("newAliasBtn","click","alias-new",()=>{this.showEditAliasModal()}),i.onDom("saveAliasBtn","click","alias-save",()=>{this.saveAlias()}),document.addEventListener("input",e=>{["aliasName","aliasCommands","aliasDescription"].includes(e.target.id)&&this.updateAliasPreview()}),document.addEventListener("click",e=>{if(e.target.classList.contains("insert-target-btn")||e.target.closest(".insert-target-btn")){e.preventDefault();const t=(e.target.classList.contains("insert-target-btn")?e.target:e.target.closest(".insert-target-btn")).closest(".textarea-with-button"),a=t?t.querySelector("textarea"):null;a&&this.insertTargetVariable(a)}})}showAliasManager(){this.renderAliasList(),modalManager.show("aliasManagerModal")}renderAliasList(){const e=document.getElementById("aliasList");if(!e)return;const t=app.getCurrentProfile();if(!t||!t.aliases)return void(e.innerHTML='\n                <div class="empty-state">\n                    <i class="fas fa-mask"></i>\n                    <h4>No Aliases</h4>\n                    <p>Create command aliases to simplify complex command sequences.</p>\n                </div>\n            ');const a=Object.entries(t.aliases);0!==a.length?(e.innerHTML=`\n            <div class="alias-grid">\n                ${a.map(([e,t])=>this.createAliasCard(e,t)).join("")}\n            </div>\n        `,e.querySelectorAll(".alias-card").forEach(e=>{const t=e.dataset.alias;e.querySelector(".edit-alias-btn")?.addEventListener("click",()=>{this.editAlias(t)}),e.querySelector(".delete-alias-btn")?.addEventListener("click",()=>{this.confirmDeleteAlias(t)}),e.querySelector(".use-alias-btn")?.addEventListener("click",()=>{this.useAlias(t)})})):e.innerHTML='\n                <div class="empty-state">\n                    <i class="fas fa-mask"></i>\n                    <h4>No Aliases</h4>\n                    <p>Create command aliases to simplify complex command sequences.</p>\n                </div>\n            '}createAliasCard(e,t){const a=t.commands.length>60?t.commands.substring(0,60)+"...":t.commands;return`\n            <div class="alias-card" data-alias="${e}">\n                <div class="alias-header">\n                    <h4>${e}</h4>\n                    <div class="alias-actions">\n                        <button class="btn btn-small-icon edit-alias-btn" title="Edit Alias">\n                            <i class="fas fa-edit"></i>\n                        </button>\n                        <button class="btn btn-small-icon use-alias-btn" title="Add to Current Key">\n                            <i class="fas fa-plus"></i>\n                        </button>\n                        <button class="btn btn-small-icon btn-danger delete-alias-btn" title="Delete Alias">\n                            <i class="fas fa-trash"></i>\n                        </button>\n                    </div>\n                </div>\n                <div class="alias-description">\n                    ${t.description||"No description"}\n                </div>\n                <div class="alias-commands">\n                    <code>${a}</code>\n                </div>\n                <div class="alias-usage">\n                    Usage: <code>${e}</code>\n                </div>\n            </div>\n        `}showEditAliasModal(e=null){const t=document.getElementById("editAliasTitle"),a=document.getElementById("aliasName"),n=document.getElementById("aliasDescription"),o=document.getElementById("aliasCommands");if(e){const i=app.getCurrentProfile().aliases[e];t&&(t.textContent="Edit Alias"),a&&(a.value=e,a.disabled=!0),n&&(n.value=i.description||""),o&&(o.value=i.commands),this.currentAlias=e}else t&&(t.textContent="New Alias"),a&&(a.value="",a.disabled=!1),n&&(n.value=""),o&&(o.value=""),this.currentAlias=null;this.updateAliasPreview(),modalManager.hide("aliasManagerModal"),modalManager.show("editAliasModal")}editAlias(e){this.showEditAliasModal(e)}async confirmDeleteAlias(e){await stoUI.confirm(`Are you sure you want to delete the alias "${e}"?`,"Delete Alias","danger")&&this.deleteAlias(e)}deleteAlias(e){const t=app.getCurrentProfile();t&&t.aliases&&t.aliases[e]&&(delete t.aliases[e],app.saveProfile(),app.setModified(!0),this.renderAliasList(),this.updateCommandLibrary(),stoUI.showToast(`Alias "${e}" deleted`,"success"))}useAlias(e){if(!l.selectedKey)return void stoUI.showToast("Please select a key first","warning");const t={command:e,type:"alias",icon:"🎭",text:`Alias: ${e}`,id:app.generateCommandId()};app.addCommand(l.selectedKey,t),modalManager.hide("aliasManagerModal"),stoUI.showToast(`Alias "${e}" added to ${l.selectedKey}`,"success")}saveAlias(){const e=document.getElementById("aliasName"),t=document.getElementById("aliasDescription"),a=document.getElementById("aliasCommands");if(!e||!a)return;const n=e.value.trim(),o=t?.value.trim()||"",i=a.value.trim(),r=this.validateAlias(n,i);if(!r.valid)return void stoUI.showToast(r.error,"error");const s=app.getCurrentProfile();if(!s)return void stoUI.showToast("No active profile","error");if(s.aliases||(s.aliases={}),!this.currentAlias&&s.aliases[n])return stoUI.showToast("An alias with this name already exists","error"),void e.focus();s.aliases[n]={name:n,description:o,commands:i,created:this.currentAlias?s.aliases[n]?.created:(new Date).toISOString(),lastModified:(new Date).toISOString()},app.saveProfile(),app.setModified(!0),this.updateCommandLibrary();const c=this.currentAlias?"updated":"created";stoUI.showToast(`Alias "${n}" ${c}`,"success"),modalManager.hide("editAliasModal"),this.showAliasManager()}validateAlias(e,t){if(!e)return{valid:!1,error:"Alias name is required"};if(!STO_DATA.validation.aliasNamePattern.test(e))return{valid:!1,error:"Invalid alias name. Use only letters, numbers, and underscores. Must start with a letter."};if(e.length>30)return{valid:!1,error:"Alias name is too long (max 30 characters)"};if(["alias","bind","unbind","bind_load_file","bind_save_file"].includes(e.toLowerCase()))return{valid:!1,error:"This is a reserved command name"};if(!t)return{valid:!1,error:"Commands are required"};if(t.length>500)return{valid:!1,error:"Command sequence is too long (max 500 characters)"};if("undefined"!=typeof app&&app.getCurrentProfile){const a=app.getCurrentProfile();if(a&&a.aliases&&Object.keys(a.aliases).some(a=>t.includes(a)&&a!==e))return{valid:!1,error:"Potential circular reference detected"}}return{valid:!0}}updateAliasPreview(){const e=document.getElementById("aliasPreview"),t=document.getElementById("aliasName"),a=document.getElementById("aliasCommands");if(!e||!t||!a)return;const n=t.value.trim()||"AliasName",o=a.value.trim()||"command sequence";e.textContent=`alias ${n} <& ${o} &>`}updateCommandLibrary(){const e=app.getCurrentProfile();if(!e||!e.aliases)return;const t=document.getElementById("commandCategories");if(!t)return;const a=t.querySelector('[data-category="aliases"]');a&&a.remove();const n=t.querySelector('[data-category="vertigo-aliases"]');n&&n.remove();const o=Object.entries(e.aliases),i=o.filter(([e,t])=>!e.startsWith("dynFxSetFXExlusionList_")),r=o.filter(([e,t])=>e.startsWith("dynFxSetFXExlusionList_"));if(i.length>0){const e=this.createAliasCategoryElement(i,"aliases","Command Aliases","fas fa-mask");t.appendChild(e)}if(r.length>0){const e=this.createAliasCategoryElement(r,"vertigo-aliases","VFX Aliases","fas fa-eye-slash");t.appendChild(e)}}createAliasCategoryElement(e,t="aliases",a="Command Aliases",n="fas fa-mask"){const o=document.createElement("div");o.className="category",o.dataset.category=t;const i=`commandCategory_${t}_collapsed`,r="true"===localStorage.getItem(i),s="vertigo-aliases"===t,c=s?"👁️":"🎭",l=s?"command-item vertigo-alias-item":"command-item alias-item";return o.innerHTML=`\n            <h4 class="${r?"collapsed":""}" data-category="${t}">\n                <i class="fas fa-chevron-right category-chevron"></i>\n                <i class="${n}"></i> \n                ${a}\n                <span class="command-count">(${e.length})</span>\n            </h4>\n            <div class="category-commands ${r?"collapsed":""}">\n                ${e.map(([e,t])=>`\n                    <div class="${l}" data-alias="${e}" title="${t.description||t.commands}">\n                        ${c} ${e}\n                    </div>\n                `).join("")}\n            </div>\n        `,o.querySelector("h4").addEventListener("click",()=>{this.toggleAliasCategory(t,o)}),o.addEventListener("click",e=>{if(e.target.classList.contains("alias-item")||e.target.classList.contains("vertigo-alias-item")){const t=e.target.dataset.alias;this.addAliasToKey(t)}}),o}toggleAliasCategory(e,t){const a=t.querySelector("h4"),n=t.querySelector(".category-commands"),o=a.querySelector(".category-chevron"),i=`commandCategory_${e}_collapsed`;n.classList.contains("collapsed")?(n.classList.remove("collapsed"),a.classList.remove("collapsed"),o.style.transform="rotate(90deg)",localStorage.setItem(i,"false")):(n.classList.add("collapsed"),a.classList.add("collapsed"),o.style.transform="rotate(0deg)",localStorage.setItem(i,"true"))}addAliasToKey(e){if(!l.selectedKey)return void stoUI.showToast("Please select a key first","warning");const t=app.getCurrentProfile().aliases[e];if(!t)return void stoUI.showToast("Alias not found","error");const a={command:e,type:"alias",icon:"🎭",text:`Alias: ${e}`,description:t.description,id:app.generateCommandId()};app.addCommand(l.selectedKey,a)}getAliasTemplates(){return{space_combat:{name:"Space Combat",description:"Aliases for space combat scenarios",templates:{AttackRun:{name:"AttackRun",description:"Full attack sequence with targeting",commands:"target_nearest_enemy $$ +STOTrayExecByTray 0 0 $$ +STOTrayExecByTray 0 1"},DefensiveMode:{name:"DefensiveMode",description:"Defensive abilities and shield management",commands:"target_self $$ +power_exec Distribute_Shields $$ +STOTrayExecByTray 2 0 $$ +STOTrayExecByTray 2 1"},HealSelf:{name:"HealSelf",description:"Self-healing sequence",commands:"target_self $$ +STOTrayExecByTray 3 0 $$ +STOTrayExecByTray 3 1"}}},ground_combat:{name:"Ground Combat",description:"Aliases for ground combat scenarios",templates:{GroundAttack:{name:"GroundAttack",description:"Basic ground combat sequence",commands:"target_nearest_enemy $$ +STOTrayExecByTray 0 0 $$ +STOTrayExecByTray 0 1"},GroundHeal:{name:"GroundHeal",description:"Ground healing sequence",commands:"target_self $$ +STOTrayExecByTray 1 0 $$ +STOTrayExecByTray 1 1"}}},communication:{name:"Communication",description:"Aliases for team communication",templates:{TeamReady:{name:"TeamReady",description:"Announce ready status to team",commands:"team Ready!"},NeedHealing:{name:"NeedHealing",description:"Request healing from team",commands:"team Need healing!"},Incoming:{name:"Incoming",description:"Warn team of incoming enemies",commands:"team Incoming enemies!"}}}}}createAliasFromTemplate(e,t){const a=this.getAliasTemplates(),n=a[e]?.templates?.[t];if(!n)return void stoUI.showToast("Template not found","error");const o=app.getCurrentProfile();o.aliases&&o.aliases[n.name]?stoUI.showToast(`Alias "${n.name}" already exists`,"warning"):(o.aliases||(o.aliases={}),o.aliases[n.name]={...n,created:(new Date).toISOString(),lastModified:(new Date).toISOString()},app.saveProfile(),app.setModified(!0),this.updateCommandLibrary(),this.renderAliasList(),stoUI.showToast(`Alias "${n.name}" created from template`,"success"))}getAliasUsage(e){const t=app.getCurrentProfile();if(!t)return[];const a=[];return Object.entries(t.keys).forEach(([t,n])=>{n.forEach((n,o)=>{(n.command===e||n.command.includes(e))&&a.push({type:"keybind",key:t,position:o+1,context:`Key "${t}", command ${o+1}`})})}),Object.entries(t.aliases||{}).forEach(([t,n])=>{t!==e&&n.commands.includes(e)&&a.push({type:"alias",alias:t,context:`Alias "${t}"`})}),a}insertTargetVariable(e){const t=e.selectionStart,a=e.value,n=a.slice(0,t)+"$Target"+a.slice(t);e.value=n,e.setSelectionRange(t+7,t+7),e.focus(),e.dispatchEvent(new Event("input",{bubbles:!0}))}},f=new class{constructor(){this.exportFormats={sto_keybind:"STO Keybind File (.txt)",json_profile:"JSON Profile (.json)",json_project:"Complete Project (.json)",csv_data:"CSV Data (.csv)",html_report:"HTML Report (.html)"}}init(){this.setupEventListeners()}setupEventListeners(){i.onDom("exportKeybindsBtn","click","exportKeybinds",()=>{this.showExportOptions()}),i.onDom("copyPreviewBtn","click","copyPreview",()=>{this.copyCommandPreview()})}async showExportOptions(){const e=app.getCurrentProfile();e?this.exportSTOKeybindFile(e):stoUI.showToast("No profile selected to export","warning")}exportSTOKeybindFile(e){try{const t=this.generateSTOKeybindFile(e);this.downloadFile(t,this.generateFileName(e,"txt"),"text/plain"),stoUI.showToast("Keybind file exported successfully","success")}catch(e){stoUI.showToast("Failed to export keybind file: "+e.message,"error")}}generateSTOKeybindFile(e,t={}){let a="";return a+=this.generateFileHeader(e),a+=this.generateKeybindSection(e.keys,{...t,profile:e,environment:t.environment||e.mode||"space"}),a+=this.generateFileFooter(),a}generateFileHeader(e){const t=(new Date).toLocaleString();let a;return"undefined"!=typeof stoKeybinds&&stoKeybinds.getProfileStats?a=stoKeybinds.getProfileStats(e):(a={totalKeys:Object.keys(e.keys||{}).length,totalCommands:0},Object.values(e.keys||{}).forEach(e=>{a.totalCommands+=e.length})),`; ================================================================\n; ${e.name} - STO Keybind Configuration\n; ================================================================\n; Mode: ${e.mode.toUpperCase()}\n; Generated: ${t}\n; Created by: STO Tools Keybind Manager v${STO_DATA.settings.version}\n;\n; Keybind Statistics:\n; - Keys bound: ${a.totalKeys}\n; - Total commands: ${a.totalCommands}\n;\n; Note: Aliases are exported separately\n; To use this file in Star Trek Online:\n; 1. Save this file to your STO Live folder\n; 2. In game, type: /bind_load_file ${this.generateFileName(e,"txt")}\n; ================================================================\n\n`}generateAliasSection(e){if(!e||0===Object.keys(e).length)return"";let t="; Command Aliases\n; ================================================================\n; Aliases allow you to create custom commands that execute\n; multiple commands in sequence. Use them in keybinds like any\n; other command.\n; ================================================================\n\n";return Object.entries(e).sort(([e],[t])=>e.localeCompare(t)).forEach(([e,a])=>{a.description&&(t+=`; ${a.description}\n`),t+=`alias ${e} <& ${a.commands} &>\n\n`}),t}generateKeybindSection(e,t={}){if(!e||0===Object.keys(e).length)return"; No keybinds defined\n\n";let a,n="; Keybind Commands\n; ================================================================\n; Each line binds a key to one or more commands.\n; Multiple commands are separated by $$";t.stabilizeExecutionOrder&&(n+="\n; EXECUTION ORDER STABILIZATION: ON\n; Commands are mirrored to ensure consistent execution order\n; Phase 1: left-to-right, Phase 2: right-to-left"),n+="\n; ================================================================\n\n",a="undefined"!=typeof stoKeybinds&&stoKeybinds.compareKeys?Object.keys(e).sort(stoKeybinds.compareKeys.bind(stoKeybinds)):Object.keys(e).sort(this.compareKeys.bind(this));const o=this.groupKeysByType(a,e);return Object.entries(o).forEach(([a,o])=>{0!==o.length&&(n+=`; ${a}\n`,n+=`; ${"-".repeat(a.length)}\n`,o.forEach(a=>{const o=e[a];if(o&&o.length>0){let e;const i=t.stabilizeExecutionOrder;let r=!1;if(t.profile&&t.profile.keybindMetadata)if(t.environment&&t.profile.keybindMetadata[t.environment]){const e=t.profile.keybindMetadata[t.environment];r=!!(e&&e[a]&&e[a].stabilizeExecutionOrder)}else r=!(!t.profile.keybindMetadata[a]||!t.profile.keybindMetadata[a].stabilizeExecutionOrder);e=(i||r)&&o.length>1&&stoKeybinds?stoKeybinds.generateMirroredCommandString(o):o.map(e=>e.command).join(" $$ "),n+=`${a} "${e}"\n`}}),n+="\n")}),n}compareKeys(e,t){const a=e.match(/^F(\d+)$/),n=t.match(/^F(\d+)$/);if(a&&n)return parseInt(a[1])-parseInt(n[1]);if(a&&!n)return-1;if(!a&&n)return 1;const o=/^\d+$/.test(e),i=/^\d+$/.test(t);if(o&&i)return parseInt(e)-parseInt(t);if(o&&!i)return-1;if(!o&&i)return 1;const r=/^[A-Z]$/.test(e),s=/^[A-Z]$/.test(t);if(r&&s)return e.localeCompare(t);if(r&&!s)return-1;if(!r&&s)return 1;const c=["Space","Tab","Enter","Escape"],l=c.indexOf(e),d=c.indexOf(t);return-1!==l&&-1!==d?l-d:-1!==l&&-1===d?-1:-1===l&&-1!==d?1:e.localeCompare(t)}groupKeysByType(e,t){const a={"Function Keys":[],"Number Keys":[],"Letter Keys":[],"Special Keys":[],"Modifier Combinations":[]};return e.forEach(e=>{/^F\d+$/.test(e)?a["Function Keys"].push(e):/^\d+$/.test(e)?a["Number Keys"].push(e):/^[A-Z]$/.test(e)?a["Letter Keys"].push(e):e.includes("+")?a["Modifier Combinations"].push(e):a["Special Keys"].push(e)}),a}generateFileFooter(){return"; ================================================================\n; End of keybind file\n; ================================================================\n; \n; Additional STO Commands Reference:\n; \n; Targeting:\n;   target_nearest_enemy    - Target closest hostile\n;   target_nearest_friend   - Target closest friendly\n;   target_self            - Target your own ship\n; \n; Combat:\n;   FireAll               - Fire all weapons\n;   FirePhasers          - Fire beam weapons only\n;   FireTorps            - Fire torpedo weapons only\n; \n; Shield Management:\n;   +power_exec <ability> - Execute bridge officer ability\n;   Examples: +power_exec Distribute_Shields \n; \n; Tray Execution:\n;   +STOTrayExecByTray <tray> <slot> - Execute ability from tray\n;   Example: +STOTrayExecByTray 0 0  (Tray 1, Slot 1)\n; \n; For more commands and help, visit the STO Wiki or community forums.\n; ================================================================\n"}exportJSONProfile(e){try{const t={version:STO_DATA.settings.version,exported:(new Date).toISOString(),type:"profile",profile:this.sanitizeProfileForExport(e)},a=JSON.stringify(t,null,2);this.downloadFile(a,this.generateFileName(e,"json"),"application/json"),stoUI.showToast("Profile exported as JSON","success")}catch(e){stoUI.showToast("Failed to export profile: "+e.message,"error")}}exportCompleteProject(){try{const e=stoStorage.getAllData(),t={version:STO_DATA.settings.version,exported:(new Date).toISOString(),type:"project",data:e},a=JSON.stringify(t,null,2),n=`STO_Tools_Keybinds_Project_${(new Date).toISOString().split("T")[0]}.json`;this.downloadFile(a,n,"application/json"),stoUI.showToast("Complete project exported","success")}catch(e){stoUI.showToast("Failed to export project: "+e.message,"error")}}exportCSVData(e){try{const t=this.generateCSVData(e);this.downloadFile(t,this.generateFileName(e,"csv"),"text/csv"),stoUI.showToast("Data exported as CSV","success")}catch(e){stoUI.showToast("Failed to export CSV: "+e.message,"error")}}generateCSVData(e){let t="Key,Command,Type,Description,Position\n";return Object.entries(e.keys).forEach(([e,a])=>{a.forEach((a,n)=>{const o=[this.escapeCSV(e),this.escapeCSV(a.command),this.escapeCSV(a.type),this.escapeCSV(a.text||""),n+1].join(",");t+=o+"\n"})}),t}escapeCSV(e){return"string"!=typeof e&&(e=String(e)),e.includes(",")||e.includes('"')||e.includes("\n")?'"'+e.replace(/"/g,'""')+'"':e}exportHTMLReport(e){try{const t=this.generateHTMLReport(e);this.downloadFile(t,this.generateFileName(e,"html"),"text/html"),stoUI.showToast("HTML report exported","success")}catch(e){stoUI.showToast("Failed to export HTML report: "+e.message,"error")}}generateHTMLReport(e){const t=stoKeybinds.getProfileStats(e),a=(new Date).toLocaleString();return`<!DOCTYPE html>\n<html lang="en">\n<head>\n    <meta charset="UTF-8">\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>${e.name} - STO Keybind Report</title>\n    <style>\n        body { font-family: Arial, sans-serif; margin: 40px; line-height: 1.6; }\n        .header { border-bottom: 2px solid #333; padding-bottom: 20px; margin-bottom: 30px; }\n        .stats { background: #f5f5f5; padding: 20px; border-radius: 5px; margin-bottom: 30px; }\n        .keybind-group { margin-bottom: 30px; }\n        .keybind-group h3 { color: #333; border-bottom: 1px solid #ccc; padding-bottom: 5px; }\n        .keybind { margin-bottom: 15px; padding: 10px; background: #fafafa; border-left: 4px solid #007acc; }\n        .key { font-weight: bold; color: #007acc; }\n        .commands { margin-top: 5px; }\n        .command { display: inline-block; margin: 2px 5px 2px 0; padding: 2px 8px; background: #e0e0e0; border-radius: 3px; font-size: 0.9em; }\n        .command.targeting { background: #d4edda; }\n        .command.combat { background: #f8d7da; }\n        .command.tray { background: #cce5ff; }\n        .command.power { background: #fff3cd; }\n        .command.alias { background: #e2e3e5; }\n        .aliases { margin-top: 30px; }\n        .alias { margin-bottom: 15px; padding: 10px; background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 5px; }\n        .alias-name { font-weight: bold; color: #495057; }\n        .alias-commands { font-family: monospace; background: #e9ecef; padding: 5px; margin-top: 5px; border-radius: 3px; }\n    </style>\n</head>\n<body>\n    <div class="header">\n        <h1>${e.name}</h1>\n        <p><strong>Mode:</strong> ${e.mode.toUpperCase()}</p>\n        <p><strong>Generated:</strong> ${a}</p>\n        <p><strong>Created by:</strong> STO Tools Keybind Manager v${STO_DATA.settings.version}</p>\n    </div>\n\n    <div class="stats">\n        <h2>Statistics</h2>\n        <ul>\n            <li><strong>Keys Bound:</strong> ${t.totalKeys}</li>\n            <li><strong>Total Commands:</strong> ${t.totalCommands}</li>\n            <li><strong>Aliases Defined:</strong> ${t.totalAliases}</li>\n        </ul>\n    </div>\n\n    ${this.generateHTMLKeybindSection(e.keys)}\n    ${this.generateHTMLAliasSection(e.aliases)}\n\n    <div style="margin-top: 50px; padding-top: 20px; border-top: 1px solid #ccc; color: #666; font-size: 0.9em;">\n        <p>This report was generated by STO Tools Keybind Manager. For more information about Star Trek Online keybinds, visit the STO Wiki.</p>\n    </div>\n</body>\n</html>`}generateHTMLKeybindSection(e){if(!e||0===Object.keys(e).length)return'<div class="keybind-group"><h2>Keybinds</h2><p>No keybinds defined.</p></div>';const t=Object.keys(e).sort(stoKeybinds.compareKeys.bind(stoKeybinds)),a=this.groupKeysByType(t,e);let n='<div class="keybind-group"><h2>Keybinds</h2>';return Object.entries(a).forEach(([t,a])=>{0!==a.length&&(n+=`<h3>${t}</h3>`,a.forEach(t=>{const a=e[t];a&&a.length>0&&(n+=`<div class="keybind">\n                        <div class="key">${t}</div>\n                        <div class="commands">\n                            ${a.map(e=>`<span class="command ${e.type}">${e.text||e.command}</span>`).join("")}\n                        </div>\n                    </div>`)}))}),n+="</div>",n}generateHTMLAliasSection(e){if(!e||0===Object.keys(e).length)return"";let t='<div class="aliases"><h2>Command Aliases</h2>';return Object.entries(e).sort(([e],[t])=>e.localeCompare(t)).forEach(([e,a])=>{t+=`<div class="alias">\n                <div class="alias-name">${e}</div>\n                ${a.description?`<div>${a.description}</div>`:""}\n                <div class="alias-commands">${a.commands}</div>\n            </div>`}),t+="</div>",t}copyCommandPreview(){const e=document.getElementById("commandPreview");e&&e.textContent.trim()?stoUI.copyToClipboard(e.textContent):stoUI.showToast("No command to copy","warning")}generateFileName(e,t){const a=e.name.replace(/[^a-zA-Z0-9\-_]/g,"_"),n=(new Date).toISOString().split("T")[0];return`${a}_${e.mode||"space"}_${n}.${t}`}downloadFile(e,t,a){const n=new Blob([e],{type:a}),o=URL.createObjectURL(n),i=document.createElement("a");i.href=o,i.download=t,document.body.appendChild(i),i.click(),document.body.removeChild(i),URL.revokeObjectURL(o)}sanitizeProfileForExport(e){const t=JSON.parse(JSON.stringify(e));return t.keys&&Object.values(t.keys).forEach(e=>{e.forEach(e=>{delete e.id})}),t}exportAllProfiles(){const e=stoStorage.getAllData().profiles;e&&0!==Object.keys(e).length?(Object.entries(e).forEach(([e,t])=>{setTimeout(()=>{this.exportSTOKeybindFile(t)},100)}),stoUI.showToast(`Exporting ${Object.keys(e).length} profiles...`,"info")):stoUI.showToast("No profiles to export","warning")}async importFromFile(e){return new Promise((t,a)=>{const n=new FileReader;n.onload=n=>{try{const o=n.target.result;switch(e.name.split(".").pop().toLowerCase()){case"txt":t(stoKeybinds.importKeybindFile(o));break;case"json":t(this.importJSONFile(o));break;default:a(new Error("Unsupported file format"))}}catch(e){a(e)}},n.onerror=()=>a(new Error("Failed to read file")),n.readAsText(e)})}importJSONFile(e){try{const t=JSON.parse(e);if("profile"===t.type&&t.profile)return stoProfiles.importProfile(e);if("project"===t.type&&t.data)return stoStorage.importData(JSON.stringify(t.data));throw new Error("Unknown JSON file format")}catch(e){throw new Error("Invalid JSON file: "+e.message)}}exportAliases(e){try{const t=this.generateAliasFile(e);this.downloadFile(t,this.generateAliasFileName(e,"txt"),"text/plain"),stoUI.showToast("Aliases exported successfully","success")}catch(e){stoUI.showToast("Failed to export aliases: "+e.message,"error")}}generateAliasFile(e){let t="";const a=(new Date).toLocaleString(),n=Object.keys(e.aliases||{}).length;return t+=`; ================================================================\n; ${e.name} - STO Alias Configuration\n; ================================================================\n; Mode: ${e.mode.toUpperCase()}\n; Generated: ${a}\n; Created by: STO Tools Keybind Manager v${STO_DATA.settings.version}\n;\n; Alias Statistics:\n; - Total aliases: ${n}\n;\n; To use these aliases in Star Trek Online:\n; 1. Save this file as "CommandAliases.txt" (exactly, without quotes)\n; 2. Place it in your STO directory:\n;    [STO Install]\\Star Trek Online\\Live\\localdata\\CommandAliases.txt\n; 3. The aliases will be available when you start the game\n;\n; Alternative: You can append these aliases to an existing CommandAliases.txt\n; file if you already have one with other aliases.\n;\n; Common STO installation paths:\n; - Steam: C:\\Program Files (x86)\\Steam\\steamapps\\common\\Star Trek Online\n; - Epic: C:\\Program Files\\Epic Games\\Star Trek Online  \n; - Arc: C:\\Program Files (x86)\\Perfect World Entertainment\\Arc Games\\Star Trek Online\n; ================================================================\n\n`,e.aliases&&Object.keys(e.aliases).length>0?t+=this.generateAliasSection(e.aliases):t+="; No aliases defined\n\n",t}generateAliasFileName(e,t){const a=e.name.replace(/[^a-zA-Z0-9\-_]/g,"_"),n=(new Date).toISOString().split("T")[0];return`${a}_aliases_${e.mode||"space"}_${n}.${t}`}},h=new class{constructor(){this.overlayId="modalOverlay"}getOverlay(){return document.getElementById(this.overlayId)}show(e){const t="string"==typeof e?document.getElementById(e):e,a=this.getOverlay();if(a&&t){a.classList.add("active"),t.classList.add("active"),document.body.classList.add("modal-open");const e=t.querySelector("input, textarea, select");return e&&setTimeout(()=>e.focus(),100),!0}return!1}hide(e){const t="string"==typeof e?document.getElementById(e):e,a=this.getOverlay();return!(!a||!t||(t.classList.remove("active"),document.querySelector(".modal.active")||(a.classList.remove("active"),document.body.classList.remove("modal-open")),0))}},g=new class{constructor(){this.toastQueue=[],this.dragState={isDragging:!1,dragElement:null,dragData:null},this.init()}init(){this.setupGlobalEventListeners(),this.setupTooltips()}showToast(e,t="info",a=3e3){const n=this.createToast(e,t,a),o=document.getElementById("toastContainer");o&&(o.appendChild(n),requestAnimationFrame(()=>{n.classList.add("show")}),setTimeout(()=>{this.removeToast(n)},a))}createToast(e,t,a){const n=document.createElement("div");n.className=`toast toast-${t}`;const o={success:"fa-check-circle",error:"fa-exclamation-circle",warning:"fa-exclamation-triangle",info:"fa-info-circle"};return n.innerHTML=`\n            <div class="toast-content">\n                <i class="fas ${o[t]||o.info}"></i>\n                <span class="toast-message">${e}</span>\n                <button class="toast-close">\n                    <i class="fas fa-times"></i>\n                </button>\n            </div>\n        `,n.querySelector(".toast-close").addEventListener("click",()=>{this.removeToast(n)}),n}hideToast(e){e&&e.parentNode&&this.removeToast(e)}removeToast(e){e.classList.add("removing"),setTimeout(()=>{e.parentNode&&e.parentNode.removeChild(e)},300)}showModal(e,t=null){return document.getElementById(e),!!modalManager.show(e)&&(t&&this.populateModalData(e,t),!0)}hideModal(e){return document.getElementById(e),!!modalManager.hide(e)&&(this.clearModalData(e),!0)}hideAllModals(){document.querySelectorAll(".modal.active").forEach(e=>{modalManager.hide(e.id)})}populateModalData(e,t){const a=document.getElementById(e);a&&Object.entries(t).forEach(([e,t])=>{const n=a.querySelector(`[data-field="${e}"], #${e}`);n&&("checkbox"===n.type?n.checked=t:n.value=t)})}clearModalData(e){const t=document.getElementById(e);t&&t.querySelectorAll("input, textarea, select").forEach(e=>{"checkbox"===e.type?e.checked=!1:e.value=""})}showLoading(e,t="Loading..."){if("string"==typeof e&&(e=document.getElementById(e)),e){e.classList.add("loading");const a=e.innerHTML;e.dataset.originalContent=a,e.innerHTML=`\n                <div class="loading-spinner">\n                    <i class="fas fa-spinner fa-spin"></i>\n                    <span>${t}</span>\n                </div>\n            `,e.disabled=!0}}hideLoading(e){"string"==typeof e&&(e=document.getElementById(e)),e&&e.classList.contains("loading")&&(e.classList.remove("loading"),e.innerHTML=e.dataset.originalContent||"",e.disabled=!1,delete e.dataset.originalContent)}async confirm(e,t="Confirm",a="warning"){return new Promise(n=>{const o=this.createConfirmModal(e,t,a),i="confirmModal";o.id=i,document.body.appendChild(o);const r=e=>{modalManager.hide(i),document.body.removeChild(o),n(e)};o.querySelector(".confirm-yes").addEventListener("click",()=>{r(!0)}),o.querySelector(".confirm-no").addEventListener("click",()=>{r(!1)}),requestAnimationFrame(()=>{modalManager.show(i)})})}createConfirmModal(e,t,a){const n=document.createElement("div");n.className="modal confirm-modal";const o={warning:"fa-exclamation-triangle",danger:"fa-exclamation-circle",info:"fa-info-circle"};return n.innerHTML=`\n            <div class="modal-content">\n                <div class="modal-header">\n                    <h3>\n                        <i class="fas ${o[a]||o.warning}"></i>\n                        ${t}\n                    </h3>\n                </div>\n                <div class="modal-body">\n                    <p>${e}</p>\n                </div>\n                <div class="modal-footer">\n                    <button class="btn btn-primary confirm-yes">Yes</button>\n                    <button class="btn btn-secondary confirm-no">No</button>\n                </div>\n            </div>\n        `,n}initDragAndDrop(e,t={}){const{dragSelector:a=".draggable",dropZoneSelector:n=".drop-zone",onDragStart:o=null,onDragEnd:i=null,onDrop:r=null}=t;e.addEventListener("dragstart",e=>{e.target.matches(a)&&(this.dragState.isDragging=!0,this.dragState.dragElement=e.target,this.dragState.dragData=e.target.dataset,e.target.classList.add("dragging"),e.dataTransfer.effectAllowed="move",o&&o(e,this.dragState))}),e.addEventListener("dragend",e=>{e.target.matches(a)&&(e.target.classList.remove("dragging"),this.dragState.isDragging=!1,this.dragState.dragElement=null,this.dragState.dragData=null,i&&i(e))}),e.addEventListener("dragover",e=>{e.preventDefault();const t=e.target.closest(n);t&&t.classList.add("drag-over")}),e.addEventListener("dragleave",e=>{const t=e.target.closest(n);t&&t.classList.remove("drag-over")}),e.addEventListener("drop",e=>{e.preventDefault();const t=e.target.closest(n);t&&(t.classList.remove("drag-over"),r&&r(e,this.dragState,t))})}validateForm(e){const t=[];return e.querySelectorAll("input[required], textarea[required], select[required]").forEach(e=>{const a=e.value.trim(),n=e.dataset.fieldName||e.name||e.id;a?(e.classList.remove("error"),"email"!==e.type||this.isValidEmail(a)||(t.push(`${n} must be a valid email`),e.classList.add("error"))):(t.push(`${n} is required`),e.classList.add("error"))}),{isValid:0===t.length,errors:t}}isValidEmail(e){return/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e)}async copyToClipboard(e){try{return await navigator.clipboard.writeText(e),this.showToast("Copied to clipboard","success"),!0}catch(t){const a=document.createElement("textarea");a.value=e,document.body.appendChild(a),a.select();try{return document.execCommand("copy"),this.showToast("Copied to clipboard","success"),!0}catch(e){return this.showToast("Failed to copy to clipboard","error"),!1}finally{document.body.removeChild(a)}}}fadeIn(e,t=300){e.style.opacity="0",e.style.display="block";let a=null;const n=o=>{a||(a=o);const i=o-a,r=Math.min(i/t,1);e.style.opacity=r,i<t&&requestAnimationFrame(n)};requestAnimationFrame(n)}fadeOut(e,t=300){let a=null;const n=o=>{a||(a=o);const i=o-a,r=Math.max(1-i/t,0);e.style.opacity=r,i<t?requestAnimationFrame(n):e.style.display="none"};requestAnimationFrame(n)}debounce(e,t){let a;return function(...n){clearTimeout(a),a=setTimeout(()=>{clearTimeout(a),e(...n)},t)}}throttle(e,t){let a;return function(){const n=arguments;a||(e.apply(this,n),a=!0,setTimeout(()=>a=!1,t))}}setupGlobalEventListeners(){document.addEventListener("keydown",e=>{"Escape"===e.key&&this.hideAllModals()}),document.addEventListener("click",e=>{e.target.classList.contains("modal-overlay")&&this.hideAllModals()})}setupTooltips(){document.addEventListener("mouseenter",e=>{e.target&&"function"==typeof e.target.hasAttribute&&e.target.hasAttribute("title")&&e.target.getAttribute("title").trim()&&this.showTooltip(e.target,e.target.getAttribute("title"))},!0),document.addEventListener("mouseleave",e=>{e.target&&"function"==typeof e.target.hasAttribute&&e.target.hasAttribute("title")&&this.hideTooltip()},!0)}showTooltip(e,t){this.hideTooltip();const a=document.createElement("div");a.className="tooltip",a.textContent=t,a.id="active-tooltip",document.body.appendChild(a);const n=e.getBoundingClientRect(),o=a.getBoundingClientRect();let i=n.left+n.width/2-o.width/2,r=n.top-o.height-8;i<8&&(i=8),i+o.width>window.innerWidth-8&&(i=window.innerWidth-o.width-8),r<8&&(r=n.bottom+8,a.classList.add("tooltip-bottom")),a.style.left=i+"px",a.style.top=r+"px",requestAnimationFrame(()=>{a.classList.add("show")})}hideTooltip(){const e=document.getElementById("active-tooltip");e&&e.remove()}},_=new class{constructor(){this.currentCommand=null,this.commandBuilders=new Map,this.init()}init(){this.setupCommandBuilders(),this.setupEventListeners()}setupCommandBuilders(){this.commandBuilders.set("targeting",{build:(e,t={})=>{const a=STO_DATA.commands.targeting.commands[e];return a?{command:a.command,type:"targeting",icon:a.icon,text:a.name,description:a.description}:null},getUI:()=>this.createTargetingUI()}),this.commandBuilders.set("combat",{build:(e,t={})=>{const a=STO_DATA.commands.combat.commands[e];return a?{command:a.command,type:"combat",icon:a.icon,text:a.name,description:a.description}:null},getUI:()=>this.createCombatUI()}),this.commandBuilders.set("tray",{build:(e,t={})=>{const a=t.tray||0,n=t.slot||0;if("tray_with_backup"===e){const e=t.backup_tray||0,o=t.backup_slot||0,i=t.active||"on";return{command:`TrayExecByTrayWithBackup ${a} ${n} ${e} ${o} ${"on"===i?1:0}`,type:"tray",icon:"⚡",text:`Execute Tray ${a+1} Slot ${n+1} (with backup)`,description:`Execute ability in tray ${a+1}, slot ${n+1} with backup in tray ${e+1}, slot ${o+1}`,parameters:{tray:a,slot:n,backup_tray:e,backup_slot:o,active:i}}}if("tray_range"===e){const e=t.start_tray||0,a=t.start_slot||0,n=t.end_tray||0,o=t.end_slot||0,i=t.command_type||"STOTrayExecByTray";return this.generateTrayRangeCommands(e,a,n,o,i).map((t,r)=>({command:t,type:"tray",icon:"⚡",text:0===r?`Execute Range: Tray ${e+1} Slot ${a+1} to Tray ${n+1} Slot ${o+1}`:t,description:0===r?`Execute abilities from tray ${e+1} slot ${a+1} to tray ${n+1} slot ${o+1}`:t,parameters:0===r?{start_tray:e,start_slot:a,end_tray:n,end_slot:o,command_type:i}:void 0}))}if("tray_range_with_backup"===e){const e=t.active||1,a=t.start_tray||0,n=t.start_slot||0,o=t.end_tray||0,i=t.end_slot||0,r=t.backup_start_tray||0,s=t.backup_start_slot||0,c=t.backup_end_tray||0,l=t.backup_end_slot||0;return this.generateTrayRangeWithBackupCommands(e,a,n,o,i,r,s,c,l).map((t,d)=>({command:t,type:"tray",icon:"⚡",text:0===d?`Execute Range with Backup: Tray ${a+1}-${o+1}`:t,description:0===d?`Execute abilities from tray ${a+1} to ${o+1} with backup range`:t,parameters:0===d?{active:e,start_tray:a,start_slot:n,end_tray:o,end_slot:i,backup_start_tray:r,backup_start_slot:s,backup_end_tray:c,backup_end_slot:l}:void 0}))}if("whole_tray"===e){const e=t.command_type||"STOTrayExecByTray";return this.generateWholeTrayCommands(a,e).map((t,n)=>({command:t,type:"tray",icon:"⚡",text:0===n?`Execute Whole Tray ${a+1}`:t,description:0===n?`Execute all abilities in tray ${a+1}`:t,parameters:0===n?{tray:a,command_type:e}:void 0}))}if("whole_tray_with_backup"===e){const e=t.active||1,n=t.backup_tray||0;return this.generateWholeTrayWithBackupCommands(e,a,n).map((t,o)=>({command:t,type:"tray",icon:"⚡",text:0===o?`Execute Whole Tray ${a+1} (with backup Tray ${n+1})`:t,description:0===o?`Execute all abilities in tray ${a+1} with backup from tray ${n+1}`:t,parameters:0===o?{active:e,tray:a,backup_tray:n}:void 0}))}const o=t.command_type||"STOTrayExecByTray";return{command:`+${o} ${a} ${n}`,type:"tray",icon:"⚡",text:`Execute Tray ${a+1} Slot ${n+1}`,description:`Execute ability in tray ${a+1}, slot ${n+1}`,parameters:{tray:a,slot:n,command_type:o}}},getUI:()=>this.createTrayUI()}),this.commandBuilders.set("power",{build:(e,t={})=>{const a=STO_DATA.commands.power.commands[e];return a?{command:a.command,type:"power",icon:a.icon,text:a.name,description:a.description}:null},getUI:()=>this.createPowerUI()}),this.commandBuilders.set("movement",{build:(e,t={})=>{const a=STO_DATA.commands.movement.commands[e];if(!a)return null;let n=a.command;return a.customizable&&t&&("throttle_adjust"===e&&void 0!==t.amount?n=`${a.command} ${t.amount}`:"throttle_set"===e&&void 0!==t.position&&(n=`${a.command} ${t.position}`)),{command:n,type:"movement",icon:a.icon,text:a.name,description:a.description}},getUI:()=>this.createMovementUI()}),this.commandBuilders.set("camera",{build:(e,t={})=>{const a=STO_DATA.commands.camera.commands[e];if(!a)return null;let n=a.command;return a.customizable&&t&&"cam_distance"===e&&void 0!==t.distance&&(n=`${a.command} ${t.distance}`),{command:n,type:"camera",icon:a.icon,text:a.name,description:a.description}},getUI:()=>this.createCameraUI()}),this.commandBuilders.set("communication",{build:(e,t={})=>{const a=STO_DATA.commands.communication.commands[e];if(!a)return null;const n=t.message||"Message text here";return{command:`${a.command} ${n}`,type:"communication",icon:a.icon,text:`${a.name}: ${n}`,description:a.description,parameters:{message:n}}},getUI:()=>this.createCommunicationUI()}),this.commandBuilders.set("system",{build:(e,t={})=>{const a=STO_DATA.commands.system.commands[e];if(!a)return null;let n=a.command;return a.customizable&&t&&("bind_save_file"!==e&&"bind_load_file"!==e||!t.filename?"combat_log"===e&&void 0!==t.state&&(n=`${a.command} ${t.state}`):n=`${a.command} ${t.filename}`),{command:n,type:"system",icon:a.icon,text:a.name,description:a.description}},getUI:()=>this.createSystemUI()}),this.commandBuilders.set("alias",{build:(e,t={})=>{const a=t.alias_name||"";return a.trim()?{command:a,type:"alias",icon:"📝",text:`Alias: ${a}`,description:"Execute custom alias",parameters:{alias_name:a}}:null},getUI:()=>this.createAliasUI()}),this.commandBuilders.set("custom",{build:(e,t={})=>{const a=t.command||"",n=t.text||"Custom Command";return{command:a,type:"custom",icon:"⚙️",text:n,description:"Custom command",parameters:{command:a,text:n}}},getUI:()=>this.createCustomUI()})}createTargetingUI(){const e=STO_DATA.commands.targeting.commands;return`\n            <div class="command-selector">\n                <label for="targetingCommand">Targeting Command:</label>\n                <select id="targetingCommand">\n                    <option value="">Select targeting command...</option>\n                    ${Object.entries(e).map(([e,t])=>`<option value="${e}">${t.name}</option>`).join("")}\n                </select>\n            </div>\n        `}createCombatUI(){const e=STO_DATA.commands.combat.commands;return`\n            <div class="command-selector">\n                <label for="combatCommand">Combat Command:</label>\n                <select id="combatCommand">\n                    <option value="">Select combat command...</option>\n                    ${Object.entries(e).map(([e,t])=>`<option value="${e}">${t.name}</option>`).join("")}\n                </select>\n                <div id="combatCommandWarning" class="command-warning" style="display: none;">\n                    <i class="fas fa-exclamation-triangle"></i>\n                    <span id="combatWarningText"></span>\n                </div>\n            </div>\n        `}createTrayUI(){return`\n            <div class="tray-builder">\n                <div class="form-group">\n                    <label for="trayCommandType">Command Type:</label>\n                    <select id="trayCommandType">\n                        <option value="custom_tray">Single Tray Slot</option>\n                        <option value="tray_with_backup">Single Tray with Backup</option>\n                        <option value="tray_range">Tray Range</option>\n                        <option value="tray_range_with_backup">Tray Range with Backup</option>\n                        <option value="whole_tray">Whole Tray</option>\n                        <option value="whole_tray_with_backup">Whole Tray with Backup</option>\n                    </select>\n                </div>\n                \n                \x3c!-- Single Tray Configuration --\x3e\n                <div id="singleTrayConfig" class="tray-config-section">\n                    <div class="form-row">\n                        <div class="form-group">\n                            <label for="trayNumber">Tray Number:</label>\n                            <select id="trayNumber">\n                                ${Array.from({length:10},(e,t)=>`<option value="${t}">Tray ${t+1}</option>`).join("")}\n                            </select>\n                        </div>\n                        <div class="form-group">\n                            <label for="slotNumber">Slot Number:</label>\n                            <select id="slotNumber">\n                                ${Array.from({length:10},(e,t)=>`<option value="${t}">Slot ${t+1}</option>`).join("")}\n                            </select>\n                        </div>\n                    </div>\n                </div>\n                \n                \x3c!-- Backup Configuration --\x3e\n                <div id="backupConfig" class="tray-config-section" style="display: none;">\n                    <h4>Backup Configuration</h4>\n                    <div class="form-row">\n                        <div class="form-group">\n                            <label for="backupTrayNumber">Backup Tray:</label>\n                            <select id="backupTrayNumber">\n                                ${Array.from({length:10},(e,t)=>`<option value="${t}">Tray ${t+1}</option>`).join("")}\n                            </select>\n                        </div>\n                        <div class="form-group">\n                            <label for="backupSlotNumber">Backup Slot:</label>\n                            <select id="backupSlotNumber">\n                                ${Array.from({length:10},(e,t)=>`<option value="${t}">Slot ${t+1}</option>`).join("")}\n                            </select>\n                        </div>\n                    </div>\n                    <div class="form-group">\n                        <label for="activeState">Active State:</label>\n                        <select id="activeState">\n                            <option value="1">Active (1)</option>\n                            <option value="0">Inactive (0)</option>\n                        </select>\n                    </div>\n                </div>\n                \n                \x3c!-- Range Configuration --\x3e\n                <div id="rangeConfig" class="tray-config-section" style="display: none;">\n                    <h4>Range Configuration</h4>\n                    <div class="form-row">\n                        <div class="form-group">\n                            <label for="startTrayNumber">Start Tray:</label>\n                            <select id="startTrayNumber">\n                                ${Array.from({length:10},(e,t)=>`<option value="${t}">Tray ${t+1}</option>`).join("")}\n                            </select>\n                        </div>\n                        <div class="form-group">\n                            <label for="startSlotNumber">Start Slot:</label>\n                            <select id="startSlotNumber">\n                                ${Array.from({length:10},(e,t)=>`<option value="${t}">Slot ${t+1}</option>`).join("")}\n                            </select>\n                        </div>\n                    </div>\n                    <div class="form-row">\n                        <div class="form-group">\n                            <label for="endTrayNumber">End Tray:</label>\n                            <select id="endTrayNumber">\n                                ${Array.from({length:10},(e,t)=>`<option value="${t}">Tray ${t+1}</option>`).join("")}\n                            </select>\n                        </div>\n                        <div class="form-group">\n                            <label for="endSlotNumber">End Slot:</label>\n                            <select id="endSlotNumber">\n                                ${Array.from({length:10},(e,t)=>`<option value="${t}">Slot ${t+1}</option>`).join("")}\n                            </select>\n                        </div>\n                    </div>\n                </div>\n                \n                \x3c!-- Backup Range Configuration --\x3e\n                <div id="backupRangeConfig" class="tray-config-section" style="display: none;">\n                    <h4>Backup Range Configuration</h4>\n                    <div class="form-row">\n                        <div class="form-group">\n                            <label for="backupStartTrayNumber">Backup Start Tray:</label>\n                            <select id="backupStartTrayNumber">\n                                ${Array.from({length:10},(e,t)=>`<option value="${t}">Tray ${t+1}</option>`).join("")}\n                            </select>\n                        </div>\n                        <div class="form-group">\n                            <label for="backupStartSlotNumber">Backup Start Slot:</label>\n                            <select id="backupStartSlotNumber">\n                                ${Array.from({length:10},(e,t)=>`<option value="${t}">Slot ${t+1}</option>`).join("")}\n                            </select>\n                        </div>\n                    </div>\n                    <div class="form-row">\n                        <div class="form-group">\n                            <label for="backupEndTrayNumber">Backup End Tray:</label>\n                            <select id="backupEndTrayNumber">\n                                ${Array.from({length:10},(e,t)=>`<option value="${t}">Tray ${t+1}</option>`).join("")}\n                            </select>\n                        </div>\n                        <div class="form-group">\n                            <label for="backupEndSlotNumber">Backup End Slot:</label>\n                            <select id="backupEndSlotNumber">\n                                ${Array.from({length:10},(e,t)=>`<option value="${t}">Slot ${t+1}</option>`).join("")}\n                            </select>\n                        </div>\n                    </div>\n                </div>\n                \n                \x3c!-- Command Type Selection --\x3e\n                <div id="commandTypeConfig" class="tray-config-section" style="display: none;">\n                    <div class="form-group">\n                        <label for="trayCommandVariant">Command Variant:</label>\n                        <select id="trayCommandVariant">\n                            <option value="STOTrayExecByTray">STOTrayExecByTray (shows key binding on UI)</option>\n                            <option value="TrayExecByTray">TrayExecByTray (no UI indication)</option>\n                        </select>\n                    </div>\n                </div>\n                \n                <div class="tray-visual" id="trayVisual">\n                    \x3c!-- Visual tray representation will be generated here --\x3e\n                </div>\n            </div>\n        `}createPowerUI(){const e=STO_DATA.commands.power.commands;return`\n            <div class="command-selector">\n                <label for="powerCommand">Shield Command:</label>\n                <select id="powerCommand">\n                    <option value="">Select shield command...</option>\n                    ${Object.entries(e).map(([e,t])=>`<option value="${e}">${t.name}</option>`).join("")}\n                </select>\n                <div id="powerCommandWarning" class="command-warning" style="display: none;">\n                    <i class="fas fa-exclamation-triangle"></i>\n                    <span id="powerWarningText"></span>\n                </div>\n            </div>\n        `}createMovementUI(){const e=STO_DATA.commands.movement.commands;return`\n            <div class="command-selector">\n                <label for="movementCommand">Movement Command:</label>\n                <select id="movementCommand">\n                    <option value="">Select movement command...</option>\n                    ${Object.entries(e).map(([e,t])=>`<option value="${e}">${t.name}</option>`).join("")}\n                </select>\n                <div id="movementParams" style="display: none;">\n                    <div class="form-group">\n                        <label for="movementAmount">Amount (-1 to 1):</label>\n                        <input type="number" id="movementAmount" min="-1" max="1" step="0.05" value="0.25">\n                    </div>\n                    <div class="form-group">\n                        <label for="movementPosition">Position (-1 to 1):</label>\n                        <input type="number" id="movementPosition" min="-1" max="1" step="0.1" value="1">\n                    </div>\n                </div>\n            </div>\n        `}createCommunicationUI(){const e=STO_DATA.commands.communication.commands;return`\n            <div class="communication-builder">\n                <div class="form-group">\n                    <label for="commCommand">Communication Type:</label>\n                    <select id="commCommand">\n                        <option value="">Select communication type...</option>\n                        ${Object.entries(e).map(([e,t])=>`<option value="${e}">${t.name}</option>`).join("")}\n                    </select>\n                </div>\n                <div class="form-group">\n                    <label for="commMessage">Message:</label>\n                    <div class="input-with-button">\n                        <input type="text" id="commMessage" placeholder="Enter your message" maxlength="100">\n                        <button type="button" class="btn btn-small insert-target-btn" title="Insert $Target variable">\n                            <i class="fas fa-crosshairs"></i> $Target\n                        </button>\n                    </div>\n                    <small>Maximum 100 characters</small>\n                </div>\n                <div class="variable-help">\n                    <h4><i class="fas fa-info-circle"></i> STO Variables</h4>\n                    <div class="variable-info">\n                        <strong>$Target</strong> - Replaced with your current target's name<br>\n                        <em>Example:</em> <code>team Attacking [$Target]</code> → <code>team Attacking [Borg Cube]</code>\n                    </div>\n                </div>\n            </div>\n        `}createCameraUI(){const e=STO_DATA.commands.camera.commands;return`\n            <div class="command-selector">\n                <label for="cameraCommand">Camera Command:</label>\n                <select id="cameraCommand">\n                    <option value="">Select camera command...</option>\n                    ${Object.entries(e).map(([e,t])=>`<option value="${e}">${t.name}</option>`).join("")}\n                </select>\n                <div id="cameraParams" style="display: none;">\n                    <div class="form-group">\n                        <label for="cameraDistance">Distance:</label>\n                        <input type="number" id="cameraDistance" min="1" max="500" value="50">\n                    </div>\n                </div>\n            </div>\n        `}createSystemUI(){const e=STO_DATA.commands.system.commands;return`\n            <div class="command-selector">\n                <label for="systemCommand">System Command:</label>\n                <select id="systemCommand">\n                    <option value="">Select system command...</option>\n                    ${Object.entries(e).map(([e,t])=>`<option value="${e}">${t.name}</option>`).join("")}\n                </select>\n                <div id="systemParams" style="display: none;">\n                    <div class="form-group">\n                        <label for="systemFilename">Filename:</label>\n                        <input type="text" id="systemFilename" value="my_binds.txt">\n                    </div>\n                    <div class="form-group">\n                        <label for="systemState">State (0/1):</label>\n                        <input type="number" id="systemState" min="0" max="1" value="1">\n                    </div>\n                </div>\n            </div>\n        `}createAliasUI(){const e=app?.getCurrentProfile(),t=e?.aliases||{},a=Object.entries(t);return 0===a.length?'\n                <div class="alias-builder">\n                    <div class="empty-state">\n                        <i class="fas fa-mask"></i>\n                        <h4>No Aliases Available</h4>\n                        <p>Create aliases in the Alias Manager first.</p>\n                        <button type="button" class="btn btn-primary" id="openAliasManager">\n                            <i class="fas fa-plus"></i> Create Alias\n                        </button>\n                    </div>\n                </div>\n            ':`\n            <div class="alias-builder">\n                <div class="form-group">\n                    <label for="aliasSelect">Available Aliases:</label>\n                    <select id="aliasSelect">\n                        <option value="">Select an alias...</option>\n                        ${a.map(([e,t])=>`<option value="${e}">${e}${t.description?" - "+t.description:""}</option>`).join("")}\n                    </select>\n                </div>\n                <div id="aliasPreviewSection" style="display: none;">\n                    <div class="alias-info">\n                        <label>Alias Commands:</label>\n                        <div class="command-preview" id="selectedAliasPreview"></div>\n                    </div>\n                </div>\n            </div>\n        `}createCustomUI(){return'\n            <div class="custom-builder">\n                <div class="form-group">\n                    <label for="customCommand">Command:</label>\n                    <div class="input-with-button">\n                        <input type="text" id="customCommand" placeholder="Enter STO command" autocomplete="off">\n                        <button type="button" class="btn btn-small insert-target-btn" title="Insert $Target variable">\n                            <i class="fas fa-crosshairs"></i> $Target\n                        </button>\n                    </div>\n                    <small>Enter the exact STO command syntax</small>\n                </div>\n                <div class="form-group">\n                    <label for="customText">Display Text:</label>\n                    <input type="text" id="customText" placeholder="Descriptive name for this command" autocomplete="off">\n                </div>\n                <div class="command-help">\n                    <h4>Common Commands:</h4>\n                    <div class="command-examples">\n                        <button type="button" class="example-cmd" data-cmd="target_nearest_enemy">target_nearest_enemy</button>\n                        <button type="button" class="example-cmd" data-cmd="FireAll">FireAll</button>\n                        <button type="button" class="example-cmd" data-cmd="+power_exec Distribute_Shields">+power_exec Distribute_Shields</button>\n                        <button type="button" class="example-cmd" data-cmd="+STOTrayExecByTray 0 0">+STOTrayExecByTray 0 0</button>\n                        <button type="button" class="example-cmd" data-cmd=\'team Attacking [$Target]\'>team Attacking [$Target]</button>\n                    </div>\n                </div>\n                <div class="variable-help">\n                    <h4><i class="fas fa-info-circle"></i> STO Variables</h4>\n                    <div class="variable-info">\n                        <strong>$Target</strong> - Replaced with your current target\'s name<br>\n                        <em>Example:</em> <code>team Focus fire on [$Target]</code>\n                    </div>\n                </div>\n            </div>\n        '}setupEventListeners(){document.addEventListener("change",e=>{"commandType"===e.target.id&&this.handleCommandTypeChange(e.target.value)}),document.addEventListener("change",e=>{"trayNumber"!==e.target.id&&"slotNumber"!==e.target.id||(this.updateTrayVisual(),this.updateCommandPreview())}),document.addEventListener("input",e=>{"commMessage"===e.target.id&&this.updateCommandPreview()}),document.addEventListener("input",e=>{"customCommand"!==e.target.id&&"customText"!==e.target.id||this.updateCommandPreview()}),document.addEventListener("click",e=>{if(e.target.classList.contains("example-cmd")){const t=e.target.dataset.cmd,a=document.getElementById("customCommand");a&&(a.value=t,this.updateCommandPreview())}}),document.addEventListener("click",e=>{if(e.target.classList.contains("insert-target-btn")||e.target.closest(".insert-target-btn")){e.preventDefault();const t=(e.target.classList.contains("insert-target-btn")?e.target:e.target.closest(".insert-target-btn")).closest(".input-with-button"),a=t?t.querySelector("input"):null;a&&this.insertTargetVariable(a)}}),document.addEventListener("change",e=>{["targetingCommand","combatCommand","powerCommand","movementCommand","cameraCommand","systemCommand","commCommand","aliasSelect"].includes(e.target.id)&&this.updateCommandPreview()})}handleCommandTypeChange(e){const t=document.getElementById("commandBuilder"),a=document.getElementById("modalCommandPreview"),n=document.getElementById("saveCommandBtn");if(t)if(e&&this.commandBuilders.has(e)){const a=this.commandBuilders.get(e).getUI();t.innerHTML=a,this.setupTypeSpecificListeners(e),n&&(n.disabled=!1),this.updateCommandPreview()}else t.innerHTML='<p class="text-muted">Select a command type to configure options.</p>',a&&(a.textContent="Select a command type to see preview"),n&&(n.disabled=!0)}setupTypeSpecificListeners(e){if("tray"===e){this.updateTrayVisual();const e=document.getElementById("trayCommandType");e&&(e.addEventListener("change",()=>{this.updateTrayConfigSections(e.value),this.updateCommandPreview()}),this.updateTrayConfigSections(e.value)),["trayNumber","slotNumber","backupTrayNumber","backupSlotNumber","activeState","startTrayNumber","startSlotNumber","endTrayNumber","endSlotNumber","backupStartTrayNumber","backupStartSlotNumber","backupEndTrayNumber","backupEndSlotNumber","trayCommandVariant"].forEach(e=>{const t=document.getElementById(e);t&&t.addEventListener("change",()=>{this.updateTrayVisual(),this.updateCommandPreview()})})}else if("power"===e){const e=document.getElementById("powerCommand");e&&e.addEventListener("change",()=>{this.showPowerWarning(e.value)})}else if("combat"===e){const e=document.getElementById("combatCommand");e&&e.addEventListener("change",()=>{this.showCombatWarning(e.value)})}else if("alias"===e){const e=document.getElementById("aliasSelect");e&&e.addEventListener("change",()=>{this.updateAliasPreview(e.value),this.updateCommandPreview()});const t=document.getElementById("openAliasManager");t&&t.addEventListener("click",()=>{"undefined"!=typeof stoAliases&&stoAliases.showAliasManager?stoAliases.showAliasManager():(stoUI.hideModal("addCommandModal"),stoUI.showModal("aliasManagerModal"))})}}updateTrayConfigSections(e){const t={singleTrayConfig:document.getElementById("singleTrayConfig"),backupConfig:document.getElementById("backupConfig"),rangeConfig:document.getElementById("rangeConfig"),backupRangeConfig:document.getElementById("backupRangeConfig"),commandTypeConfig:document.getElementById("commandTypeConfig")};switch(Object.values(t).forEach(e=>{e&&(e.style.display="none")}),e){case"custom_tray":case"whole_tray":t.singleTrayConfig&&(t.singleTrayConfig.style.display="block"),t.commandTypeConfig&&(t.commandTypeConfig.style.display="block");break;case"tray_with_backup":case"whole_tray_with_backup":t.singleTrayConfig&&(t.singleTrayConfig.style.display="block"),t.backupConfig&&(t.backupConfig.style.display="block");break;case"tray_range":t.rangeConfig&&(t.rangeConfig.style.display="block"),t.commandTypeConfig&&(t.commandTypeConfig.style.display="block");break;case"tray_range_with_backup":t.rangeConfig&&(t.rangeConfig.style.display="block"),t.backupRangeConfig&&(t.backupRangeConfig.style.display="block"),t.backupConfig&&(t.backupConfig.style.display="block")}}showPowerWarning(e){const t=document.getElementById("powerCommandWarning"),a=document.getElementById("powerWarningText");if(t&&a){if(e&&STO_DATA.commands.power.commands[e]){const n=STO_DATA.commands.power.commands[e];if(n.warning)return a.textContent=n.warning,void(t.style.display="block")}t.style.display="none"}}showCombatWarning(e){const t=document.getElementById("combatCommandWarning"),a=document.getElementById("combatWarningText");if(t&&a){if(e&&STO_DATA.commands.combat.commands[e]){const n=STO_DATA.commands.combat.commands[e];if(n.warning)return a.textContent=n.warning,void(t.style.display="block")}t.style.display="none"}}updateAliasPreview(e){const t=document.getElementById("aliasPreviewSection"),a=document.getElementById("selectedAliasPreview");if(t&&a)if(e){const n=app?.getCurrentProfile(),o=n?.aliases?.[e];o?(a.textContent=o.commands,t.style.display="block"):t.style.display="none"}else t.style.display="none"}updateCommandPreview(){const e=document.getElementById("modalCommandPreview");if(!e)return void console.log("DEBUG: modalCommandPreview element not found");const t=this.buildCurrentCommand();if(console.log("DEBUG: buildCurrentCommand returned:",t),t){if(Array.isArray(t)){console.log("DEBUG: Command is array with length:",t.length);const a=t.map(e=>e.command);console.log("DEBUG: Command strings:",a),e.textContent=a.join(" $$ ")}else console.log("DEBUG: Command is single object:",t.command),e.textContent=t.command;e.className="command-preview valid"}else console.log("DEBUG: No command returned, showing default message"),e.textContent="Configure command options to see preview",e.className="command-preview"}buildCurrentCommand(){const e=document.getElementById("commandType");if(!e||!e.value)return null;const t=e.value,a=this.commandBuilders.get(t);if(!a)return null;let n=null,o={};switch(t){case"targeting":n=document.getElementById("targetingCommand")?.value;break;case"combat":n=document.getElementById("combatCommand")?.value;break;case"tray":switch(n=document.getElementById("trayCommandType")?.value||"custom_tray",n){case"custom_tray":o={tray:parseInt(document.getElementById("trayNumber")?.value||0),slot:parseInt(document.getElementById("slotNumber")?.value||0),command_type:document.getElementById("trayCommandVariant")?.value||"STOTrayExecByTray"};break;case"tray_with_backup":o={tray:parseInt(document.getElementById("trayNumber")?.value||0),slot:parseInt(document.getElementById("slotNumber")?.value||0),backup_tray:parseInt(document.getElementById("backupTrayNumber")?.value||0),backup_slot:parseInt(document.getElementById("backupSlotNumber")?.value||0),active:parseInt(document.getElementById("activeState")?.value||1)};break;case"tray_range":o={start_tray:parseInt(document.getElementById("startTrayNumber")?.value||0),start_slot:parseInt(document.getElementById("startSlotNumber")?.value||0),end_tray:parseInt(document.getElementById("endTrayNumber")?.value||0),end_slot:parseInt(document.getElementById("endSlotNumber")?.value||0),command_type:document.getElementById("trayCommandVariant")?.value||"STOTrayExecByTray"};break;case"tray_range_with_backup":o={active:parseInt(document.getElementById("activeState")?.value||1),start_tray:parseInt(document.getElementById("startTrayNumber")?.value||0),start_slot:parseInt(document.getElementById("startSlotNumber")?.value||0),end_tray:parseInt(document.getElementById("endTrayNumber")?.value||0),end_slot:parseInt(document.getElementById("endSlotNumber")?.value||0),backup_start_tray:parseInt(document.getElementById("backupStartTrayNumber")?.value||0),backup_start_slot:parseInt(document.getElementById("backupStartSlotNumber")?.value||0),backup_end_tray:parseInt(document.getElementById("backupEndTrayNumber")?.value||0),backup_end_slot:parseInt(document.getElementById("backupEndSlotNumber")?.value||0)};break;case"whole_tray":o={tray:parseInt(document.getElementById("trayNumber")?.value||0),command_type:document.getElementById("trayCommandVariant")?.value||"STOTrayExecByTray"};break;case"whole_tray_with_backup":o={active:parseInt(document.getElementById("activeState")?.value||1),tray:parseInt(document.getElementById("trayNumber")?.value||0),backup_tray:parseInt(document.getElementById("backupTrayNumber")?.value||0)}}break;case"power":n=document.getElementById("powerCommand")?.value;break;case"movement":n=document.getElementById("movementCommand")?.value,"throttle_adjust"===n?o.amount=parseFloat(document.getElementById("movementAmount")?.value||.25):"throttle_set"===n&&(o.position=parseFloat(document.getElementById("movementPosition")?.value||1));break;case"camera":n=document.getElementById("cameraCommand")?.value,"cam_distance"===n&&(o.distance=parseInt(document.getElementById("cameraDistance")?.value||50));break;case"communication":n=document.getElementById("commCommand")?.value,o={message:document.getElementById("commMessage")?.value||"Message text here"};break;case"system":n=document.getElementById("systemCommand")?.value,"bind_save_file"===n||"bind_load_file"===n?o.filename=document.getElementById("systemFilename")?.value||"my_binds.txt":"combat_log"===n&&(o.state=parseInt(document.getElementById("systemState")?.value||1));break;case"alias":n="alias",o={alias_name:document.getElementById("aliasSelect")?.value||""};break;case"custom":n="custom",o={command:document.getElementById("customCommand")?.value||"",text:document.getElementById("customText")?.value||"Custom Command"}}return n||"custom"===t?a.build(n,o):null}updateTrayVisual(){const e=document.getElementById("trayVisual"),t=document.getElementById("trayNumber")?.value||0,a=document.getElementById("slotNumber")?.value||0;e&&(e.innerHTML=`\n            <div class="tray-grid">\n                <div class="tray-label">Tray ${parseInt(t)+1}</div>\n                <div class="slot-grid">\n                    ${Array.from({length:10},(e,t)=>`\n                        <div class="slot ${t==a?"selected":""}" data-slot="${t}">\n                            ${t+1}\n                        </div>\n                    `).join("")}\n                </div>\n            </div>\n        `,e.querySelectorAll(".slot").forEach(e=>{e.addEventListener("click",()=>{const t=document.getElementById("slotNumber");t&&(t.value=e.dataset.slot,this.updateTrayVisual(),this.updateCommandPreview())})}))}generateTrayRangeCommands(e,t,a,n,o){const i=[],r="STOTrayExecByTray"===o?"+":"";if(e===a)for(let a=t;a<=n;a++)i.push(`${r}${o} ${e} ${a}`);else{for(let a=t;a<=9;a++)i.push(`${r}${o} ${e} ${a}`);for(let t=e+1;t<a;t++)for(let e=0;e<=9;e++)i.push(`${r}${o} ${t} ${e}`);if(a>e)for(let e=0;e<=n;e++)i.push(`${r}${o} ${a} ${e}`)}return i}generateTrayRangeWithBackupCommands(e,t,a,n,o,i,r,s,c){const l=[],d=this.generateTraySlotList(t,a,n,o),m=this.generateTraySlotList(i,r,s,c);for(let t=0;t<Math.max(d.length,m.length);t++){const a=d[t]||d[d.length-1],n=m[t]||m[m.length-1];l.push(`TrayExecByTrayWithBackup ${e} ${a.tray} ${a.slot} ${n.tray} ${n.slot}`)}return l}generateWholeTrayCommands(e,t){const a=[],n="STOTrayExecByTray"===t?"+":"";for(let o=0;o<=9;o++)a.push(`${n}${t} ${e} ${o}`);return a}generateWholeTrayWithBackupCommands(e,t,a){const n=[];for(let o=0;o<=9;o++)n.push(`TrayExecByTrayWithBackup ${e} ${t} ${o} ${a} ${o}`);return n}generateTraySlotList(e,t,a,n){const o=[];if(e===a)for(let a=t;a<=n;a++)o.push({tray:e,slot:a});else{for(let a=t;a<=9;a++)o.push({tray:e,slot:a});for(let t=e+1;t<a;t++)for(let e=0;e<=9;e++)o.push({tray:t,slot:e});if(a>e)for(let e=0;e<=n;e++)o.push({tray:a,slot:e})}return o}getCurrentCommand(){return this.buildCurrentCommand()}validateCommand(e){if(Array.isArray(e)){for(let t=0;t<e.length;t++){const a=this.validateCommand(e[t]);if(!a.valid)return{valid:!1,error:`Command ${t+1}: ${a.error}`}}return{valid:!0}}let t;if("string"==typeof e)t=e;else{if(!e||!e.command)return{valid:!1,error:"No command provided"};t=e.command}if(!t||0===t.trim().length)return{valid:!1,error:"Command cannot be empty"};const a=t.trim();return["quit","exit","shutdown"].some(e=>a.toLowerCase().includes(e))?{valid:!1,error:"Dangerous command not allowed"}:this.hasUnquotedPipeCharacter(a)?{valid:!1,error:"Invalid characters in command (|)"}:{valid:!0}}hasUnquotedPipeCharacter(e){let t=!1,a=null;for(let n=0;n<e.length;n++){const o=e[n];if(t||'"'!==o&&"'"!==o){if(t&&o===a){let o=0;for(let t=n-1;t>=0&&"\\"===e[t];t--)o++;o%2==0&&(t=!1,a=null)}else if(!t&&"|"===o)return!0}else t=!0,a=o}return!1}getTemplateCommands(e){if(!STO_DATA.templates)return[];const t=[];return Object.entries(STO_DATA.templates).forEach(([a,n])=>{Object.entries(n).forEach(([n,o])=>{o.commands.some(t=>this.detectCommandType(t)===e)&&t.push({id:`${a}_${n}`,name:o.name,description:o.description,scenario:a,commands:o.commands.map(e=>({command:e,type:this.detectCommandType(e),icon:this.getCommandIcon(e),text:this.getCommandText(e)}))})})}),t}detectCommandType(e){if(!e||"string"!=typeof e)return"custom";const t=e.toLowerCase().trim();return t.includes("+stotrayexecbytray")?"tray":t.startsWith("say ")||t.startsWith("team ")||t.startsWith("zone ")||t.startsWith("tell ")||t.includes('"')?"communication":t.includes("+power_exec")||t.includes("distribute_shields")||t.includes("reroute_shields")?"power":t.includes("+fullimpulse")||t.includes("+reverse")||t.includes("throttle")||t.includes("+turn")||t.includes("+up")||t.includes("+down")||t.includes("+left")||t.includes("+right")||t.includes("+forward")||t.includes("+backward")||t.includes("follow")?"movement":t.includes("cam")||t.includes("look")||t.includes("zoom")?"camera":t.includes("fire")||t.includes("attack")||"fireall"===t||"firephasers"===t||"firetorps"===t||"firephaserstorps"===t?"combat":t.includes("target")||"target_enemy_near"===t||"target_self"===t||"target_friend_near"===t||"target_clear"===t?"targeting":t.includes("+gentoggle")||"screenshot"===t||t.includes("hud")||"interactwindow"===t?"system":"custom"}getCommandIcon(e){return{targeting:"🎯",combat:"🔥",tray:"⚡",power:"🔋",communication:"💬",movement:"🚀",camera:"📹",system:"⚙️"}[this.detectCommandType(e)]||"⚙️"}getCommandText(e){if(e.includes("+STOTrayExecByTray")){const t=e.match(/\+STOTrayExecByTray\s+(\d+)\s+(\d+)/);if(t)return`Execute Tray ${parseInt(t[1])+1} Slot ${parseInt(t[2])+1}`}for(const[t,a]of Object.entries(STO_DATA.commands))for(const[t,n]of Object.entries(a.commands))if(n.command===e)return n.name;return e.replace(/[_+]/g," ").replace(/([A-Z])/g," $1").trim()}insertTargetVariable(e){const t=e.selectionStart,a=e.value,n=a.slice(0,t)+"$Target"+a.slice(t);e.value=n,e.setSelectionRange(t+7,t+7),e.focus(),e.dispatchEvent(new Event("input",{bubbles:!0}))}},b=new class{constructor(){this.modalId="fileExplorerModal",this.treeId="fileTree",this.contentId="fileContent"}init(){this.setupEventListeners()}setupEventListeners(){i.onDom("fileExplorerBtn","click","fileExplorer-open",()=>{this.openExplorer()}),i.onDom(this.treeId,"click","fileExplorer-tree-click",e=>{const t=e.target.closest(".tree-node");t&&this.selectNode(t)}),i.onDom("copyFileContentBtn","click","copyFileContent",()=>{const e=document.getElementById(this.contentId);if(!e)return;const t=e.textContent||"";t.trim()?(stoUI.copyToClipboard(t),stoUI.showToast("Content copied to clipboard","success")):stoUI.showToast("Nothing to copy","warning")})}openExplorer(){this.buildTree();const e=document.getElementById(this.contentId);e&&(e.textContent="Select an item on the left to preview export"),stoUI.showModal(this.modalId)}buildTree(){const e=document.getElementById(this.treeId);if(!e)return;e.innerHTML="";const t=stoStorage.getAllData().profiles||{};Object.entries(t).forEach(([t,a])=>{const n=this.createNode("profile",a.name,{profileId:t}),o=document.createElement("div");if(o.className="tree-children",a.builds&&a.builds.space){const e=this.createNode("build","Space Build",{profileId:t,environment:"space"});o.appendChild(e)}if(a.builds&&a.builds.ground){const e=this.createNode("build","Ground Build",{profileId:t,environment:"ground"});o.appendChild(e)}const i=this.createNode("aliases","Aliases",{profileId:t});o.appendChild(i),n.appendChild(o),e.appendChild(n)})}createNode(e,t,a={}){const n=document.createElement("div");return n.className=`tree-node ${e}`,n.textContent=t,n.dataset.type=e,Object.entries(a).forEach(([e,t])=>{n.setAttribute(`data-${e}`,t)}),n}selectNode(e){const t=document.querySelector(".tree-node.selected");t&&t.classList.remove("selected"),e.classList.add("selected");const a=e.dataset.type||e.getAttribute("data-type"),n=e.getAttribute("data-profileid"),o=e.getAttribute("data-environment");if(n)try{let e="";e="build"===a?this.generateBuildExport(n,o):"aliases"===a?this.generateAliasExport(n):"Select a Space/Ground build or Aliases to preview export.";const t=document.getElementById(this.contentId);t&&(t.textContent=e||"No content available.")}catch(e){console.error("Failed to generate export content:",e),stoUI.showToast("Failed to generate export","error")}}generateBuildExport(e,t){const a=stoStorage.getProfile(e);if(!a||!a.builds||!a.builds[t])return"";const n=a.builds[t],o={name:`${a.name} ${t}`,mode:t,keys:n.keys||{},keybindMetadata:a.keybindMetadata||{},aliases:n.aliases||{}};return stoExport.generateSTOKeybindFile(o,{environment:t})}generateAliasExport(e){const t=stoStorage.getProfile(e);if(!t)return"";const a={...t.aliases||{},...t.builds?.space?.aliases||{},...t.builds?.ground?.aliases||{}},n={name:t.name,mode:t.currentEnvironment||"space",aliases:a};return stoExport.generateAliasFile(n)}},v=new class{constructor(){this.selectedEffects={space:new Set,ground:new Set},this.showPlayerSay=!1}generateAlias(e){if(!this.selectedEffects[e])throw new InvalidEnvironmentError(e);const t=Array.from(this.selectedEffects[e]);if(0===t.length)return"";let a=`alias dynFxSetFXExlusionList_${e.charAt(0).toUpperCase()+e.slice(1)} <& dynFxSetFXExlusionList ${t.join(",")}`;return this.showPlayerSay&&(a+=" $$ PlayerSay VFX Supression Loaded"),a+=" &>",a}getSelectedEffects(e){if(!this.selectedEffects[e])throw new InvalidEnvironmentError(e);return Array.from(this.selectedEffects[e])}toggleEffect(e,t){if(!this.selectedEffects[e])throw new InvalidEnvironmentError(e);if(!t)throw new InvalidEffectError(t,e);this.selectedEffects[e].has(t)?this.selectedEffects[e].delete(t):this.selectedEffects[e].add(t)}clearAllEffects(){this.selectedEffects.space.clear(),this.selectedEffects.ground.clear()}selectAllEffects(e){if(!d[e])throw new InvalidEnvironmentError(e);if(!this.selectedEffects[e])throw new InvalidEnvironmentError(e);d[e].forEach(t=>{this.selectedEffects[e].add(t.effect)})}getEffectCount(e){if(!this.selectedEffects[e])throw new InvalidEnvironmentError(e);return this.selectedEffects[e].size}isEffectSelected(e,t){if(!this.selectedEffects[e])throw new InvalidEnvironmentError(e);return this.selectedEffects[e].has(t)}saveState(e){e.vertigoSettings||(e.vertigoSettings={}),e.vertigoSettings={selectedEffects:{space:Array.from(this.selectedEffects.space),ground:Array.from(this.selectedEffects.ground)},showPlayerSay:this.showPlayerSay}}loadState(e){if(e&&e.vertigoSettings){const t=e.vertigoSettings;this.selectedEffects.space=new Set(t.selectedEffects?.space||[]),this.selectedEffects.ground=new Set(t.selectedEffects?.ground||[]),this.showPlayerSay=t.showPlayerSay||!1}else this.selectedEffects.space.clear(),this.selectedEffects.ground.clear(),this.showPlayerSay=!1}};Object.assign(window,{stoStorage:m,stoProfiles:p,stoKeybinds:u,stoAliases:y,stoExport:f,modalManager:h,stoUI:g,stoCommands:_,stoFileExplorer:b,vertigoManager:v,VFX_EFFECTS:d,VERTIGO_EFFECTS:d});const T=new class{constructor(){this.store=l,this.eventListeners=new Map,"loading"===document.readyState?document.addEventListener("DOMContentLoaded",()=>this.init()):this.init()}get currentProfile(){return this.store.currentProfile}set currentProfile(e){this.store.currentProfile=e}get currentMode(){return this.store.currentMode}set currentMode(e){this.store.currentMode=e}get currentEnvironment(){return this.store.currentEnvironment}set currentEnvironment(e){this.store.currentEnvironment=e}get selectedKey(){return this.store.selectedKey}set selectedKey(e){this.store.selectedKey=e}get isModified(){return this.store.isModified}set isModified(e){this.store.isModified=e}get undoStack(){return this.store.undoStack}set undoStack(e){this.store.undoStack=e}get redoStack(){return this.store.redoStack}set redoStack(e){this.store.redoStack=e}get maxUndoSteps(){return this.store.maxUndoSteps}set maxUndoSteps(e){this.store.maxUndoSteps=e}get commandIdCounter(){return this.store.commandIdCounter}set commandIdCounter(e){this.store.commandIdCounter=e}async init(){try{if("undefined"==typeof stoStorage||"undefined"==typeof stoUI)throw new Error("Required dependencies not loaded");await this.loadData(),this.applyTheme(),this.setupEventListeners(),this.setupCommandLibrary(),this.setupDragAndDrop(),this.renderProfiles(),this.renderKeyGrid(),this.renderCommandChain();const e=stoStorage.getSettings();this.updateThemeToggleButton(e.theme||"default"),this.isFirstTime()&&this.showWelcomeMessage(),stoUI.showToast("STO Tools Keybind Manager loaded successfully","success"),i.emit("sto-app-ready",{app:this})}catch(e){console.error("Failed to initialize application:",e),"undefined"!=typeof stoUI&&stoUI.showToast&&stoUI.showToast("Failed to load application","error"),i.emit("sto-app-error",{error:e})}}async loadData(){const e=stoStorage.getAllData();this.currentProfile=e.currentProfile;const t=e.profiles[this.currentProfile];this.currentEnvironment=t&&t.currentEnvironment||"space",e.profiles[this.currentProfile]||(this.currentProfile=Object.keys(e.profiles)[0],this.saveCurrentProfile())}saveData(){const e=stoStorage.getAllData();return e.currentProfile=this.currentProfile,e.lastModified=(new Date).toISOString(),!!stoStorage.saveAllData(e)&&(this.setModified(!1),!0)}saveCurrentProfile(){const e=stoStorage.getAllData();return e.currentProfile=this.currentProfile,stoStorage.saveAllData(e)}setModified(e=!0){this.isModified=e;const t=document.getElementById("modifiedIndicator");t&&(t.style.display=e?"inline":"none")}getCurrentProfile(){const e=stoStorage.getProfile(this.currentProfile);return e?this.getCurrentBuild(e):null}getCurrentBuild(e){return e?(e.builds||(e.builds={space:{keys:e.keys||{}},ground:{keys:{}}},e.currentEnvironment=e.mode||"space",delete e.mode,delete e.keys,stoStorage.saveProfile(this.currentProfile,e)),e.builds||(e.builds={space:{keys:{}},ground:{keys:{}}}),e.builds[this.currentEnvironment]||(e.builds[this.currentEnvironment]={keys:{}}),e.builds[this.currentEnvironment].keys||(e.builds[this.currentEnvironment].keys={}),{...e,keys:e.builds[this.currentEnvironment].keys,aliases:e.aliases||{},mode:this.currentEnvironment}):null}switchProfile(e){if(e!==this.currentProfile){this.currentProfile=e,this.selectedKey=null;const t=stoStorage.getProfile(e);t&&(this.currentEnvironment=t.currentEnvironment||"space"),this.saveCurrentProfile(),this.renderKeyGrid(),this.renderCommandChain(),this.updateProfileInfo();const a=this.getCurrentProfile();stoUI.showToast(`Switched to profile: ${a.name} (${this.currentEnvironment})`,"success")}}createProfile(e,t="",a="space"){const n=this.generateProfileId(e),o={name:e,description:t,mode:a,keys:{},aliases:{},created:(new Date).toISOString(),lastModified:(new Date).toISOString()};return stoStorage.saveProfile(n,o)?(this.switchProfile(n),this.renderProfiles(),stoUI.showToast(`Profile "${e}" created`,"success"),n):(stoUI.showToast("Failed to create profile","error"),null)}cloneProfile(e,t){const a=stoStorage.getProfile(e);if(!a)return null;const n=this.generateProfileId(t),o={...JSON.parse(JSON.stringify(a)),name:t,description:`Copy of ${a.name}`,created:(new Date).toISOString(),lastModified:(new Date).toISOString()};return stoStorage.saveProfile(n,o)?(this.renderProfiles(),stoUI.showToast(`Profile "${t}" created from "${a.name}"`,"success"),n):(stoUI.showToast("Failed to clone profile","error"),null)}deleteProfile(e){const t=stoStorage.getProfile(e);if(!t)return!1;const a=stoStorage.getAllData();if(Object.keys(a.profiles).length<=1)return stoUI.showToast("Cannot delete the last profile","warning"),!1;if(stoStorage.deleteProfile(e)){if(this.currentProfile===e){const e=Object.keys(stoStorage.getAllData().profiles);this.switchProfile(e[0])}return this.renderProfiles(),stoUI.showToast(`Profile "${t.name}" deleted`,"success"),!0}return stoUI.showToast("Failed to delete profile","error"),!1}generateProfileId(e){const t=e.toLowerCase().replace(/[^a-z0-9]/g,"_");let a=t,n=1;const o=stoStorage.getAllData();for(;o.profiles[a];)a=`${t}_${n}`,n++;return a}selectKey(e){this.selectedKey=e;const t=this.getCurrentProfile(),a=document.getElementById("stabilizeExecutionOrder");if(a&&t&&t.keybindMetadata){let n=!1;if(t.keybindMetadata[this.currentEnvironment]){const a=t.keybindMetadata[this.currentEnvironment];n=!(!a[e]||!a[e].stabilizeExecutionOrder)}!n&&t.keybindMetadata[e]&&(n=!!t.keybindMetadata[e].stabilizeExecutionOrder),a.checked=n}else a&&(a.checked=!1);this.renderKeyGrid(),this.renderCommandChain(),this.updateChainActions()}addKey(e){if(!this.isValidKeyName(e))return stoUI.showToast("Invalid key name","error"),!1;const t=this.getCurrentProfile();return t.keys[e]?(stoUI.showToast(`Key "${e}" already exists`,"warning"),!1):(t.keys[e]=[],stoStorage.saveProfile(this.currentProfile,t),this.renderKeyGrid(),this.selectKey(e),this.setModified(!0),stoUI.showToast(`Key "${e}" added`,"success"),!0)}deleteKey(e){const t=this.getCurrentProfile();return!!t.keys[e]&&(delete t.keys[e],stoStorage.saveProfile(this.currentProfile,t),this.selectedKey===e&&(this.selectedKey=null),this.renderKeyGrid(),this.renderCommandChain(),this.setModified(!0),stoUI.showToast(`Key "${e}" deleted`,"success"),!0)}isValidKeyName(e){return STO_DATA.validation.keyNamePattern.test(e)&&e.length<=20}addCommand(e,t){const a=this.getCurrentProfile();a.keys[e]||(a.keys[e]=[]),Array.isArray(t)?(t.forEach(t=>{t.id||(t.id=this.generateCommandId()),a.keys[e].push(t)}),stoUI.showToast(`${t.length} commands added`,"success")):(t.id||(t.id=this.generateCommandId()),a.keys[e].push(t),stoUI.showToast("Command added","success")),stoStorage.saveProfile(this.currentProfile,a),this.renderCommandChain(),this.renderKeyGrid(),this.setModified(!0)}deleteCommand(e,t){const a=this.getCurrentProfile();a.keys[e]&&a.keys[e][t]&&(a.keys[e].splice(t,1),stoStorage.saveProfile(this.currentProfile,a),this.renderCommandChain(),this.renderKeyGrid(),this.setModified(!0),stoUI.showToast("Command deleted","success"))}moveCommand(e,t,a){const n=this.getCurrentProfile(),o=n.keys[e];if(o&&t>=0&&t<o.length&&a>=0&&a<o.length){const[e]=o.splice(t,1);o.splice(a,0,e),stoStorage.saveProfile(this.currentProfile,n),this.renderCommandChain(),this.setModified(!0)}}generateCommandId(){return"cmd_"+Date.now()+"_"+Math.random().toString(36).substr(2,9)}renderProfiles(){const e=document.getElementById("profileSelect");if(!e)return;const t=stoStorage.getAllData();if(e.innerHTML="",0===Object.keys(t.profiles).length){const t=document.createElement("option");t.value="",t.textContent="No profiles available",t.disabled=!0,e.appendChild(t)}else Object.entries(t.profiles).forEach(([t,a])=>{const n=document.createElement("option");n.value=t,n.textContent=a.name,t===this.currentProfile&&(n.selected=!0),e.appendChild(n)});this.updateProfileInfo()}updateProfileInfo(){const e=this.getCurrentProfile();document.querySelectorAll(".mode-btn").forEach(t=>{t.classList.toggle("active",e&&t.dataset.mode===this.currentEnvironment),t.disabled=!e});const t=document.getElementById("keyCount");if(t)if(e){const a=Object.keys(e.keys).length;t.textContent=`${a} key${1!==a?"s":""}`}else t.textContent="No profile"}renderKeyGrid(){const e=document.getElementById("keyGrid");if(!e)return;const t=this.getCurrentProfile();if(!t)return;if(e.innerHTML="",!t)return void(e.innerHTML='\n                <div class="empty-state">\n                    <i class="fas fa-folder-open"></i>\n                    <h4>No Profile Selected</h4>\n                    <p>Create a new profile or load default data to get started.</p>\n                </div>\n            ');const a=Object.keys(t.keys),n=[...new Set([...a,"Space","1","2","3","4","5","F1","F2","F3","F4"])].sort(),o=localStorage.getItem("keyViewMode")||"key-types";"categorized"===o?this.renderCategorizedKeyView(e,t,n):"key-types"===o?this.renderKeyTypeView(e,t,n):this.renderSimpleKeyGrid(e,n),this.updateViewToggleButton(o);const i=document.getElementById("keyFilter");i&&i.value.trim()&&this.filterKeys(i.value.trim())}renderSimpleKeyGrid(e,t){e.classList.remove("categorized"),t.forEach(t=>{const a=this.createKeyElement(t);e.appendChild(a)})}renderCategorizedKeyView(e,t,a){e.classList.add("categorized");const n=this.categorizeKeys(t.keys,a);Object.entries(n).sort(([e,t],[a,n])=>t.priority!==n.priority?t.priority-n.priority:t.name.localeCompare(n.name)).forEach(([t,a])=>{const n=this.createKeyCategoryElement(t,a);e.appendChild(n)})}categorizeKeys(e,t){const a={};return a.unknown={name:"Unknown",icon:"fas fa-question-circle",keys:new Set,priority:0},Object.entries(STO_DATA.commands).forEach(([e,t])=>{a[e]={name:t.name,icon:t.icon,keys:new Set,priority:1}}),t.forEach(t=>{const n=e[t]||[];if(!n||0===n.length)return void a.unknown.keys.add(t);const o=new Set;n.forEach(e=>{if(e.type&&a[e.type])o.add(e.type);else if(window.stoCommands){const t=window.stoCommands.detectCommandType(e.command);a[t]&&o.add(t)}}),o.size>0?o.forEach(e=>{a[e].keys.add(t)}):(a.custom||(a.custom={name:"Custom Commands",icon:"fas fa-cog",keys:new Set,priority:2}),a.custom.keys.add(t))}),Object.values(a).forEach(e=>{e.keys=Array.from(e.keys).sort(this.compareKeys.bind(this))}),a}createKeyCategoryElement(e,t,a="command"){const n=document.createElement("div");n.className="category",n.dataset.category=e;const o="key-type"===a?`keyTypeCategory_${e}_collapsed`:`keyCategory_${e}_collapsed`,i="true"===localStorage.getItem(o);return n.innerHTML=`\n            <h4 class="${i?"collapsed":""}" data-category="${e}" data-mode="${a}">\n                <i class="fas fa-chevron-right category-chevron"></i>\n                <i class="${t.icon}"></i> \n                ${t.name} \n                <span class="key-count">(${t.keys.length})</span>\n            </h4>\n            <div class="category-commands ${i?"collapsed":""}">\n                ${t.keys.map(e=>this.createKeyElementHTML(e)).join("")}\n            </div>\n        `,n.querySelector("h4").addEventListener("click",()=>{this.toggleKeyCategory(e,n,a)}),n.querySelectorAll(".command-item").forEach(e=>{e.addEventListener("click",()=>{const t=e.dataset.key;this.selectKey(t)})}),n}createKeyElementHTML(e){const t=this.getCurrentProfile().keys[e]||[],a=this.selectedKey===e,n=e.length;let o;return o=n<=6?"short":n<=12?"medium":"long",`\n            <div class="command-item ${a?"active":""}" data-key="${e}" data-length="${o}">\n                <span class="key-label">${e}</span>\n                ${t.length>0?`\n                    <span class="command-count-badge">${t.length}</span>\n                `:""}\n            </div>\n        `}toggleKeyCategory(e,t,a="command"){const n=t.querySelector("h4"),o=t.querySelector(".category-commands"),i=n.querySelector(".category-chevron"),r="key-type"===a?`keyTypeCategory_${e}_collapsed`:`keyCategory_${e}_collapsed`;o.classList.contains("collapsed")?(o.classList.remove("collapsed"),n.classList.remove("collapsed"),i.style.transform="rotate(90deg)",localStorage.setItem(r,"false")):(o.classList.add("collapsed"),n.classList.add("collapsed"),i.style.transform="rotate(0deg)",localStorage.setItem(r,"true"))}formatKeyName(e){return e.includes("+")?e.replace(/\+/g,"<br>+<br>"):e}detectKeyTypes(e){const t=[];e.includes("+")&&e.split("+").some(e=>e.match(/^(Ctrl|Control|Alt|Shift|Win|Cmd|Super)$/i))&&t.push("modifiers");const a=e.split("+").pop();return a.match(/^F\d+$/)?t.push("function"):a.match(/^(Lbutton|Rbutton|Mbutton|Leftdrag|Rightdrag|Middledrag|Leftclick|Rightclick|Middleclick|Leftdoubleclick|Rightdoubleclick|Middledoubleclick|Wheelplus|Wheelminus|Mousechord|Mouse|Wheel|LMouse|RMouse|MMouse|XMouse|Drag)/i)?t.push("mouse"):a.match(/^(Numpad|Keypad)/i)?t.push("numberpad"):a.match(/^(Ctrl|Control|Alt|Shift|Win|Cmd|Super)$/i)?t.includes("modifiers")||t.push("modifiers"):a.match(/^(Up|Down|Left|Right|Home|End|PageUp|PageDown|Insert|Delete)$/i)?t.push("navigation"):a.match(/^(Space|Tab|Enter|Return|Escape|Esc|Backspace|CapsLock|ScrollLock|NumLock|PrintScreen|Pause|Break)$/i)?t.push("system"):a.match(/^[0-9]$/)||a.match(/^[A-Za-z]$/)?t.push("alphanumeric"):a.match(/^[`~!@#$%^&*()_+\-=\[\]{}\\|;':",./<>?]$/)||a.match(/^(Comma|Period|Semicolon|Quote|Slash|Backslash|Minus|Plus|Equals|Bracket|Grave|Tilde)$/i)?t.push("symbols"):t.push("other"),t.length>0?t:["other"]}categorizeKeysByType(e,t){const a={function:{name:"Function Keys",icon:"fas fa-keyboard",keys:new Set,priority:1},alphanumeric:{name:"Letters & Numbers",icon:"fas fa-font",keys:new Set,priority:2},numberpad:{name:"Numberpad",icon:"fas fa-calculator",keys:new Set,priority:3},modifiers:{name:"Modifier Keys",icon:"fas fa-hand-paper",keys:new Set,priority:4},navigation:{name:"Navigation",icon:"fas fa-arrows-alt",keys:new Set,priority:5},system:{name:"System Keys",icon:"fas fa-cogs",keys:new Set,priority:6},mouse:{name:"Mouse & Wheel",icon:"fas fa-mouse",keys:new Set,priority:7},symbols:{name:"Symbols & Punctuation",icon:"fas fa-at",keys:new Set,priority:8},other:{name:"Other Keys",icon:"fas fa-question-circle",keys:new Set,priority:9}};return t.forEach(e=>{this.detectKeyTypes(e).forEach(t=>{a[t]?a[t].keys.add(e):a.other.keys.add(e)})}),Object.values(a).forEach(e=>{e.keys=Array.from(e.keys).sort(this.compareKeys.bind(this))}),a}renderKeyTypeView(e,t,a){e.classList.add("categorized");const n=this.categorizeKeysByType(t.keys,a);Object.entries(n).sort(([e,t],[a,n])=>t.priority-n.priority).forEach(([t,a])=>{const n=this.createKeyCategoryElement(t,a,"key-type");e.appendChild(n)})}compareKeys(e,t){const a=e=>"Space"===e?0:e.match(/^[0-9]$/)?1:e.match(/^F[0-9]+$/)?2:e.includes("Ctrl+")?3:e.includes("Alt+")?4:e.includes("Shift+")?5:6,n=a(e),o=a(t);return n!==o?n-o:e.localeCompare(t)}createKeyElement(e){const t=this.getCurrentProfile().keys[e]||[],a=e===this.selectedKey,n=document.createElement("div");n.className="key-item "+(a?"active":""),n.dataset.key=e,n.title=`${e}: ${t.length} command${1!==t.length?"s":""}`;const o=this.formatKeyName(e);let i;if(o.includes("<br>")){const t=e.split("+"),a=Math.max(...t.map(e=>e.length));i=a<=4?"short":a<=8?"medium":"long"}else{const t=e.length;i=t<=3?"short":t<=5?"medium":t<=8?"long":"extra-long"}return n.dataset.length=i,n.innerHTML=`\n            <div class="key-label">${o}</div>\n            ${t.length>0?`\n                <div class="activity-bar" style="width: ${Math.min(15*t.length,100)}%"></div>\n                <div class="command-count-badge">${t.length}</div>\n            `:""}\n        `,n.addEventListener("click",()=>{this.selectKey(e)}),n}updateViewToggleButton(e){const t=document.getElementById("toggleKeyViewBtn");if(t){const a=t.querySelector("i");"categorized"===e?(a.className="fas fa-sitemap",t.title="Switch to key type view"):"key-types"===e?(a.className="fas fa-th",t.title="Switch to grid view"):(a.className="fas fa-list",t.title="Switch to command categories")}}toggleKeyView(){const e=localStorage.getItem("keyViewMode")||"key-types";let t;t="key-types"===e?"grid":"grid"===e?"categorized":"key-types",localStorage.setItem("keyViewMode",t),this.renderKeyGrid()}renderCommandChain(){const e=document.getElementById("commandList"),t=document.getElementById("chainTitle"),a=document.getElementById("commandPreview"),n=document.getElementById("commandCount"),o=document.getElementById("emptyState");if(!e||!t||!a)return;if(!this.selectedKey)return t.textContent="Select a key to edit",a.textContent="Select a key to see the generated command",n&&(n.textContent="0 commands"),o&&(o.style.display="block"),void(e.innerHTML='<div class="empty-state" id="emptyState"><i class="fas fa-keyboard"></i><h4>No Key Selected</h4><p>Select a key from the left panel to view and edit its command chain.</p></div>');const i=this.getCurrentProfile().keys[this.selectedKey]||[];if(t.textContent=`Command Chain for ${this.selectedKey}`,n&&(n.textContent=`${i.length} command${1!==i.length?"s":""}`),0===i.length)e.innerHTML=`\n                <div class="empty-state">\n                    <i class="fas fa-plus-circle"></i>\n                    <h4>No Commands</h4>\n                    <p>Click "Add Command" to start building your command chain for ${this.selectedKey}.</p>\n                </div>\n            `,a.textContent=`${this.selectedKey} ""`;else{e.innerHTML="",i.forEach((t,a)=>{const n=this.createCommandElement(t,a);e.appendChild(n)});const t=document.getElementById("stabilizeExecutionOrder");let n;n=t&&t.checked&&i.length>1?stoKeybinds.generateMirroredCommandString(i):i.map(e=>e.command).join(" $$ "),a.textContent=`${this.selectedKey} "${n}"`}}createCommandElement(e,t){const a=document.createElement("div");a.className="command-item-row",a.dataset.index=t,a.draggable=!0;const n=this.findCommandDefinition(e),o=n&&n.customizable;let i=e.text,r=e.icon;if(n)if(i=n.name,r=n.icon,o&&e.parameters){if("tray_with_backup"===n.commandId){const t=e.parameters;i=`${n.name} (${t.active} ${t.tray} ${t.slot} ${t.backup_tray} ${t.backup_slot})`}else if("custom_tray"===n.commandId){const t=e.parameters;i=`${n.name} (${t.tray} ${t.slot})`}else if("target"===n.commandId){const t=e.parameters;i=`${n.name}: ${t.entityName}`}}else if(o)if(e.command.includes("TrayExecByTrayWithBackup")){const t=e.command.split(" ");t.length>=6&&(i=`${n.name} (${t[1]} ${t[2]} ${t[3]} ${t[4]} ${t[5]})`)}else if(e.command.includes("TrayExec")){const t=e.command.replace("+","").split(" ");t.length>=3&&(i=`${n.name} (${t[1]} ${t[2]})`)}else if(e.command.includes("Target ")){const t=e.command.match(/Target "([^"]+)"/);t&&(i=`${n.name}: ${t[1]}`)}o&&(a.dataset.parameters="true",a.classList.add("customizable"));const s=this.getCommandWarning(e),c=s?`<span class="command-warning-icon" title="${s}"><i class="fas fa-exclamation-triangle"></i></span>`:"",l=o?' <span class="param-indicator" title="Editable parameters">⚙️</span>':"";return a.innerHTML=`\n            <div class="command-number">${t+1}</div>\n            <div class="command-content">\n                <span class="command-icon">${r}</span>\n                <span class="command-text">${i}${l}</span>\n                ${c}\n            </div>\n            <span class="command-type ${e.type}">${e.type}</span>\n            <div class="command-actions">\n                <button class="btn btn-small-icon" onclick="app.editCommand(${t})" title="Edit Command">\n                    <i class="fas fa-edit"></i>\n                </button>\n                <button class="btn btn-small-icon btn-danger" onclick="app.deleteCommand('${this.selectedKey}', ${t})" title="Delete Command">\n                    <i class="fas fa-times"></i>\n                </button>\n                <button class="btn btn-small-icon" onclick="app.moveCommand('${this.selectedKey}', ${t}, ${t-1})" \n                        title="Move Up" ${0===t?"disabled":""}>\n                    <i class="fas fa-chevron-up"></i>\n                </button>\n                <button class="btn btn-small-icon" onclick="app.moveCommand('${this.selectedKey}', ${t}, ${t+1})" \n                        title="Move Down" ${t===this.getCurrentProfile().keys[this.selectedKey].length-1?"disabled":""}>\n                    <i class="fas fa-chevron-down"></i>\n                </button>\n            </div>\n        `,a}getCommandWarning(e){const t=STO_DATA.commands;for(const[a,n]of Object.entries(t))for(const[t,a]of Object.entries(n.commands))if(a.command===e.command||a.name===e.text||e.command.includes(a.command))return a.warning||null;return null}setupCommandLibrary(){const e=document.getElementById("commandCategories");e&&(e.innerHTML="",Object.entries(STO_DATA.commands).forEach(([t,a])=>{const n=this.createCategoryElement(t,a);e.appendChild(n)}),this.filterCommandLibrary())}createCategoryElement(e,t){const a=document.createElement("div");a.className="category",a.dataset.category=e;const n=`commandCategory_${e}_collapsed`,o="true"===localStorage.getItem(n);return a.innerHTML=`\n            <h4 class="${o?"collapsed":""}" data-category="${e}">\n                <i class="fas fa-chevron-right category-chevron"></i>\n                <i class="${t.icon}"></i> \n                ${t.name}\n                <span class="command-count">(${Object.keys(t.commands).length})</span>\n            </h4>\n            <div class="category-commands ${o?"collapsed":""}">\n                ${Object.entries(t.commands).map(([e,t])=>`\n                    <div class="command-item ${t.customizable?"customizable":""}" data-command="${e}" title="${t.description}${t.customizable?" (Customizable)":""}">\n                        ${t.icon} ${t.name}${t.customizable?' <span class="param-indicator">⚙️</span>':""}\n                    </div>\n                `).join("")}\n            </div>\n        `,a.querySelector("h4").addEventListener("click",()=>{this.toggleCommandCategory(e,a)}),a.addEventListener("click",t=>{if(t.target.classList.contains("command-item")){const a=t.target.dataset.command;this.addCommandFromLibrary(e,a)}}),a}toggleCommandCategory(e,t){const a=t.querySelector("h4"),n=t.querySelector(".category-commands"),o=a.querySelector(".category-chevron"),i=`commandCategory_${e}_collapsed`;n.classList.contains("collapsed")?(n.classList.remove("collapsed"),a.classList.remove("collapsed"),o.style.transform="rotate(90deg)",localStorage.setItem(i,"false")):(n.classList.add("collapsed"),a.classList.add("collapsed"),o.style.transform="rotate(0deg)",localStorage.setItem(i,"true"))}addCommandFromLibrary(e,t){if(!this.selectedKey)return void stoUI.showToast("Please select a key first","warning");const a=STO_DATA.commands[e].commands[t];if(!a)return;if(a.customizable&&a.parameters)return void this.showParameterModal(e,t,a);const n={command:a.command,type:e,icon:a.icon,text:a.name,id:this.generateCommandId()};this.addCommand(this.selectedKey,n)}setupDragAndDrop(){const e=document.getElementById("commandList");e&&stoUI.initDragAndDrop(e,{dragSelector:".command-item-row",dropZoneSelector:".command-item-row",onDrop:(e,t,a)=>{if(!this.selectedKey)return;const n=parseInt(t.dragElement.dataset.index),o=parseInt(a.dataset.index);n!==o&&this.moveCommand(this.selectedKey,n,o)}})}updateChainActions(){const e=!!this.selectedKey;["addCommandBtn","addFromTemplateBtn","importFromKeyBtn","deleteKeyBtn","duplicateKeyBtn"].forEach(t=>{const a=document.getElementById(t);a&&(a.disabled=!e)})}setupEventListeners(){const e=document.getElementById("profileSelect");e?.addEventListener("change",e=>{this.switchProfile(e.target.value)}),document.querySelectorAll(".mode-btn").forEach(e=>{e.addEventListener("click",e=>{const t=e.target.dataset.mode;this.switchMode(t)})}),i.onDom("openProjectBtn","click","project-open",()=>{this.openProject()}),i.onDom("saveProjectBtn","click","project-save",()=>{this.saveProject()}),i.onDom("exportKeybindsBtn","click","keybinds-export",()=>{this.exportKeybinds()}),i.onDom("vertigoBtn","click","vertigo-open",()=>{this.showVertigoModal()}),i.onDom("addKeyBtn","click","key-add",()=>{this.showKeySelectionModal()}),i.onDom("deleteKeyBtn","click","key-delete",()=>{this.selectedKey&&this.confirmDeleteKey(this.selectedKey)}),i.onDom("duplicateKeyBtn","click","key-duplicate",()=>{this.selectedKey&&this.duplicateKey(this.selectedKey)}),i.onDom("addCommandBtn","click","command-add",()=>{modalManager.show("addCommandModal")}),i.onDom("addFromTemplateBtn","click","command-add-template",()=>{this.showTemplateModal()}),i.onDom("clearChainBtn","click","command-chain-clear",()=>{this.selectedKey&&this.confirmClearChain(this.selectedKey)}),i.onDom("validateChainBtn","click","command-chain-validate",()=>{this.validateCurrentChain()}),i.onDom("stabilizeExecutionOrder","change","stabilize-change",e=>{if(this.selectedKey){const t=this.currentEnvironment,a=stoStorage.getProfile(this.currentProfile);a&&(a.keybindMetadata||(a.keybindMetadata={}),a.keybindMetadata[t]||(a.keybindMetadata[t]={}),a.keybindMetadata[t][this.selectedKey]||(a.keybindMetadata[t][this.selectedKey]={}),a.keybindMetadata[t][this.selectedKey].stabilizeExecutionOrder=e.target.checked,stoStorage.saveProfile(this.currentProfile,a),this.setModified(!0))}this.renderCommandChain()}),i.onDom("keyFilter","input","key-filter",e=>{this.filterKeys(e.target.value)}),i.onDom("commandSearch","input","command-search",e=>{this.filterCommands(e.target.value)}),i.onDom("showAllKeysBtn","click","show-all-keys",()=>{this.showAllKeys()}),i.onDom("toggleKeyViewBtn","click","toggle-key-view",()=>{this.toggleKeyView()}),i.onDom("toggleLibraryBtn","click","toggle-library",()=>{this.toggleLibrary()}),this.setupModalHandlers(),setInterval(()=>{this.isModified&&this.saveData()},3e4)}setupModalHandlers(){i.onDom("confirmAddKeyBtn","click","key-add-confirm",()=>{const e=document.getElementById("newKeyName")?.value.trim();e&&(this.addKey(e),modalManager.hide("addKeyModal"))}),document.querySelectorAll(".key-suggestion").forEach(e=>{e.addEventListener("click",e=>{const t=e.target.dataset.key,a=document.getElementById("newKeyName");a&&(a.value=t)})}),i.onDom("saveCommandBtn","click","command-save",()=>{this.saveCommandFromModal()}),document.querySelectorAll(".modal-close, [data-modal]").forEach(e=>{e.addEventListener("click",e=>{const t=e.target.dataset.modal||e.target.closest("button").dataset.modal;t&&(modalManager.hide(t),"vertigoModal"===t&&(this.vertigoInitialState&&!this.vertigoSaving&&(vertigoManager.selectedEffects.space=new Set(this.vertigoInitialState.selectedEffects.space),vertigoManager.selectedEffects.ground=new Set(this.vertigoInitialState.selectedEffects.ground),vertigoManager.showPlayerSay=this.vertigoInitialState.showPlayerSay),delete this.vertigoInitialState,this.vertigoSaving=!1))})})}saveProfile(){const e=this.getCurrentProfile();if(!e)return;this.saveCurrentBuild();const t=stoStorage.getProfile(this.currentProfile);if(!t)return;const a={...t,name:e.name,description:e.description||t.description,aliases:e.aliases||{},keybindMetadata:e.keybindMetadata||t.keybindMetadata,created:t.created,lastModified:(new Date).toISOString(),currentEnvironment:this.currentEnvironment};stoStorage.saveProfile(this.currentProfile,a)}switchMode(e){if(this.currentEnvironment!==e){this.saveCurrentBuild(),this.currentEnvironment=e;const t=stoStorage.getProfile(this.currentProfile);t&&(t.currentEnvironment=e,stoStorage.saveProfile(this.currentProfile,t)),this.updateModeButtons(),this.updateProfileInfo(),this.renderKeyGrid(),this.renderCommandChain(),this.filterCommandLibrary(),this.setModified(!0),stoUI.showToast(`Switched to ${e} mode`,"success")}}updateModeButtons(){const e=document.querySelector('[data-mode="space"]'),t=document.querySelector('[data-mode="ground"]');e&&t&&(e.classList.toggle("active","space"===this.currentEnvironment),t.classList.toggle("active","ground"===this.currentEnvironment))}saveCurrentBuild(){const e=stoStorage.getProfile(this.currentProfile),t=this.getCurrentProfile();e&&t&&(e.builds||(e.builds={space:{keys:{}},ground:{keys:{}}}),e.builds[this.currentEnvironment]={keys:t.keys||{}},stoStorage.saveProfile(this.currentProfile,e))}async confirmDeleteKey(e){await stoUI.confirm(`Are you sure you want to delete the key "${e}" and all its commands?`,"Delete Key","danger")&&this.deleteKey(e)}async confirmClearChain(e){await stoUI.confirm(`Are you sure you want to clear all commands for "${e}"?`,"Clear Commands","warning")&&(this.getCurrentProfile().keys[e]=[],this.saveCurrentBuild(),this.renderCommandChain(),this.renderKeyGrid(),this.setModified(!0),stoUI.showToast(`Commands cleared for ${e}`,"success"))}openProject(){const e=document.getElementById("fileInput");e.accept=".json",e.onchange=e=>{const t=e.target.files[0];if(t){const e=new FileReader;e.onload=e=>{try{stoStorage.importData(e.target.result)?(this.loadData(),this.renderProfiles(),this.renderKeyGrid(),this.renderCommandChain(),stoUI.showToast("Project loaded successfully","success")):stoUI.showToast("Failed to load project file","error")}catch(e){stoUI.showToast("Invalid project file","error")}},e.readAsText(t)}},e.click()}saveProject(){const e=stoStorage.exportData(),t=new Blob([e],{type:"application/json"}),a=URL.createObjectURL(t),n=document.createElement("a");n.href=a,n.download="sto_keybinds.json",n.click(),URL.revokeObjectURL(a),stoUI.showToast("Project exported successfully","success")}exportKeybinds(){const e=this.getCurrentProfile();if(!e)return;const t=stoExport.generateSTOKeybindFile(e,{environment:this.currentEnvironment}),a=new Blob([t],{type:"text/plain"}),n=URL.createObjectURL(a),o=document.createElement("a");o.href=n;const i=e.name.replace(/[^a-zA-Z0-9]/g,"_");o.download=`${i}_${this.currentEnvironment}_keybinds.txt`,o.click(),URL.revokeObjectURL(n),stoUI.showToast(`${this.currentEnvironment} keybinds exported successfully`,"success")}isFirstTime(){return!localStorage.getItem("sto_keybind_manager_visited")}showWelcomeMessage(){localStorage.setItem("sto_keybind_manager_visited","true"),modalManager.show("aboutModal")}duplicateKey(e){const t=this.getCurrentProfile(),a=t.keys[e];if(!a||0===a.length)return void stoUI.showToast("No commands to duplicate","warning");let n=e+"_copy",o=1;for(;t.keys[n];)n=`${e}_copy_${o}`,o++;const i=a.map(e=>({...e,id:this.generateCommandId()}));t.keys[n]=i,stoStorage.saveProfile(this.currentProfile,t),this.renderKeyGrid(),this.setModified(!0),stoUI.showToast(`Key "${e}" duplicated as "${n}"`,"success")}showTemplateModal(){stoUI.showToast("Template system coming soon","info")}validateCurrentChain(){if(!this.selectedKey)return void stoUI.showToast("No key selected","warning");const e=this.getCurrentProfile().keys[this.selectedKey]||[];if(0===e.length)return void stoUI.showToast("No commands to validate","warning");const t=stoKeybinds.validateKeybind(this.selectedKey,e);if(t.valid)stoUI.showToast("Command chain is valid","success");else{const e="Validation errors:\n"+t.errors.join("\n");stoUI.showToast(e,"error",5e3)}}filterKeys(e){const t=e.toLowerCase();document.querySelectorAll(".key-item").forEach(a=>{const n=a.dataset.key.toLowerCase(),o=!e||n.includes(t);a.style.display=o?"flex":"none"}),document.querySelectorAll(".command-item[data-key]").forEach(a=>{const n=a.dataset.key.toLowerCase(),o=!e||n.includes(t);a.style.display=o?"flex":"none"}),document.querySelectorAll(".category").forEach(t=>{const a=t.querySelectorAll('.command-item[data-key]:not([style*="display: none"])'),n=!e||a.length>0;t.style.display=n?"block":"none"})}filterCommands(e){const t=document.querySelectorAll(".command-item"),a=e.toLowerCase();t.forEach(t=>{const n=t.textContent.toLowerCase(),o=!e||n.includes(a);t.style.display=o?"flex":"none"}),document.querySelectorAll(".category").forEach(t=>{const a=t.querySelectorAll('.command-item:not([style*="display: none"])'),n=!e||a.length>0;t.style.display=n?"block":"none"})}showAllKeys(){document.querySelectorAll(".key-item").forEach(e=>{e.style.display="flex"}),document.querySelectorAll(".command-item[data-key]").forEach(e=>{e.style.display="flex"}),document.querySelectorAll(".category").forEach(e=>{e.style.display="block"});const e=document.getElementById("keyFilter");e&&(e.value="")}toggleLibrary(){const e=document.getElementById("libraryContent"),t=document.getElementById("toggleLibraryBtn");if(e&&t){const a="none"===e.style.display;e.style.display=a?"block":"none";const n=t.querySelector("i");n&&(n.className=a?"fas fa-chevron-up":"fas fa-chevron-down")}}saveCommandFromModal(){if(!this.selectedKey)return void stoUI.showToast("Please select a key first","warning");const e=stoCommands.getCurrentCommand();if(!e)return void stoUI.showToast("Please configure a command","warning");const t=stoCommands.validateCommand(e);t.valid?(this.addCommand(this.selectedKey,e),modalManager.hide("addCommandModal")):stoUI.showToast(t.error,"error")}showParameterModal(e,t,a){this.currentParameterCommand={categoryId:e,commandId:t,commandDef:a},document.getElementById("parameterModal")||this.createParameterModal(),this.populateParameterModal(a),modalManager.show("parameterModal")}createParameterModal(){const e=document.createElement("div");e.className="modal",e.id="parameterModal",e.innerHTML='\n            <div class="modal-content">\n                <div class="modal-header">\n                    <h3 id="parameterModalTitle">Configure Command Parameters</h3>\n                    <button class="modal-close" data-modal="parameterModal">\n                        <i class="fas fa-times"></i>\n                    </button>\n                </div>\n                <div class="modal-body">\n                    <div id="parameterInputs">\n                        \x3c!-- Parameter inputs will be populated here --\x3e\n                    </div>\n                    <div class="command-preview-modal">\n                        <label>Generated Command:</label>\n                        <div class="command-preview" id="parameterCommandPreview">\n                            \x3c!-- Command preview will be shown here --\x3e\n                        </div>\n                    </div>\n                </div>\n                <div class="modal-footer">\n                    <button class="btn btn-primary" id="saveParameterCommandBtn">Add Command</button>\n                    <button class="btn btn-secondary" data-modal="parameterModal">Cancel</button>\n                </div>\n            </div>\n        ',document.body.appendChild(e),i.onDom("saveParameterCommandBtn","click","parameter-command-save",()=>{this.saveParameterCommand()}),e.querySelectorAll('.modal-close, [data-modal="parameterModal"]').forEach(e=>{e.addEventListener("click",()=>{this.cancelParameterCommand()})})}cancelParameterCommand(){this.currentParameterCommand=null;const e=document.getElementById("saveParameterCommandBtn");e&&(e.textContent="Add Command"),modalManager.hide("parameterModal")}populateParameterModal(e){const t=document.getElementById("parameterInputs");document.getElementById("parameterModalTitle").textContent=`Configure: ${e.name}`,t.innerHTML="",Object.entries(e.parameters).forEach(([e,a])=>{const n=document.createElement("div");n.className="form-group";const o=document.createElement("label");let i;if(o.textContent=this.formatParameterName(e),o.setAttribute("for",`param_${e}`),"message"===e){const t=document.createElement("div");t.className="input-with-button",i=document.createElement("input"),i.type="text",i.id=`param_${e}`,i.name=e,i.value=a.default||"",a.placeholder&&(i.placeholder=a.placeholder);const r=document.createElement("button");r.type="button",r.className="btn btn-small insert-target-btn",r.title="Insert $Target variable",r.innerHTML='<i class="fas fa-crosshairs"></i> $Target',t.appendChild(i),t.appendChild(r);const s=document.createElement("small");s.textContent=this.getParameterHelp(e,a);const c=document.createElement("div");c.className="variable-help",c.innerHTML="<strong>$Target</strong> - Use to include your current target's name in the message",n.appendChild(o),n.appendChild(t),n.appendChild(s),n.appendChild(c)}else{"select"===a.type?(i=document.createElement("select"),i.id=`param_${e}`,i.name=e,a.options.forEach(e=>{const t=document.createElement("option");t.value=e,t.textContent="STOTrayExecByTray"===e?"STOTrayExecByTray (shows key binding on UI)":"TrayExecByTray (no UI indication)",e===a.default&&(t.selected=!0),i.appendChild(t)})):(i=document.createElement("input"),i.type="number"===a.type?"number":"text",i.id=`param_${e}`,i.name=e,i.value=a.default||"",a.placeholder&&(i.placeholder=a.placeholder),"number"===a.type&&(void 0!==a.min&&(i.min=a.min),void 0!==a.max&&(i.max=a.max),void 0!==a.step&&(i.step=a.step)));const t=document.createElement("small");t.textContent=this.getParameterHelp(e,a),n.appendChild(o),n.appendChild(i),n.appendChild(t)}t.appendChild(n),i.addEventListener("input",()=>{this.updateParameterPreview()}),"SELECT"===i.tagName&&i.addEventListener("change",()=>{this.updateParameterPreview()})}),this.updateParameterPreview()}formatParameterName(e){return e.replace(/_/g," ").replace(/\b\w/g,e=>e.toUpperCase())}getParameterHelp(e,t){return{entityName:"Name of the entity to target (e.g., ship name, player name)",active:"Whether the command is active (1 = active, 0 = inactive)",tray:"Primary tray number (0-9, where 0 is the first tray)",slot:"Primary slot number (0-9, where 0 is the first slot)",backup_tray:"Backup tray number (0-9, where 0 is the first tray)",backup_slot:"Backup slot number (0-9, where 0 is the first slot)",amount:"Throttle adjustment amount (-1 to 1)",position:"Throttle position (-1 = full reverse, 0 = stop, 1 = full forward)",distance:"Camera distance from target",filename:"Name of the keybind file (without extension)",message:"Text message to send",state:"Enable (1) or disable (0) combat log",command_type:"STOTrayExecByTray shows key binding on UI, TrayExecByTray does not"}[e]||`${t.type} value ${void 0!==t.min?`(${t.min} to ${t.max})`:""}`}updateParameterPreview(){if(!this.currentParameterCommand)return;const{categoryId:e,commandId:t,commandDef:a}=this.currentParameterCommand,n=this.getParameterValues(),o=this.buildParameterizedCommand(e,t,a,n),i=document.getElementById("parameterCommandPreview");if(i&&o)if(Array.isArray(o)){const e=o.map(e=>e.command);i.textContent=e.join(" $$ ")}else i.textContent=o.command}getParameterValues(){const e={};return document.querySelectorAll("#parameterInputs input, #parameterInputs select").forEach(t=>{const a=t.name;let n=t.value;"number"===t.type&&(n=parseFloat(n)||0),e[a]=n}),e}buildParameterizedCommand(e,t,a,n){const o={targeting:e=>"target"===t&&e.entityName?{command:`${a.command} "${e.entityName}"`,text:`Target: ${e.entityName}`}:{command:a.command,text:a.name},tray:n=>{const o=n.tray||0,i=n.slot||0;if("tray_with_backup"===t){const e=void 0!==n.active?n.active:1,t=n.backup_tray||0,a=n.backup_slot||0;return{command:`TrayExecByTrayWithBackup ${e} ${o} ${i} ${t} ${a}`,text:`Execute Tray ${o+1} Slot ${i+1} (backup: Tray ${t+1} Slot ${a+1})`}}if("tray_range"===t){const t=n.start_tray||0,o=n.start_slot||0,i=n.end_tray||0,r=n.end_slot||0,s=n.command_type||"STOTrayExecByTray";return stoCommands.generateTrayRangeCommands(t,o,i,r,s).map((n,s)=>{let c,l;try{const e=n.replace("+","").trim().split(/\s+/);c=parseInt(e[1]),l=parseInt(e[2])}catch(e){c=void 0,l=void 0}return{command:n,type:e,icon:a.icon,text:0===s?`Execute Range: Tray ${t+1} Slot ${o+1} to Tray ${i+1} Slot ${r+1}`:n,id:this.generateCommandId(),parameters:{tray:c,slot:l}}})}if("tray_range_with_backup"===t){const t=n.active||1,o=n.start_tray||0,i=n.start_slot||0,r=n.end_tray||0,s=n.end_slot||0,c=n.backup_start_tray||0,l=n.backup_start_slot||0,d=n.backup_end_tray||0,m=n.backup_end_slot||0;return stoCommands.generateTrayRangeWithBackupCommands(t,o,i,r,s,c,l,d,m).map((t,n)=>{let i,s,c,l,d;try{const e=t.trim().split(/\s+/);i=parseInt(e[1]),s=parseInt(e[2]),c=parseInt(e[3]),l=parseInt(e[4]),d=parseInt(e[5])}catch(e){}return{command:t,type:e,icon:a.icon,text:0===n?`Execute Range with Backup: Tray ${o+1}-${r+1}`:t,id:this.generateCommandId(),parameters:{active:i,tray:s,slot:c,backup_tray:l,backup_slot:d}}})}if("whole_tray"===t){const t=n.command_type||"STOTrayExecByTray";return stoCommands.generateWholeTrayCommands(o,t).map((t,n)=>{let i;try{const e=t.replace("+","").trim().split(/\s+/);i=parseInt(e[2])}catch(e){i=void 0}return{command:t,type:e,icon:a.icon,text:0===n?`Execute Whole Tray ${o+1}`:t,id:this.generateCommandId(),parameters:{tray:o,slot:i}}})}if("whole_tray_with_backup"===t){const t=n.active||1,i=n.backup_tray||0;return stoCommands.generateWholeTrayWithBackupCommands(t,o,i).map((t,n)=>{let r,s,c,l,d;try{const e=t.trim().split(/\s+/);r=parseInt(e[1]),s=parseInt(e[2]),c=parseInt(e[3]),l=parseInt(e[4]),d=parseInt(e[5])}catch(e){}return{command:t,type:e,icon:a.icon,text:0===n?`Execute Whole Tray ${o+1} (with backup Tray ${i+1})`:t,id:this.generateCommandId(),parameters:{active:r,tray:s,slot:c,backup_tray:l,backup_slot:d}}})}{const e=this.currentParameterCommand&&this.currentParameterCommand.isEditing,t=n.command_type||"STOTrayExecByTray",a="+";if(e){const e=this.getCurrentProfile().keys[this.selectedKey][this.currentParameterCommand.editIndex];if(e&&(e.command.startsWith("TrayExecByTray")||e.command.startsWith("+TrayExecByTray")))return{command:`+TrayExecByTray ${o} ${i}`,text:`Execute Tray ${o+1} Slot ${i+1}`}}return{command:`${a}${t} ${o} ${i}`,text:`Execute Tray ${o+1} Slot ${i+1}`}}},movement:e=>{let n=a.command;return"throttle_adjust"===t&&void 0!==e.amount?n=`${a.command} ${e.amount}`:"throttle_set"===t&&void 0!==e.position&&(n=`${a.command} ${e.position}`),{command:n,text:a.name}},camera:e=>{let n=a.command;return"cam_distance"===t&&void 0!==e.distance&&(n=`${a.command} ${e.distance}`),{command:n,text:a.name}},communication:e=>({command:`${a.command} ${e.message||"Message text here"}`,text:`${a.name}: ${e.message||"Message text here"}`}),system:e=>{let n=a.command;return"bind_save_file"!==t&&"bind_load_file"!==t||!e.filename?"combat_log"===t&&void 0!==e.state&&(n=`${a.command} ${e.state}`):n=`${a.command} ${e.filename}`,{command:n,text:a.name}}},i=o[e];if(i){const t=i(n);return Array.isArray(t)?t:{command:t.command,type:e,icon:a.icon,text:t.text,id:this.generateCommandId(),parameters:n}}return null}saveParameterCommand(){if(!this.selectedKey||!this.currentParameterCommand)return;const{categoryId:e,commandId:t,commandDef:a,editIndex:n,isEditing:o}=this.currentParameterCommand,i=this.getParameterValues(),r=this.buildParameterizedCommand(e,t,a,i);if(r){if(o&&void 0!==n)if(Array.isArray(r)){const e=this.getCurrentProfile();e.keys[this.selectedKey].splice(n,1,...r),stoStorage.saveProfile(this.currentProfile,e),this.renderCommandChain(),this.setModified(!0),stoUI.showToast(`${r.length} commands updated successfully`,"success")}else{const e=this.getCurrentProfile();e.keys[this.selectedKey][n]=r,stoStorage.saveProfile(this.currentProfile,e),this.renderCommandChain(),this.setModified(!0),stoUI.showToast("Command updated successfully","success")}else this.addCommand(this.selectedKey,r);modalManager.hide("parameterModal"),this.currentParameterCommand=null,document.getElementById("saveParameterCommandBtn").textContent="Add Command"}}editCommand(e){if(!this.selectedKey)return;const t=this.getCurrentProfile().keys[this.selectedKey];if(!t||!t[e])return;const a=t[e];if(a.parameters&&a.type){const t=this.findCommandDefinition(a);if(t&&t.customizable)return void this.editParameterizedCommand(e,a,t)}const n=this.findCommandDefinition(a);n&&n.customizable?this.editParameterizedCommand(e,a,n):stoUI.showToast(`Command: ${a.command}\nType: ${a.type}`,"info",3e3)}findCommandDefinition(e){if(e.command.includes("TrayExec")){const t=STO_DATA.commands.tray;if(t)if(e.command.includes("TrayExecByTrayWithBackup")&&e.command.includes("$$")){if(e.command.split("$$").map(e=>e.trim()).length>1){const e=t.commands.tray_range_with_backup;if(e)return{commandId:"tray_range_with_backup",...e}}}else if((e.command.includes("STOTrayExecByTray")||e.command.includes("TrayExecByTray"))&&e.command.includes("$$")&&!e.command.includes("WithBackup")){if(e.command.split("$$").map(e=>e.trim()).length>1){const e=t.commands.tray_range;if(e)return{commandId:"tray_range",...e}}}else if(e.command.includes("TrayExecByTrayWithBackup")){const e=t.commands.tray_with_backup;if(e)return{commandId:"tray_with_backup",...e}}else if(e.command.includes("STOTrayExecByTray")||e.command.includes("TrayExecByTray")&&!e.command.includes("WithBackup")){const e=t.commands.custom_tray;if(e)return{commandId:"custom_tray",...e}}}const t=STO_DATA.commands[e.type];if(!t)return null;for(const[a,n]of Object.entries(t.commands))if(n.command===e.command)return{commandId:a,...n};for(const[a,n]of Object.entries(t.commands))if(n.customizable&&e.command.startsWith(n.command.split(" ")[0]))return{commandId:a,...n};return null}editParameterizedCommand(e,t,a){this.currentParameterCommand={categoryId:t.type,commandId:a.commandId,commandDef:a,editIndex:e,isEditing:!0},document.getElementById("parameterModal")||this.createParameterModal(),this.populateParameterModalForEdit(a,t.parameters),document.getElementById("parameterModalTitle").textContent=`Edit: ${a.name}`,document.getElementById("saveParameterCommandBtn").textContent="Update Command",modalManager.show("parameterModal")}populateParameterModalForEdit(e,t){const a=document.getElementById("parameterInputs");a.innerHTML="",Object.entries(e.parameters).forEach(([e,n])=>{const o=document.createElement("div");o.className="form-group";const i=document.createElement("label");let r;if(i.textContent=this.formatParameterName(e),i.setAttribute("for",`param_${e}`),"select"===n.type){r=document.createElement("select"),r.id=`param_${e}`,r.name=e,n.options.forEach(e=>{const t=document.createElement("option");t.value=e,t.textContent="STOTrayExecByTray"===e?"STOTrayExecByTray (shows key binding on UI)":"TrayExecByTray (no UI indication)",r.appendChild(t)});const a=t&&void 0!==t[e]?t[e]:n.default;r.value=null!=a?a:n.default}else{r=document.createElement("input"),r.type="number"===n.type?"number":"text",r.id=`param_${e}`,r.name=e;const a=t&&void 0!==t[e]?t[e]:n.default;r.value=null!=a?a:"",n.placeholder&&(r.placeholder=n.placeholder),"number"===n.type&&(void 0!==n.min&&(r.min=n.min),void 0!==n.max&&(r.max=n.max),void 0!==n.step&&(r.step=n.step))}const s=document.createElement("small");s.textContent=this.getParameterHelp(e,n),o.appendChild(i),o.appendChild(r),o.appendChild(s),a.appendChild(o),r.addEventListener("input",()=>{this.updateParameterPreview()}),"SELECT"===r.tagName&&r.addEventListener("change",()=>{this.updateParameterPreview()})}),this.updateParameterPreview()}filterCommandLibrary(){document.querySelectorAll(".command-item").forEach(e=>{const t=e.dataset.command;if(!t)return;let a=null;for(const[e,n]of Object.entries(STO_DATA.commands))if(n.commands[t]){a=n.commands[t];break}if(a){let t=!0;t=!a.environment||a.environment===this.currentEnvironment,e.style.display=t?"flex":"none"}}),document.querySelectorAll(".category").forEach(e=>{const t=e.querySelectorAll('.command-item:not([style*="display: none"])').length>0;e.style.display=t?"block":"none"})}showKeySelectionModal(){this.setupKeySelectionModal(),modalManager.show("keySelectionModal")}setupKeySelectionModal(){this.populateCommonKeys();const e=document.getElementById("findOtherKeysBtn");e&&(e.onclick=()=>this.showFullKeyList());const t=document.getElementById("keySearchInput");t&&(t.oninput=e=>this.filterKeyList(e.target.value))}populateCommonKeys(){const e=document.getElementById("commonKeysGrid");if(!e)return;const t=STO_DATA.keys.common.keys;e.innerHTML="",t.forEach(t=>{const a=document.createElement("div");a.className="key-button",a.onclick=()=>this.selectKeyFromModal(t.key),a.innerHTML=`\n                <div class="key-name">${t.key}</div>\n                <div class="key-desc">${t.description}</div>\n            `,e.appendChild(a)})}showFullKeyList(){const e=document.getElementById("fullKeysSection"),t=document.getElementById("findOtherKeysBtn");e&&t&&(e.style.display="block",t.style.display="none",this.populateKeyCategories())}populateKeyCategories(){const e=document.getElementById("keyCategories");e&&(e.innerHTML="",Object.entries(STO_DATA.keys).forEach(([t,a])=>{if("common"===t)return;if(console.log("Processing category:",t,a),!a||!a.name||!a.keys)return void console.warn(`Invalid category data for categoryId: ${t}`,a);const n=document.createElement("div");n.className="key-category";const o=document.createElement("div");o.className="key-category-header",o.onclick=()=>this.toggleKeySelectionCategory(t),o.innerHTML=`\n                <div>\n                    <h5>${a.name}</h5>\n                    <div class="category-desc">${a.description||""}</div>\n                </div>\n                <i class="fas fa-chevron-right category-chevron"></i>\n            `;const i=document.createElement("div");i.className="key-category-content collapsed",i.id=`key-category-${t}`,Array.isArray(a.keys)&&a.keys.forEach(e=>{if(e&&e.key){const t=document.createElement("div");t.className="key-button",t.onclick=()=>this.selectKeyFromModal(e.key),t.innerHTML=`\n                            <div class="key-name">${e.key}</div>\n                            <div class="key-desc">${e.description||""}</div>\n                        `,i.appendChild(t)}}),n.appendChild(o),n.appendChild(i),e.appendChild(n)}))}toggleKeySelectionCategory(e){const t=document.getElementById(`key-category-${e}`);if(!t)return void console.warn(`Key selection category content not found for categoryId: ${e}`);const a=t.previousElementSibling;if(t&&a)if(t.classList.contains("collapsed")){t.classList.remove("collapsed"),a.classList.remove("collapsed");const e=a.querySelector(".category-chevron");e&&(e.style.transform="rotate(90deg)")}else{t.classList.add("collapsed"),a.classList.add("collapsed");const e=a.querySelector(".category-chevron");e&&(e.style.transform="rotate(0deg)")}}filterKeyList(e){const t=e.toLowerCase().trim();document.querySelectorAll("#keyCategories .key-button").forEach(e=>{const a=e.querySelector(".key-name").textContent.toLowerCase(),n=e.querySelector(".key-desc").textContent.toLowerCase(),o=a.includes(t)||n.includes(t);e.style.display=o?"flex":"none"}),document.querySelectorAll(".key-category").forEach(e=>{const a=e.querySelectorAll('.key-button:not([style*="display: none"])').length>0;if(""===t)e.style.display="block";else if(e.style.display=a?"block":"none",a){const t=e.querySelector(".key-category-content"),a=e.querySelector(".key-category-header");t&&a&&(t.classList.remove("collapsed"),a.classList.remove("collapsed"))}})}selectKeyFromModal(e){modalManager.hide("keySelectionModal"),this.selectKey(e)}insertTargetVariable(e){const t=e.selectionStart,a=e.value,n=a.slice(0,t)+"$Target"+a.slice(t);e.value=n,e.setSelectionRange(t+7,t+7),e.focus(),e.dispatchEvent(new Event("input",{bubbles:!0}))}showVertigoModal(){const e=stoStorage.getProfile(this.currentProfile);e&&vertigoManager.loadState(e),this.vertigoInitialState={selectedEffects:{space:new Set(vertigoManager.selectedEffects.space),ground:new Set(vertigoManager.selectedEffects.ground)},showPlayerSay:vertigoManager.showPlayerSay},this.populateVertigoModal(),this.setupVertigoEventListeners(),modalManager.show("vertigoModal")}populateVertigoModal(){const e=document.getElementById("spaceEffectsList");e&&(e.innerHTML="",VFX_EFFECTS.space.forEach(t=>{const a=this.createEffectItem("space",t);e.appendChild(a)}));const t=document.getElementById("groundEffectsList");t&&(t.innerHTML="",VFX_EFFECTS.ground.forEach(e=>{const a=this.createEffectItem("ground",e);t.appendChild(a)})),this.updateVertigoCheckboxes("space"),this.updateVertigoCheckboxes("ground");const a=document.getElementById("vertigoShowPlayerSay");a&&(a.checked=vertigoManager.showPlayerSay),this.updateVertigoEffectCounts(),this.updateVertigoPreview()}createEffectItem(e,t){const a=document.createElement("div");a.className="effect-item",a.innerHTML=`\n            <input type="checkbox" id="effect_${e}_${t.effect.replace(/[^a-zA-Z0-9]/g,"_")}" \n                   data-environment="${e}" \n                   data-effect="${t.effect}">\n            <label for="effect_${e}_${t.effect.replace(/[^a-zA-Z0-9]/g,"_")}" \n                   class="effect-label">${t.label}</label>\n        `;const n=a.querySelector('input[type="checkbox"]');return n.addEventListener("change",()=>{vertigoManager.toggleEffect(e,t.effect),this.updateVertigoEffectCounts(),this.updateVertigoPreview(),a.classList.toggle("selected",n.checked)}),a.querySelector(".effect-label").addEventListener("click",()=>{n.checked=!n.checked,n.dispatchEvent(new Event("change"))}),a}setupVertigoEventListeners(){["spaceSelectAll","spaceClearAll","groundSelectAll","groundClearAll","vertigoShowPlayerSay","saveVertigoBtn"].forEach(e=>{const t=document.getElementById(e);t&&t.replaceWith(t.cloneNode(!0))}),i.onDom("spaceSelectAll","click","vertigo-space-select-all",()=>{try{vertigoManager.selectAllEffects("space"),this.updateVertigoCheckboxes("space"),this.updateVertigoEffectCounts(),this.updateVertigoPreview()}catch(e){e instanceof InvalidEnvironmentError?stoUI.showToast(`Error: ${e.message}`,"error"):(stoUI.showToast("Failed to select all space effects","error"),console.error("Error selecting all space effects:",e))}}),i.onDom("spaceClearAll","click","vertigo-space-clear-all",()=>{vertigoManager.selectedEffects.space.clear(),this.updateVertigoCheckboxes("space"),this.updateVertigoEffectCounts(),this.updateVertigoPreview()}),i.onDom("groundSelectAll","click","vertigo-ground-select-all",()=>{try{vertigoManager.selectAllEffects("ground"),this.updateVertigoCheckboxes("ground"),this.updateVertigoEffectCounts(),this.updateVertigoPreview()}catch(e){e instanceof InvalidEnvironmentError?stoUI.showToast(`Error: ${e.message}`,"error"):(stoUI.showToast("Failed to select all ground effects","error"),console.error("Error selecting all ground effects:",e))}}),i.onDom("groundClearAll","click","vertigo-ground-clear-all",()=>{vertigoManager.selectedEffects.ground.clear(),this.updateVertigoCheckboxes("ground"),this.updateVertigoEffectCounts(),this.updateVertigoPreview()}),i.onDom("vertigoShowPlayerSay","change","vertigo-show-playersay",e=>{vertigoManager.showPlayerSay=e.target.checked,this.updateVertigoPreview()}),i.onDom("saveVertigoBtn","click","vertigo-save",()=>{this.generateVertigoAliases()})}updateVertigoCheckboxes(e){document.querySelectorAll(`input[data-environment="${e}"]`).forEach(t=>{const a=t.dataset.effect,n=vertigoManager.isEffectSelected(e,a);t.checked=n,t.closest(".effect-item").classList.toggle("selected",n)})}updateVertigoEffectCounts(){const e=vertigoManager.getEffectCount("space"),t=vertigoManager.getEffectCount("ground"),a=document.getElementById("spaceEffectCount"),n=document.getElementById("groundEffectCount");a&&(a.textContent=`${e} selected`),n&&(n.textContent=`${t} selected`)}updateVertigoPreview(){const e=document.getElementById("spaceAliasCommand"),t=document.getElementById("groundAliasCommand");if(e)try{const t=vertigoManager.generateAlias("space");e.textContent=t||"No space effects selected"}catch(t){t instanceof InvalidEnvironmentError?(e.textContent="Error: Invalid environment",stoUI.showToast(`Space preview error: ${t.message}`,"error")):(e.textContent="Error generating preview",console.error("Error generating space alias preview:",t))}if(t)try{const e=vertigoManager.generateAlias("ground");t.textContent=e||"No ground effects selected"}catch(e){e instanceof InvalidEnvironmentError?(t.textContent="Error: Invalid environment",stoUI.showToast(`Ground preview error: ${e.message}`,"error")):(t.textContent="Error generating preview",console.error("Error generating ground alias preview:",e))}}generateVertigoAliases(){let e="",t="";try{e=vertigoManager.generateAlias("space")}catch(e){return e instanceof InvalidEnvironmentError?void stoUI.showToast(`Space alias error: ${e.message}`,"error"):(stoUI.showToast("Failed to generate space alias","error"),void console.error("Error generating space alias:",e))}try{t=vertigoManager.generateAlias("ground")}catch(e){return e instanceof InvalidEnvironmentError?void stoUI.showToast(`Ground alias error: ${e.message}`,"error"):(stoUI.showToast("Failed to generate ground alias","error"),void console.error("Error generating ground alias:",e))}if(!e&&!t)return void stoUI.showToast("No effects selected. Please select at least one effect to generate aliases.","warning");if(!this.getCurrentProfile())return void stoUI.showToast("No profile selected","error");const a=stoStorage.getProfile(this.currentProfile);if(!a)return void stoUI.showToast("No profile found","error");let n=0;if(a.aliases||(a.aliases={}),e){const t="dynFxSetFXExlusionList_Space",o=e.match(/alias\s+\w+\s+<&\s+(.+?)&>/),i=o?o[1]:"";a.aliases[t]={name:t,description:"VFX - Disable Space Visual Effects",commands:i,created:(new Date).toISOString(),lastModified:(new Date).toISOString()},n++}if(t){const e="dynFxSetFXExlusionList_Ground",o=t.match(/alias\s+\w+\s+<&\s+(.+?)&>/),i=o?o[1]:"";a.aliases[e]={name:e,description:"VFX - Disable Ground Visual Effects",commands:i,created:(new Date).toISOString(),lastModified:(new Date).toISOString()},n++}vertigoManager.saveState(a),stoStorage.saveProfile(this.currentProfile,a),this.saveProfile(),this.setModified(!0),"undefined"!=typeof stoAliases&&stoAliases.updateCommandLibrary&&stoAliases.updateCommandLibrary(),this.vertigoInitialState={selectedEffects:{space:new Set(vertigoManager.selectedEffects.space),ground:new Set(vertigoManager.selectedEffects.ground)},showPlayerSay:vertigoManager.showPlayerSay},this.vertigoSaving=!0,modalManager.hide("vertigoModal"),stoUI.showToast(`Generated ${n} Vertigo alias${n>1?"es":""}! Check the Alias Manager to bind them to keys.`,"success")}applyTheme(){const e=stoStorage.getSettings().theme||"default";"dark"===e?document.documentElement.setAttribute("data-theme","dark"):document.documentElement.removeAttribute("data-theme"),this.updateThemeToggleButton(e)}toggleTheme(){const e=stoStorage.getSettings(),t="dark"===(e.theme||"default")?"default":"dark";e.theme=t,stoStorage.saveSettings(e),this.applyTheme();const a="dark"===t?"Dark Mode":"Light Mode";stoUI.showToast(`Switched to ${a}`,"success")}updateThemeToggleButton(e){const t=document.getElementById("themeToggleBtn"),a=document.getElementById("themeToggleText"),n=t?.querySelector("i");t&&a&&n&&("dark"===e?(n.className="fas fa-sun",a.textContent="Light Mode"):(n.className="fas fa-moon",a.textContent="Dark Mode"))}};window.app=T,i.on("sto-app-ready",()=>{p.init(),u.init(),y.init(),f.init(),b.init()});
+const e = 'v2025.06.20-preview-1',
+  t = {}
+function a(e, a) {
+  t[e] || (t[e] = new Set()), t[e].add(a)
+}
+function n(e, a) {
+  t[e] && t[e].delete(a)
+}
+function o(e, a) {
+  if (t[e])
+    for (const n of t[e])
+      try {
+        n(a)
+      } catch (e) {
+        console.error(e)
+      }
+}
+var i = {
+  on: a,
+  off: n,
+  emit: o,
+  onDom: function (e, t, i, r) {
+    if (
+      ('string' == typeof e && (e = document.getElementById(e)),
+      !e || !e.addEventListener)
+    )
+      return () => {}
+    'function' == typeof i && ((r = i), (i = t)), i || (i = t)
+    const s = (e) => o(i, e)
+    return (
+      e.addEventListener(t, s),
+      r && a(i, r),
+      () => {
+        e.removeEventListener(t, s), r && n(i, r)
+      }
+    )
+  },
+}
+const r = {
+  commands: {
+    targeting: {
+      name: 'Targeting',
+      icon: 'fas fa-crosshairs',
+      description: 'Target selection and management',
+      commands: {
+        target: {
+          name: 'Target by Name',
+          command: 'Target',
+          description: 'Target entity by name (requires quotes)',
+          syntax: 'Target "EntityName"',
+          icon: '🎯',
+          customizable: !0,
+          parameters: {
+            entityName: {
+              type: 'text',
+              default: 'EntityName',
+              placeholder: 'Enter entity name',
+            },
+          },
+        },
+        target_enemy_near: {
+          name: 'Target Nearest Enemy',
+          command: 'Target_Enemy_Near',
+          description: 'Target the nearest enemy in view',
+          syntax: 'Target_Enemy_Near',
+          icon: '🎯',
+        },
+        target_friend_near: {
+          name: 'Target Nearest Friend',
+          command: 'Target_Friend_Near',
+          description: 'Target the nearest friendly entity',
+          syntax: 'Target_Friend_Near',
+          icon: '🤝',
+        },
+        target_self: {
+          name: 'Target Self',
+          command: 'Target_Self',
+          description: 'Target your own ship/character',
+          syntax: 'Target_Self',
+          icon: '👤',
+        },
+        target_clear: {
+          name: 'Clear Target',
+          command: 'Target_Clear',
+          description: 'Remove current target lock',
+          syntax: 'Target_Clear',
+          icon: '❌',
+        },
+        target_teammate_1: {
+          name: 'Target Teammate 1',
+          command: 'Target_Teammate 1',
+          description: 'Target first team member',
+          syntax: 'Target_Teammate 1',
+          icon: '👥',
+        },
+        target_teammate_2: {
+          name: 'Target Teammate 2',
+          command: 'Target_Teammate 2',
+          description: 'Target second team member',
+          syntax: 'Target_Teammate 2',
+          icon: '👥',
+        },
+        target_teammate_3: {
+          name: 'Target Teammate 3',
+          command: 'Target_Teammate 3',
+          description: 'Target third team member',
+          syntax: 'Target_Teammate 3',
+          icon: '👥',
+        },
+        target_teammate_4: {
+          name: 'Target Teammate 4',
+          command: 'Target_Teammate 4',
+          description: 'Target fourth team member',
+          syntax: 'Target_Teammate 4',
+          icon: '👥',
+        },
+      },
+    },
+    combat: {
+      name: 'Combat',
+      icon: 'fas fa-fire',
+      description: 'Weapon firing and combat actions',
+      commands: {
+        fire_all: {
+          name: 'Fire All Weapons',
+          command: 'FireAll',
+          description: 'Fire all weapons',
+          syntax: 'FireAll',
+          environment: 'space',
+          icon: '🔥',
+          warning:
+            'Not recommended on spam bars as it interferes with firing cycles',
+        },
+        fire_phasers: {
+          name: 'Fire Energy Weapons',
+          command: 'FirePhasers',
+          description: 'Fire all Energy Weapons',
+          syntax: 'FirePhasers',
+          environment: 'space',
+          icon: '⚡',
+          warning:
+            'Not recommended on spam bars as it interferes with firing cycles',
+        },
+        fire_torps: {
+          name: 'Fire Torpedoes',
+          command: 'FireTorps',
+          description: 'Fire all Torpedos',
+          syntax: 'FireTorps',
+          environment: 'space',
+          icon: '🚀',
+          warning:
+            'Not recommended on spam bars as it interferes with firing cycles',
+        },
+        fire_mines: {
+          name: 'Fire Mines',
+          command: 'FireMines',
+          description: 'Fire all Mines',
+          syntax: 'FireMines',
+          environment: 'space',
+          icon: '💣',
+          warning:
+            'Not recommended on spam bars as it interferes with firing cycles',
+        },
+        fire_phasers_torps: {
+          name: 'Fire Phasers & Torpedoes',
+          command: 'FirePhasersTorps',
+          description: 'Fire phasers & torpedos',
+          syntax: 'FirePhasersTorps',
+          environment: 'space',
+          icon: '💥',
+          warning:
+            'Not recommended on spam bars as it interferes with firing cycles',
+        },
+        fire_projectiles: {
+          name: 'Fire Projectiles',
+          command: 'FireProjectiles',
+          description: 'Fire torpedos & mines',
+          syntax: 'FireProjectiles',
+          environment: 'space',
+          icon: '🎯',
+          warning:
+            'Not recommended on spam bars as it interferes with firing cycles',
+        },
+      },
+    },
+    tray: {
+      name: 'Tray Execution',
+      icon: 'fas fa-th',
+      description: 'Execute abilities from action trays',
+      commands: {
+        custom_tray: {
+          name: 'Tray Execution',
+          command: '+STOTrayExecByTray 0 0',
+          description: 'Execute specific tray slot',
+          syntax: '+STOTrayExecByTray <tray> <slot>',
+          icon: '⚡',
+          customizable: !0,
+          parameters: {
+            tray: { type: 'number', min: 0, max: 9, default: 0 },
+            slot: { type: 'number', min: 0, max: 9, default: 0 },
+            command_type: {
+              type: 'select',
+              options: ['STOTrayExecByTray', 'TrayExecByTray'],
+              default: 'STOTrayExecByTray',
+            },
+          },
+        },
+        tray_with_backup: {
+          name: 'Tray Execution with Backup',
+          command: 'TrayExecByTrayWithBackup 1 0 0 0 0',
+          description: 'Execute specific tray slot with backup ability',
+          syntax:
+            'TrayExecByTrayWithBackup <active> <tray> <slot> <backup_tray> <backup_slot>',
+          icon: '⚡',
+          customizable: !0,
+          parameters: {
+            active: { type: 'number', min: 0, max: 1, default: 1 },
+            tray: { type: 'number', min: 0, max: 9, default: 0 },
+            slot: { type: 'number', min: 0, max: 9, default: 0 },
+            backup_tray: { type: 'number', min: 0, max: 9, default: 0 },
+            backup_slot: { type: 'number', min: 0, max: 9, default: 0 },
+          },
+        },
+        tray_range: {
+          name: 'Tray Range Execution',
+          command: '+STOTrayExecByTray 0 0',
+          description: 'Execute a range of tray slots',
+          syntax: '+STOTrayExecByTray <tray> <slot> $$ ... (range)',
+          icon: '⚡',
+          customizable: !0,
+          parameters: {
+            start_tray: { type: 'number', min: 0, max: 9, default: 0 },
+            start_slot: { type: 'number', min: 0, max: 9, default: 0 },
+            end_tray: { type: 'number', min: 0, max: 9, default: 0 },
+            end_slot: { type: 'number', min: 0, max: 9, default: 0 },
+            command_type: {
+              type: 'select',
+              options: ['STOTrayExecByTray', 'TrayExecByTray'],
+              default: 'STOTrayExecByTray',
+            },
+          },
+        },
+        tray_range_with_backup: {
+          name: 'Tray Range with Backup',
+          command: 'TrayExecByTrayWithBackup 1 0 0 0 0',
+          description: 'Execute a range of tray slots with backup abilities',
+          syntax:
+            'TrayExecByTrayWithBackup <active> <tray> <slot> <backup_tray> <backup_slot> $$ ... (range)',
+          icon: '⚡',
+          customizable: !0,
+          parameters: {
+            active: { type: 'number', min: 0, max: 1, default: 1 },
+            start_tray: { type: 'number', min: 0, max: 9, default: 0 },
+            start_slot: { type: 'number', min: 0, max: 9, default: 0 },
+            end_tray: { type: 'number', min: 0, max: 9, default: 0 },
+            end_slot: { type: 'number', min: 0, max: 9, default: 0 },
+            backup_start_tray: { type: 'number', min: 0, max: 9, default: 0 },
+            backup_start_slot: { type: 'number', min: 0, max: 9, default: 0 },
+            backup_end_tray: { type: 'number', min: 0, max: 9, default: 0 },
+            backup_end_slot: { type: 'number', min: 0, max: 9, default: 0 },
+          },
+        },
+        whole_tray: {
+          name: 'Whole Tray Execution',
+          command: '+STOTrayExecByTray 0 0',
+          description: 'Execute all slots in a tray',
+          syntax: '+STOTrayExecByTray <tray> <slot> $$ ... (all slots)',
+          icon: '⚡',
+          customizable: !0,
+          parameters: {
+            tray: { type: 'number', min: 0, max: 9, default: 0 },
+            command_type: {
+              type: 'select',
+              options: ['STOTrayExecByTray', 'TrayExecByTray'],
+              default: 'STOTrayExecByTray',
+            },
+          },
+        },
+        whole_tray_with_backup: {
+          name: 'Whole Tray with Backup',
+          command: 'TrayExecByTrayWithBackup 1 0 0 0 0',
+          description: 'Execute all slots in a tray with backup tray',
+          syntax:
+            'TrayExecByTrayWithBackup <active> <tray> <slot> <backup_tray> <backup_slot> $$ ... (all slots)',
+          icon: '⚡',
+          customizable: !0,
+          parameters: {
+            active: { type: 'number', min: 0, max: 1, default: 1 },
+            tray: { type: 'number', min: 0, max: 9, default: 0 },
+            backup_tray: { type: 'number', min: 0, max: 9, default: 0 },
+          },
+        },
+      },
+    },
+    power: {
+      name: 'Shield Management',
+      icon: 'fas fa-shield-alt',
+      description: 'Shield power and distribution management',
+      commands: {
+        distribute_shields: {
+          name: 'Distribute Shields',
+          command: '+power_exec Distribute_Shields',
+          description:
+            'Evenly distributes shields as if clicking in the middle of the ship and shields icon',
+          syntax: '+power_exec Distribute_Shields',
+          environment: 'space',
+          icon: '🛡️',
+          warning:
+            'Not recommended on spam bars as it interferes with firing cycles',
+        },
+        reroute_shields_rear: {
+          name: 'Reroute Shields Rear',
+          command: '+power_exec reroute_shields_rear',
+          description: 'Route shield power to rear facing',
+          syntax: '+power_exec reroute_shields_rear',
+          environment: 'space',
+          icon: '🛡️',
+        },
+        reroute_shields_left: {
+          name: 'Reroute Shields Left',
+          command: '+power_exec reroute_shields_left',
+          description: 'Route shield power to left side',
+          syntax: '+power_exec reroute_shields_left',
+          environment: 'space',
+          icon: '🛡️',
+        },
+        reroute_shields_right: {
+          name: 'Reroute Shields Right',
+          command: '+power_exec reroute_shields_right',
+          description: 'Route shield power to right side',
+          syntax: '+power_exec reroute_shields_right',
+          environment: 'space',
+          icon: '🛡️',
+        },
+        reroute_shields_forward: {
+          name: 'Reroute Shields Forward',
+          command: '+power_exec reroute_shields_forward',
+          description: 'Route shield power to forward facing',
+          syntax: '+power_exec reroute_shields_forward',
+          environment: 'space',
+          icon: '🛡️',
+        },
+      },
+    },
+    movement: {
+      name: 'Movement',
+      icon: 'fas fa-arrows-alt',
+      description: 'Ship movement and navigation',
+      commands: {
+        full_impulse: {
+          name: 'Full Impulse',
+          command: '+fullimpulse',
+          description: 'Engage full impulse drive',
+          syntax: '+fullimpulse',
+          environment: 'space',
+          icon: '🚀',
+        },
+        reverse: {
+          name: 'Reverse',
+          command: '+reverse',
+          description: 'Reverse engines',
+          syntax: '+reverse',
+          icon: '⬅️',
+        },
+        throttle_adjust: {
+          name: 'Throttle Adjust',
+          command: 'ThrottleAdjust',
+          description: 'Increase or decrease the throttle by amount',
+          syntax: 'ThrottleAdjust <amount>',
+          icon: '⚡',
+          customizable: !0,
+          parameters: {
+            amount: {
+              type: 'number',
+              min: -1,
+              max: 1,
+              default: 0.25,
+              step: 0.05,
+            },
+          },
+        },
+        throttle_set: {
+          name: 'Throttle Set',
+          command: 'ThrottleSet',
+          description:
+            'Set the throttle to a specific position (negative = reverse, 0 = stop)',
+          syntax: 'ThrottleSet <position>',
+          icon: '🎛️',
+          customizable: !0,
+          parameters: {
+            position: {
+              type: 'number',
+              min: -1,
+              max: 1,
+              default: 1,
+              step: 0.1,
+            },
+          },
+        },
+        throttle_toggle: {
+          name: 'Throttle Toggle',
+          command: 'ThrottleToggle',
+          description: 'Alternates between full throttle and full stop',
+          syntax: 'ThrottleToggle',
+          icon: '🔄',
+        },
+        turn_left: {
+          name: 'Turn Left',
+          command: '+turnleft',
+          description: 'Turn ship left (continuous while held)',
+          syntax: '+turnleft',
+          icon: '↪️',
+        },
+        turn_right: {
+          name: 'Turn Right',
+          command: '+turnright',
+          description: 'Turn ship right (continuous while held)',
+          syntax: '+turnright',
+          icon: '↩️',
+        },
+        pitch_up: {
+          name: 'Pitch Up',
+          command: '+up',
+          description: 'Pitch ship nose up (space altitude change)',
+          syntax: '+up',
+          icon: '⬆️',
+        },
+        pitch_down: {
+          name: 'Pitch Down',
+          command: '+down',
+          description: 'Pitch ship nose down (space altitude change)',
+          syntax: '+down',
+          icon: '⬇️',
+        },
+        strafe_left: {
+          name: 'Strafe Left',
+          command: '+left',
+          description: 'Strafe ship left',
+          syntax: '+left',
+          icon: '⬅️',
+        },
+        strafe_right: {
+          name: 'Strafe Right',
+          command: '+right',
+          description: 'Strafe ship right',
+          syntax: '+right',
+          icon: '➡️',
+        },
+        forward: {
+          name: 'Forward',
+          command: '+forward',
+          description: 'Move forward',
+          syntax: '+forward',
+          icon: '⬆️',
+        },
+        backward: {
+          name: 'Backward',
+          command: '+backward',
+          description: 'Move backward',
+          syntax: '+backward',
+          icon: '⬇️',
+        },
+        auto_forward: {
+          name: 'Auto Forward',
+          command: 'autoForward',
+          description:
+            'Character moves forward until given new movement commands',
+          syntax: 'autoForward',
+          environment: 'ground',
+          icon: '🏃',
+        },
+        follow: {
+          name: 'Follow Target',
+          command: 'Follow',
+          description: 'Follow the targeted entity',
+          syntax: 'Follow',
+          icon: '👥',
+        },
+        follow_cancel: {
+          name: 'Cancel Follow',
+          command: 'Follow_Cancel',
+          description: 'Stop following and forget about the target',
+          syntax: 'Follow_Cancel',
+          icon: '❌',
+        },
+      },
+    },
+    camera: {
+      name: 'Camera',
+      icon: 'fas fa-video',
+      description: 'Camera control and view management',
+      commands: {
+        zoom_in: {
+          name: 'Zoom In',
+          command: 'Camzoomin',
+          description: 'Zoom the camera in',
+          syntax: 'Camzoomin',
+          icon: '🔍',
+        },
+        zoom_out: {
+          name: 'Zoom Out',
+          command: 'Camzoomout',
+          description: 'Zoom the camera out',
+          syntax: 'Camzoomout',
+          icon: '🔎',
+        },
+        zoom_in_small: {
+          name: 'Zoom In Small',
+          command: 'Camzoominsmall',
+          description: 'Zoom the camera in slightly',
+          syntax: 'Camzoominsmall',
+          icon: '🔍',
+        },
+        zoom_out_small: {
+          name: 'Zoom Out Small',
+          command: 'Camzoomoutsmall',
+          description: 'Zoom the camera out slightly',
+          syntax: 'Camzoomoutsmall',
+          icon: '🔎',
+        },
+        cam_distance: {
+          name: 'Set Camera Distance',
+          command: 'camdist',
+          description: 'Sets the camera distance from the player',
+          syntax: 'camdist <distance>',
+          icon: '📏',
+          customizable: !0,
+          parameters: {
+            distance: { type: 'number', min: 1, max: 500, default: 50 },
+          },
+        },
+        cam_reset: {
+          name: 'Reset Camera',
+          command: 'CamReset',
+          description: 'Reset the camera position to default',
+          syntax: 'CamReset',
+          icon: '🔄',
+        },
+        cam_target_lock: {
+          name: 'Lock Camera to Target',
+          command: 'Camsetlocktotarget',
+          description: 'Lock or unlock the camera to the target',
+          syntax: 'Camsetlocktotarget',
+          icon: '🎯',
+        },
+        cam_cycle_distance: {
+          name: 'Cycle Camera Distance',
+          command: 'camCycleDist',
+          description:
+            'Cycle the camera distance between several preset values',
+          syntax: 'camCycleDist',
+          icon: '🔄',
+        },
+        cam_mouse_look: {
+          name: 'Mouse Look',
+          command: '+camMouseLook',
+          description: 'Enable mouse look camera control',
+          syntax: '+camMouseLook',
+          icon: '🖱️',
+        },
+        cam_turn_to_face: {
+          name: 'Turn to Face Camera',
+          command: '+camTurnToFace',
+          description: 'Turn ship to face camera direction',
+          syntax: '+camTurnToFace',
+          icon: '↪️',
+        },
+        look_up: {
+          name: 'Look Up',
+          command: 'lookUp',
+          description: 'Change point of view to look straight up',
+          syntax: 'lookUp',
+          icon: '⬆️',
+        },
+        look_down: {
+          name: 'Look Down',
+          command: 'lookDown',
+          description: 'Change point of view to look straight down',
+          syntax: 'lookDown',
+          icon: '⬇️',
+        },
+      },
+    },
+    communication: {
+      name: 'Communication',
+      icon: 'fas fa-comments',
+      description: 'Chat and team communication',
+      commands: {
+        team_message: {
+          name: 'Team Message',
+          command: 'team',
+          description: 'Send message to team',
+          syntax: 'team message',
+          icon: '💬',
+          customizable: !0,
+          parameters: {
+            message: { type: 'text', default: 'Message text here' },
+          },
+        },
+        local_message: {
+          name: 'Local Message',
+          command: 'say',
+          description: 'Send message to local area',
+          syntax: 'say message',
+          icon: '📢',
+          customizable: !0,
+          parameters: {
+            message: { type: 'text', default: 'Message text here' },
+          },
+        },
+        zone_message: {
+          name: 'Zone Message',
+          command: 'zone',
+          description: 'Send message to zone',
+          syntax: 'zone message',
+          icon: '📡',
+          customizable: !0,
+          parameters: {
+            message: { type: 'text', default: 'Message text here' },
+          },
+        },
+      },
+    },
+    system: {
+      name: 'System',
+      icon: 'fas fa-cog',
+      description: 'UI and system commands',
+      commands: {
+        toggle_hud: {
+          name: 'Toggle HUD',
+          command: '+GenToggleHUD',
+          description: 'Toggle HUD visibility',
+          syntax: '+GenToggleHUD',
+          icon: '👁️',
+        },
+        screenshot: {
+          name: 'Screenshot',
+          command: 'screenshot',
+          description: 'Take a screenshot',
+          syntax: 'screenshot',
+          icon: '📷',
+        },
+        screenshot_jpg: {
+          name: 'Screenshot JPG',
+          command: 'screenshot_jpg',
+          description: 'Save a screenshot as JPG',
+          syntax: 'screenshot_jpg',
+          icon: '📷',
+        },
+        autofire_toggle: {
+          name: 'Toggle Autofire',
+          command: '+GenToggleAutofire',
+          description: 'Toggle weapon autofire',
+          syntax: '+GenToggleAutofire',
+          icon: '🔁',
+        },
+        bind_save_file: {
+          name: 'Save Binds to File',
+          command: 'bind_save_file',
+          description: 'Save all your binds to a text file',
+          syntax: 'bind_save_file <filename>',
+          icon: '💾',
+          customizable: !0,
+          parameters: { filename: { type: 'text', default: 'my_binds.txt' } },
+        },
+        bind_load_file: {
+          name: 'Load Binds from File',
+          command: 'bind_load_file',
+          description: 'Load a bind file into the client',
+          syntax: 'bind_load_file <filename>',
+          icon: '📁',
+          customizable: !0,
+          parameters: { filename: { type: 'text', default: 'my_binds.txt' } },
+        },
+        combat_log: {
+          name: 'Toggle Combat Log',
+          command: 'CombatLog',
+          description: 'Turn combat log recording on/off (1=on, 0=off)',
+          syntax: 'CombatLog <1/0>',
+          icon: '📊',
+          customizable: !0,
+          parameters: { state: { type: 'number', min: 0, max: 1, default: 1 } },
+        },
+        missions: {
+          name: 'Show/Hide Missions',
+          command: 'missions',
+          description: 'Show/hide the mission journal',
+          syntax: 'missions',
+          icon: '📋',
+        },
+        inventory: {
+          name: 'Show/Hide Inventory',
+          command: 'Inventory',
+          description: 'Show/hide your inventory',
+          syntax: 'Inventory',
+          icon: '🎒',
+        },
+        map: {
+          name: 'Show/Hide Map',
+          command: 'Map',
+          description: 'Show/hide the map window',
+          syntax: 'Map',
+          icon: '🗺️',
+        },
+      },
+    },
+  },
+  templates: {
+    space_combat: {
+      basic_attack: {
+        name: 'Basic Attack Sequence',
+        description: 'Target enemy and fire all weapons',
+        commands: ['Target_Enemy_Near', 'FireAll'],
+      },
+      defensive_sequence: {
+        name: 'Defensive Sequence',
+        description: 'Target self and activate defensive abilities',
+        commands: ['Target_Self', '+power_exec Distribute_Shields'],
+      },
+      alpha_strike: {
+        name: 'Alpha Strike',
+        description: 'Full offensive sequence with buffs',
+        commands: ['Target_Enemy_Near', 'FireAll'],
+      },
+      healing_sequence: {
+        name: 'Emergency Healing',
+        description: 'Self-healing and damage control',
+        commands: ['Target_Self', '+power_exec Distribute_Shields'],
+      },
+    },
+    ground_combat: {
+      basic_ground_attack: {
+        name: 'Basic Ground Attack',
+        description: 'Target and attack sequence for ground combat',
+        commands: ['Target_Enemy_Near', '+STOTrayExecByTray 0 0'],
+      },
+    },
+  },
+  defaultProfiles: {
+    default_space: {
+      name: 'Default Space',
+      description: 'Basic space combat configuration',
+      currentEnvironment: 'space',
+      builds: {
+        space: {
+          keys: {
+            Space: [
+              {
+                command: 'Target_Enemy_Near',
+                type: 'targeting',
+                icon: '🎯',
+                text: 'Target nearest enemy',
+                id: 'cmd_1',
+              },
+              {
+                command: 'FireAll',
+                type: 'combat',
+                icon: '🔥',
+                text: 'Fire all weapons',
+                id: 'cmd_2',
+              },
+            ],
+          },
+          aliases: {
+            AttackCall: {
+              description: 'Call out attack target to team',
+              commands: 'team Attacking [$Target] - focus fire!',
+            },
+            TargetReport: {
+              description: 'Report current target to team',
+              commands: 'team Current target: [$Target]',
+            },
+            HealCall: {
+              description: 'Request healing for target',
+              commands: 'team Need healing on [$Target]!',
+            },
+          },
+        },
+        ground: {
+          keys: {
+            Space: [
+              {
+                command: 'Target_Enemy_Near',
+                type: 'targeting',
+                icon: '🎯',
+                text: 'Target nearest enemy',
+                id: 'cmd_g1',
+              },
+              {
+                command: '+STOTrayExecByTray 0 0',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Primary attack',
+                id: 'cmd_g2',
+              },
+            ],
+          },
+          aliases: {},
+        },
+      },
+    },
+    tactical_space: {
+      name: 'Tactical Space',
+      description: 'Aggressive DPS-focused space build',
+      currentEnvironment: 'space',
+      builds: {
+        space: {
+          keys: {
+            Space: [
+              {
+                command: 'Target_Enemy_Near',
+                type: 'targeting',
+                icon: '🎯',
+                text: 'Target nearest enemy',
+                id: 'cmd_1',
+              },
+              {
+                command: '+STOTrayExecByTray 0 0',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Execute Tray 1 Slot 1',
+                id: 'cmd_2',
+              },
+              {
+                command: 'FireAll',
+                type: 'combat',
+                icon: '🔥',
+                text: 'Fire all weapons',
+                id: 'cmd_3',
+              },
+              {
+                command: '+power_exec Distribute_Shields',
+                type: 'power',
+                icon: '🛡️',
+                text: 'Distribute shields',
+                id: 'cmd_4',
+              },
+            ],
+            1: [
+              {
+                command: '+STOTrayExecByTray 1 0',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Execute Tray 2 Slot 1',
+                id: 'cmd_5',
+              },
+            ],
+            F1: [
+              {
+                command: 'Target_Self',
+                type: 'targeting',
+                icon: '👤',
+                text: 'Target self',
+                id: 'cmd_6',
+              },
+              {
+                command: '+STOTrayExecByTray 2 0',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Execute Tray 3 Slot 1',
+                id: 'cmd_7',
+              },
+            ],
+          },
+          aliases: {},
+        },
+        ground: {
+          keys: {
+            Space: [
+              {
+                command: 'Target_Enemy_Near',
+                type: 'targeting',
+                icon: '🎯',
+                text: 'Target nearest enemy',
+                id: 'cmd_g1',
+              },
+              {
+                command: '+STOTrayExecByTray 0 0',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Primary attack',
+                id: 'cmd_g2',
+              },
+            ],
+            1: [
+              {
+                command: '+STOTrayExecByTray 0 1',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Secondary attack',
+                id: 'cmd_g3',
+              },
+            ],
+            F1: [
+              {
+                command: 'Target_Self',
+                type: 'targeting',
+                icon: '👤',
+                text: 'Target self',
+                id: 'cmd_g4',
+              },
+              {
+                command: '+STOTrayExecByTray 1 0',
+                type: 'tray',
+                icon: '💊',
+                text: 'Heal self',
+                id: 'cmd_g5',
+              },
+            ],
+          },
+          aliases: {},
+        },
+      },
+    },
+  },
+  keys: {
+    common: {
+      name: 'Common Keys',
+      description: 'Most frequently used keys',
+      keys: [
+        { key: 'Space', description: 'Spacebar' },
+        { key: '1', description: 'Number 1' },
+        { key: '2', description: 'Number 2' },
+        { key: '3', description: 'Number 3' },
+        { key: '4', description: 'Number 4' },
+        { key: '5', description: 'Number 5' },
+        { key: 'F1', description: 'Function Key 1' },
+        { key: 'F2', description: 'Function Key 2' },
+        { key: 'F3', description: 'Function Key 3' },
+        { key: 'F4', description: 'Function Key 4' },
+        { key: 'Tab', description: 'Tab' },
+        { key: 'enter', description: 'Main Enter Key' },
+        { key: 'Shift', description: 'Shift' },
+        { key: 'Control', description: 'Control' },
+        { key: 'ALT', description: 'Alt' },
+      ],
+    },
+    letters: {
+      name: 'Letter Keys',
+      description: 'A-Z keyboard letters',
+      keys: [
+        { key: 'A', description: 'Key A' },
+        { key: 'B', description: 'Key B' },
+        { key: 'C', description: 'Key C' },
+        { key: 'D', description: 'Key D' },
+        { key: 'E', description: 'Key E' },
+        { key: 'F', description: 'Key F' },
+        { key: 'G', description: 'Key G' },
+        { key: 'H', description: 'Key H' },
+        { key: 'I', description: 'Key I' },
+        { key: 'J', description: 'Key J' },
+        { key: 'K', description: 'Key K' },
+        { key: 'L', description: 'Key L' },
+        { key: 'M', description: 'Key M' },
+        { key: 'N', description: 'Key N' },
+        { key: 'O', description: 'Key O' },
+        { key: 'P', description: 'Key P' },
+        { key: 'Q', description: 'Key Q' },
+        { key: 'R', description: 'Key R' },
+        { key: 'S', description: 'Key S' },
+        { key: 'T', description: 'Key T' },
+        { key: 'U', description: 'Key U' },
+        { key: 'V', description: 'Key V' },
+        { key: 'W', description: 'Key W' },
+        { key: 'X', description: 'Key X' },
+        { key: 'Y', description: 'Key Y' },
+        { key: 'Z', description: 'Key Z' },
+      ],
+    },
+    numbers: {
+      name: 'Number Keys',
+      description: 'Number row and numpad',
+      keys: [
+        { key: '0', description: 'Number 0' },
+        { key: '6', description: 'Number 6' },
+        { key: '7', description: 'Number 7' },
+        { key: '8', description: 'Number 8' },
+        { key: '9', description: 'Number 9' },
+        { key: 'numpad0', description: 'Numerical Keypad 0' },
+        { key: 'numpad1', description: 'Numerical Keypad 1' },
+        { key: 'numpad2', description: 'Numerical Keypad 2' },
+        { key: 'numpad3', description: 'Numerical Keypad 3' },
+        { key: 'numpad4', description: 'Numerical Keypad 4' },
+        { key: 'numpad5', description: 'Numerical Keypad 5' },
+        { key: 'numpad6', description: 'Numerical Keypad 6' },
+        { key: 'numpad7', description: 'Numerical Keypad 7' },
+        { key: 'numpad8', description: 'Numerical Keypad 8' },
+        { key: 'numpad9', description: 'Numerical Keypad 9' },
+        { key: 'Decimal', description: 'Numerical Keypad Decimal' },
+        { key: 'Divide', description: 'Numerical Keypad Divide' },
+        { key: 'Multiply', description: 'Multiply (*)' },
+        { key: 'Subtract', description: 'Subtract (-)' },
+        { key: 'Add', description: 'Add (+)' },
+        { key: 'numpadenter', description: 'Numerical Keypad Enter' },
+      ],
+    },
+    function: {
+      name: 'Function Keys',
+      description: 'F1-F24 function keys',
+      keys: [
+        { key: 'F5', description: 'Function Key 5' },
+        { key: 'F6', description: 'Function Key 6' },
+        { key: 'F7', description: 'Function Key 7' },
+        { key: 'F8', description: 'Function Key 8' },
+        { key: 'F9', description: 'Function Key 9' },
+        { key: 'F10', description: 'Function Key 10' },
+        { key: 'F11', description: 'Function Key 11' },
+        { key: 'F12', description: 'Function Key 12' },
+        { key: 'F13', description: 'Function Key 13' },
+        { key: 'F14', description: 'Function Key 14' },
+        { key: 'F15', description: 'Function Key 15' },
+        { key: 'F16', description: 'Function Key 16' },
+        { key: 'F17', description: 'Function Key 17' },
+        { key: 'F18', description: 'Function Key 18' },
+        { key: 'F19', description: 'Function Key 19' },
+        { key: 'F20', description: 'Function Key 20' },
+        { key: 'F21', description: 'Function Key 21' },
+        { key: 'F22', description: 'Function Key 22' },
+        { key: 'F23', description: 'Function Key 23' },
+        { key: 'F24', description: 'Function Key 24' },
+      ],
+    },
+    arrows: {
+      name: 'Arrow & Navigation',
+      description: 'Arrow keys and navigation',
+      keys: [
+        { key: 'Up', description: 'Arrow Key: Up' },
+        { key: 'Down', description: 'Arrow Key: Down' },
+        { key: 'Left', description: 'Arrow Key: Left' },
+        { key: 'Right', description: 'Arrow Key: Right' },
+        { key: 'Home', description: 'Home' },
+        { key: 'End', description: 'End' },
+        { key: 'PageUp', description: 'Page Up' },
+        { key: 'PageDown', description: 'Page Down' },
+        { key: 'insert', description: 'Insert' },
+        { key: 'delete', description: 'Delete' },
+      ],
+    },
+    modifiers: {
+      name: 'Modifier Keys',
+      description: 'Shift, Ctrl, Alt variations',
+      keys: [
+        { key: 'LALT', description: 'Alt (Left)' },
+        { key: 'RALT', description: 'Alt (Right)' },
+        { key: 'LCTRL', description: 'Control (Left)' },
+        { key: 'RCTRL', description: 'Control (Right)' },
+      ],
+    },
+    symbols: {
+      name: 'Symbol Keys',
+      description: 'Punctuation and symbols',
+      keys: [
+        { key: '[', description: '[' },
+        { key: ']', description: ']' },
+        { key: '\\', description: '\\' },
+        { key: ',', description: 'Comma (,)' },
+        { key: '.', description: 'Period (.)' },
+        { key: '/', description: 'Divide (/)' },
+        { key: '`', description: 'Tilda Key (~)' },
+      ],
+    },
+    mouse: {
+      name: 'Mouse Controls',
+      description: 'Mouse buttons and scroll',
+      keys: [
+        { key: 'Lbutton', description: 'Mouse Left Press' },
+        { key: 'Rbutton', description: 'Mouse Right Press' },
+        { key: 'Middleclick', description: 'Mouse Middle Click' },
+        { key: 'Button1', description: 'Mouse Button 1' },
+        { key: 'Button2', description: 'Mouse Button 2' },
+        { key: 'Button3', description: 'Mouse Button 3' },
+        { key: 'Button4', description: 'Mouse Button 4' },
+        { key: 'Button5', description: 'Mouse Button 5' },
+        { key: 'Button6', description: 'Mouse Button 6' },
+        { key: 'Button7', description: 'Mouse Button 7' },
+        { key: 'Button8', description: 'Mouse Button 8' },
+        { key: 'Button9', description: 'Mouse Button 9' },
+        { key: 'Button10', description: 'Mouse Button 10' },
+        { key: 'Wheelplus', description: 'Mouse Scroll Up' },
+        { key: 'Wheelminus', description: 'Mouse Scroll Down' },
+      ],
+    },
+    gamepad: {
+      name: 'Xbox Controller',
+      description: 'Xbox/Gamepad controls',
+      keys: [
+        { key: 'Joy1', description: 'XBOX Contr [Start]' },
+        { key: 'Joy2', description: 'XBOX Contr [Back]' },
+        { key: 'Joy3', description: 'XBOX Contr [L Thumb depress]' },
+        { key: 'Joy4', description: 'XBOX Contr [R Thumb depress]' },
+        { key: 'Joy5', description: 'XBOX Contr [Left Bumper]' },
+        { key: 'Joy6', description: 'XBOX Contr [Right Bumper]' },
+        { key: 'Joy7', description: 'XBOX Contr [Left Trigger]' },
+        { key: 'Joy8', description: 'XBOX Contr [Right Trigger]' },
+        { key: 'Joy9', description: 'XBOX Contr [A Button]' },
+        { key: 'Joy10', description: 'XBOX Contr [B Button]' },
+        { key: 'Joy11', description: 'XBOX Contr [X Button]' },
+        { key: 'Joy12', description: 'XBOX Contr [Y Button]' },
+        { key: 'Joypad_up', description: 'XBOX Contr [Pad up]' },
+        { key: 'Joypad_down', description: 'XBOX Contr [Pad down]' },
+        { key: 'Joypad_left', description: 'XBOX Contr [Pad left]' },
+        { key: 'Joypad_right', description: 'XBOX Contr [Pad right]' },
+        { key: 'Lstick_up', description: 'XBOX Contr [Left Stick up]' },
+        { key: 'Lstick_down', description: 'XBOX Contr [Left Stick down]' },
+        { key: 'Lstick_left', description: 'XBOX Contr [Left Stick left]' },
+        { key: 'Lstick_right', description: 'XBOX Contr [Left Stick right]' },
+        { key: 'Rstick_up', description: 'XBOX Contr [Right Stick up]' },
+        { key: 'Rstick_down', description: 'XBOX Contr [Right Stick down]' },
+        { key: 'Rstick_left', description: 'XBOX Contr [Right Stick left]' },
+        { key: 'Rstick_right', description: 'XBOX Contr [Right Stick right]' },
+      ],
+    },
+  },
+  validation: {
+    keyNamePattern: /^[a-zA-Z0-9_+\-\s]+$/,
+    aliasNamePattern: /^[a-zA-Z_][a-zA-Z0-9_]*$/,
+    maxCommandsPerKey: 20,
+    maxKeysPerProfile: 100,
+  },
+  settings: {
+    version: '1.0.0',
+    autoSave: !0,
+    maxUndoSteps: 50,
+    defaultMode: 'space',
+  },
+  variables: {
+    target: {
+      variable: '$Target',
+      description: 'Replaced with the name of your current target',
+      example: 'team Target [$Target]',
+      usableIn: ['communication', 'custom', 'aliases'],
+      notes:
+        "If your target's name is 'froggyMonster', this will output 'Target [froggyMonster]'",
+    },
+  },
+}
+;(window.STO_DATA = r),
+  (window.COMMAND_CATEGORIES = r.commands),
+  (window.COMMANDS = {}),
+  Object.entries(r.commands).forEach(([e, t]) => {
+    Object.entries(t.commands).forEach(([t, a]) => {
+      window.COMMANDS[t] = { ...a, category: e, key: t }
+    })
+  }),
+  (window.KEY_LAYOUTS = r.keyLayouts || {
+    qwerty: {
+      name: 'QWERTY',
+      rows: [
+        [
+          { key: 'Escape', display: 'Esc' },
+          { key: 'F1', display: 'F1' },
+          { key: 'F2', display: 'F2' },
+          { key: 'F3', display: 'F3' },
+          { key: 'F4', display: 'F4' },
+          { key: 'F5', display: 'F5' },
+          { key: 'F6', display: 'F6' },
+          { key: 'F7', display: 'F7' },
+          { key: 'F8', display: 'F8' },
+          { key: 'F9', display: 'F9' },
+          { key: 'F10', display: 'F10' },
+          { key: 'F11', display: 'F11' },
+          { key: 'F12', display: 'F12' },
+        ],
+        [
+          { key: '`', display: '`' },
+          { key: '1', display: '1' },
+          { key: '2', display: '2' },
+          { key: '3', display: '3' },
+          { key: '4', display: '4' },
+          { key: '5', display: '5' },
+          { key: '6', display: '6' },
+          { key: '7', display: '7' },
+          { key: '8', display: '8' },
+          { key: '9', display: '9' },
+          { key: '0', display: '0' },
+          { key: '-', display: '-' },
+          { key: '=', display: '=' },
+          { key: 'Backspace', display: 'Backspace' },
+        ],
+        [
+          { key: 'Tab', display: 'Tab' },
+          { key: 'Q', display: 'Q' },
+          { key: 'W', display: 'W' },
+          { key: 'E', display: 'E' },
+          { key: 'R', display: 'R' },
+          { key: 'T', display: 'T' },
+          { key: 'Y', display: 'Y' },
+          { key: 'U', display: 'U' },
+          { key: 'I', display: 'I' },
+          { key: 'O', display: 'O' },
+          { key: 'P', display: 'P' },
+          { key: '[', display: '[' },
+          { key: ']', display: ']' },
+          { key: '\\', display: '\\' },
+        ],
+        [
+          { key: 'CapsLock', display: 'Caps' },
+          { key: 'A', display: 'A' },
+          { key: 'S', display: 'S' },
+          { key: 'D', display: 'D' },
+          { key: 'F', display: 'F' },
+          { key: 'G', display: 'G' },
+          { key: 'H', display: 'H' },
+          { key: 'J', display: 'J' },
+          { key: 'K', display: 'K' },
+          { key: 'L', display: 'L' },
+          { key: ';', display: ';' },
+          { key: "'", display: "'" },
+          { key: 'Enter', display: 'Enter' },
+        ],
+        [
+          { key: 'Shift', display: 'Shift' },
+          { key: 'Z', display: 'Z' },
+          { key: 'X', display: 'X' },
+          { key: 'C', display: 'C' },
+          { key: 'V', display: 'V' },
+          { key: 'B', display: 'B' },
+          { key: 'N', display: 'N' },
+          { key: 'M', display: 'M' },
+          { key: ',', display: ',' },
+          { key: '.', display: '.' },
+          { key: '/', display: '/' },
+          { key: 'Shift', display: 'Shift' },
+        ],
+        [
+          { key: 'Ctrl', display: 'Ctrl' },
+          { key: 'Alt', display: 'Alt' },
+          { key: 'Space', display: 'Space' },
+          { key: 'Alt', display: 'Alt' },
+          { key: 'Ctrl', display: 'Ctrl' },
+        ],
+      ],
+    },
+  }),
+  (window.DEFAULT_SETTINGS = {
+    keyLayout: 'qwerty',
+    autoSave: r.settings?.autoSave || !0,
+    showTooltips: !0,
+    exportFormat: 'txt',
+    maxUndoSteps: r.settings?.maxUndoSteps || 50,
+    defaultMode: r.settings?.defaultMode || 'space',
+  }),
+  (window.SAMPLE_PROFILES = Object.values(r.defaultProfiles).map((e) => ({
+    id: e.name.toLowerCase().replace(/\s+/g, '_'),
+    name: e.name,
+    description: e.description,
+    currentEnvironment: e.currentEnvironment || 'space',
+    builds: e.builds || { space: { keys: {} }, ground: { keys: {} } },
+    mode: e.currentEnvironment || 'space',
+    keybinds: e.builds?.space?.keys || {},
+    aliases: e.builds?.space?.aliases || {},
+    created: new Date().toISOString(),
+    modified: new Date().toISOString(),
+  }))),
+  (window.SAMPLE_ALIASES = {
+    attack_sequence: {
+      name: 'Attack Sequence',
+      commands: ['Target_Enemy_Near', 'FireAll'],
+      description: 'Target and attack nearest enemy',
+    },
+    defensive_sequence: {
+      name: 'Defensive Sequence',
+      commands: ['Target_Self', '+power_exec Distribute_Shields'],
+      description: 'Self-target and activate defensive abilities',
+    },
+    heal_sequence: {
+      name: 'Healing Sequence',
+      commands: [
+        'Target_Self',
+        '+STOTrayExecByTray 3 0 $$ +STOTrayExecByTray 3 1',
+      ],
+      description: 'Emergency healing and repair sequence',
+    },
+  }),
+  (window.TRAY_CONFIG = {
+    maxTrays: 10,
+    slotsPerTray: 10,
+    defaultTray: 0,
+    maxCommandsPerSlot: 1,
+  }),
+  (window.getCommandsByCategory = function (e) {
+    return e && r.commands[e] ? Object.values(r.commands[e].commands) : []
+  })
+class s extends Error {
+  constructor(e, t = 'STO_ERROR') {
+    super(e), (this.name = 'STOError'), (this.code = t)
+  }
+}
+class c extends s {
+  constructor(e, t = 'VFX_ERROR') {
+    super(e, t), (this.name = 'VertigoError')
+  }
+}
+'undefined' != typeof window &&
+  ((window.STOError = s),
+  (window.VertigoError = c),
+  (window.InvalidEnvironmentError = class extends c {
+    constructor(e) {
+      super(
+        `Invalid environment '${e}'. Valid environments are: space, ground`,
+        'INVALID_ENVIRONMENT'
+      ),
+        (this.environment = e)
+    }
+  }),
+  (window.InvalidEffectError = class extends c {
+    constructor(e, t) {
+      super(`Invalid effect '${e}' for environment '${t}'`, 'INVALID_EFFECT'),
+        (this.effectName = e),
+        (this.environment = t)
+    }
+  }))
+const l = new Proxy(
+    {
+      currentProfile: null,
+      currentMode: 'space',
+      currentEnvironment: 'space',
+      selectedKey: null,
+      isModified: !1,
+      undoStack: [],
+      redoStack: [],
+      maxUndoSteps: 50,
+      commandIdCounter: 0,
+    },
+    {
+      set: (e, t, a) => (
+        (e[t] = a), i && i.emit && i.emit(`store:${t}`, a), !0
+      ),
+    }
+  ),
+  d = {
+    space: [
+      {
+        label: 'Advanced inhibiting turret shield bubble',
+        effect: 'Fx_Rep_Temporal_Ship_Chroniton_Stabilization_Proc',
+      },
+      {
+        label: 'Approaching Agony',
+        effect: 'Cfx_Lockboxfx_Cb29_Ship_Agony_Field',
+      },
+      {
+        label: 'Attack Pattern Alpha',
+        effect: 'Fx_Ship_Tac_Attackpatternalpha',
+      },
+      { label: 'Attack Pattern Beta', effect: 'Fx_Ship_Tac_Attackpatternbeta' },
+      {
+        label: 'Attack Pattern Delta',
+        effect: 'Fx_Ship_Tac_Attackpatterndelta',
+      },
+      {
+        label: 'Attack Pattern Omega',
+        effect: 'Fx_Ship_Tac_Attackpatternomega',
+      },
+      {
+        label: 'Beacon of Kahless',
+        effect: 'Fx_Er_Bbs_Beacon_Of_Kahless_Flash',
+      },
+      {
+        label: 'Boost Morale',
+        effect:
+          'Fx_Ship_Spec_Powers_Command_Boost_Morale_Bufffx,Cfx_Ship_Spec_Powers_Command_Boost_Morale_Activate',
+      },
+      {
+        label: 'Brace for Impact',
+        effect: 'Fx_Bop_Braceforimpact,Cfx_Ship_Sci_Hazardemitter_Buff',
+      },
+      {
+        label: 'Breath of the Dragon',
+        effect: 'Fx_Ship_Cp_T6_Hysperian_Dragonbreath',
+      },
+      {
+        label: 'Call Emergency Artillery',
+        effect:
+          'Fx_Ships_Boffs_Cmd_Callartillery_Activate,Fx_Ships_Boffs_Cmd_Callartillery_Explosion',
+      },
+      {
+        label: 'Competitive Engine Buff Effect',
+        effect: 'Fx_Ship_Mod_Haste_Buff_Gen',
+      },
+      {
+        label: 'Co-opt Energy Weapons',
+        effect:
+          'Fx_Capt_Powers_Ship_Sci_Coopt_Energy_Wep_Aoe,Cfx_Capt_Powers_Ship_Sci_Coopt_Energy_Wep_Area',
+      },
+      {
+        label: 'Concentrate Fire Power',
+        effect:
+          'Fx_Ships_Boff_Cmd_Confire_Activatefx,Cfx_Ships_Boff_Cmd_Confire_Mark',
+      },
+      {
+        label: 'Cnidarian Jellyfish AoE',
+        effect: 'Cfx_Ship_Sp_T6_Jellyfish_Cnidarian_Defense_Aoe',
+      },
+      {
+        label: 'Dark Matter Anomaly',
+        effect: 'Cfx_Ship_Console_Dark_Matter_Anamoly_Costumefx',
+      },
+      { label: 'Delphic Tear', effect: 'Fx_Ships_Consoles_Cb21_Delphictear' },
+      {
+        label: 'Destabilising Resonance Beam',
+        effect: 'P_Er_Ship_Destabilizing_Resonance_Beam_Aoe_Particles',
+      },
+      {
+        label: 'Elachi Walker Combat Pet (3 effects)',
+        effect:
+          'Soundfx_Elachiwalker_Footstep_Pet,Fx_Er_Tfo_Elachi_Walker_Combat_Pet_Deathfx,Soundfx_Elachiwalker_Petsummon',
+      },
+      {
+        label: 'Electrified Anomalies Trait',
+        effect:
+          'Fx_Tp_Ship_T6_Risian_Science_Electrified_Anomalies_Arc_Foe,Fx_Tp_Ship_T6_Risian_Science_Electrified_Anomalies_Arc_Friend',
+      },
+      {
+        label: 'Emergency Pwr to Shields',
+        effect: 'Fx_Ship_Eng_Emergencypowershields',
+      },
+      {
+        label: 'Emergency Pwr to Wep',
+        effect: 'Fx_Ship_Eng_Emergencypowerweapons',
+      },
+      {
+        label: 'Engineering Fleet III',
+        effect: 'Fx_Ship_Boff_Fleet_Capt_Engineering_Teambuff',
+      },
+      {
+        label: 'Engineering Team',
+        effect: 'Cfx_Ship_Crewteam_Engineeringteam_Buff',
+      },
+      {
+        label: 'EPS Power Transfer',
+        effect: 'Cfx_Ship_Eng_Epspowertransfer_Target',
+      },
+      { label: 'Focus Frenzy', effect: 'Fx_Skilltree_Ship_Ffrenzy_Activatefx' },
+      { label: 'Go Down Fighting', effect: 'Fx_Bop_Godownfighting' },
+      { label: 'Hangar Pet Rank Up', effect: 'Fx_Ship_Levelup_Fighter_Rankup' },
+      { label: 'Hazard Emitters', effect: 'Cfx_Ship_Sci_Hazardemitter_Buff' },
+      {
+        label: 'Intel Fleet III',
+        effect: 'Fx_Ship_Boff_Fleet_Capt_Intel_Teambuff',
+      },
+      {
+        label: 'Intel Team (uses 3 effects)',
+        effect:
+          'Cfx_Ship_Cruiser_Auras_Taunt,Cfx_Spc_Boffpowers_Intel_Intelteam_Buff,Fx_Ships_Intel_Lyinginwait',
+      },
+      {
+        label: 'Kemocite on ship animation',
+        effect: 'C1_E_Ship_Xindi_Lockboxcb15_Kemocite_Weaponry_Bufffx',
+      },
+      {
+        label: 'Kemocite HitFX ring',
+        effect: 'Fx_Ship_Xindi_Lockboxcb15_Kemocite_Weaponry_Aoe_Proc',
+      },
+      {
+        label: 'Kentari Ferocity Weapons Glow',
+        effect:
+          'P_Trait_Powers_Ship_Lukari_Colony_Kentari_Ferocity_Weapons_Glow',
+      },
+      {
+        label: 'Kobayashi Maru powerup silenced',
+        effect:
+          'Fx_Evr_Kmaru_Ship_Dev_Resupply_Drop_Powerup_Bufffx,Fx_Evr_Kmaru_Ship_Dev_Resupply_Drop_Powerup',
+      },
+      {
+        label: 'Less Obvious Loot Drop Common',
+        effect: 'Cfx_Space_Loot_Drop_Common_Costumefx',
+      },
+      {
+        label: 'Less Obvious Loot Drop Uncommon',
+        effect: 'Cfx_Space_Loot_Drop_Uncommon_Costumefx',
+      },
+      {
+        label: 'Less Obvious Loot Drop Rare',
+        effect: 'Cfx_Space_Loot_Drop_Rare_Costumefx',
+      },
+      {
+        label: 'Less Obvious Loot Drop Very Rare',
+        effect: 'Cfx_Space_Loot_Drop_Veryrare_Costumefx',
+      },
+      {
+        label: 'Less Obvious Loot Drop Lock Box',
+        effect: 'Cfx_Space_Loot_Drop_Chancebox_Costumefx',
+      },
+      {
+        label: 'Less Obvious Loot Drop Dilithium',
+        effect: 'Cfx_Space_Loot_Drop_Dilithium_Costumefx',
+      },
+      { label: 'Miraculous Repairs', effect: 'Fx_Bop_Miracleworker' },
+      {
+        label: 'MW - Align Shield Frequencies',
+        effect: 'Fx_Spc_Boffpowers_Miracleworker_Alignshieldfrequencies_Hitfx',
+      },
+      {
+        label: 'MW - Destabilize Warp Core',
+        effect: 'Fx_Spc_Boffpowers_Miracleworker_Destabilizewarpcore',
+      },
+      {
+        label: 'MW - Exceed rated limits',
+        effect:
+          'Fx_Spc_Boffpowers_Miracleworker_Energyweaponsexceedratedlimits_Dot_Hitfx,Fx_Spc_Boffpowers_Miracleworker_Energyweaponsexceedratedlimits',
+      },
+      {
+        label: 'MW - Fix em up (and other green glows)',
+        effect: 'Fx_Ship_Mod_Damage_Buff',
+      },
+      {
+        label: 'MW - Mixed Armaments Synergy',
+        effect: 'Fx_Spc_Boffpowers_Miracleworker_Mixedarmamentssynergy',
+      },
+      {
+        label: 'MW - Narrow Sensor Bands',
+        effect: 'Fx_Spc_Boffpowers_Miracleworker_Narrowsensorbands',
+      },
+      {
+        label: 'MW - Null Pointer Flood',
+        effect: 'Fx_Spc_Boffpowers_Miracleworker_Nullpointerflood',
+      },
+      {
+        label: 'MW - Reroute shilds to Hull containment',
+        effect:
+          'Fx_Spc_Boffpowers_Miracleworker_Rerouteshieldstohullcontainment,Cfx_Spc_Boffpowers_Miracleworker_Rerouteshieldstohullcontainment',
+      },
+      { label: 'Nadion Inversion', effect: 'Fx_Bop_Nadioinversion' },
+      {
+        label: 'Nanoprobe Shield Generator (Dyson Rep)',
+        effect: 'Cfx_Rp_Dyson_Ship_Reactive_Shielding',
+      },
+      {
+        label: 'Neutronic Eddies',
+        effect: 'Cfx_Ships_Cp_T6_Risian_Science_Neutronic_Edides_Costumefx',
+      },
+      {
+        label: 'Overwhelm Emitters',
+        effect: 'Fx_Ships_Boff_Cmd_Owemitters_Activatefx',
+      },
+      { label: 'Photonic Officer', effect: 'Fx_Bop_Photonicofficer_activate' },
+      {
+        label: 'PILOT - Clean Getaway',
+        effect: 'Fx_Spc_Boff_Pilot_Cleangetaway_Activate',
+      },
+      {
+        label: 'PILOT - Coolant Ignition (mostly)',
+        effect:
+          'Fx_Spc_Boff_Pilot_Coolantinjection_Ignite,Fx_Spc_Boff_Pilot_Coolantinjection_Costumefx',
+      },
+      {
+        label: 'PILOT - Deploy Countermeasures',
+        effect: 'Fx_Spc_Boff_Pilot_Deploycm',
+      },
+      {
+        label: 'PILOT - Fly her apart',
+        effect: 'Cfx_Spc_Boff_Pilot_Flyapart_Dot',
+      },
+      {
+        label: 'PILOT - Form Up (mostly)',
+        effect:
+          'Fx_Spc_Boff_Pilot_Formup_Teleport,Fx_Spc_Boff_Pilot_Formup_Buff_Wepbuff',
+      },
+      {
+        label: 'PILOT - hold Together',
+        effect: 'Cfx_Spc_Boff_Pilot_Holdtogether',
+      },
+      {
+        label: 'PILOT - Lambda',
+        effect:
+          'Fx_Ship_Mod_Damage_Buff,Fx_Spc_Boff_Pilot_Aplambda_Bufffx,Fx_Spc_Boff_Pilot_Aplambda',
+      },
+      {
+        label: 'PILOT - Lock Trajectory',
+        effect:
+          'Fx_Spc_Boff_Pilot_Flares_Switch,Cfx_Spc_Boff_Pilot_Locktrajectory',
+      },
+      {
+        label: 'PILOT - Pilot Team',
+        effect: 'Cfx_Spc_Boff_Pilot_Pilotteam_Buff',
+      },
+      {
+        label: 'PILOT - Reroute Reserves to Weapons',
+        effect:
+          'Fx_Spc_Boff_Pilot_Reroute_Wepbuff,Fx_Spc_Boff_Pilot_Reroute_Activate',
+      },
+      {
+        label: 'PILOT - Subspace Boom',
+        effect:
+          'Cfx_Spc_Boff_Pilot_Ssboom_Costumefx_Neverdie,Fx_Spc_Boff_Pilot_Ssboom_Boom',
+      },
+      {
+        label: 'Plasma Storm',
+        effect: 'Cfx_Ship_Cp_Cb27_Generate_Plasma_Storm_Costumefx',
+      },
+      {
+        label: 'Rally Point Marker',
+        effect: 'Cfx_Ships_Boff_Cmd_Rallypoint_Marker',
+      },
+      {
+        label: 'Reverse Shield Polarity',
+        effect: 'Cfx_Ship_Eng_Reverseshieldpolarity_Buff',
+      },
+      {
+        label: 'Scattering Field',
+        effect:
+          'Cfx_Ship_Sci_Dampeningfield_Aoe,Cfx_Ship_Sci_Dampeningfield_Shield_Buff',
+      },
+      { label: 'Science Team', effect: 'Cfx_Ship_Crewteam_Scienceteam_Buff' },
+      {
+        label: 'Science Fleet III',
+        effect: 'Fx_Ship_Boff_Fleet_Capt_Science_Teambuff',
+      },
+      {
+        label: 'Soliton Wave Generator (uses 4 effects)',
+        effect:
+          'Cfx_Ship_Risa_Loot_Soliton_Wave_Suckfx_Target,Cfx_Ship_Risa_Loot_Soliton_Wave_Suckfx,Cfx_Ship_Risa_Loot_Soliton_Wave_Out,Cfx_Ship_Risa_Loot_Soliton_Wave_In',
+      },
+      {
+        label: 'Spore Infused Anomalies',
+        effect: 'Fx_Trait_Powers_Ship_T6_Somerville_Sia_Blast',
+      },
+      {
+        label: 'Subspace Vortex Teleport Effect',
+        effect: 'Fx_Ship_Xindi_Lockboxcb15_Subspace_Vortex_Teleport',
+      },
+      {
+        label: 'Suppression Barrage',
+        effect: 'Cfx_Ships_Boff_Cmd_Sbarrage_Buff',
+      },
+      {
+        label: 'Surgical Strikes',
+        effect: 'Fx_Spc_Boffpowers_Int_Sstrikes_Buff',
+      },
+      {
+        label: 'Tactical Fleet III',
+        effect: 'Fx_Ship_Boff_Fleet_Capt_Tactical_Teambuff',
+      },
+      { label: 'Tactical Initiative', effect: 'Fx_Bop_Tacticalinitiative' },
+      { label: 'Tactical Team', effect: 'Cfx_Ship_Crewteam_Tacticalteam_Buff' },
+      {
+        label: 'Target Rich Environment',
+        effect: 'Fx_Ship_Trait_Cb20_Targetrichenvironment',
+      },
+      {
+        label: 'Temporal Anchor',
+        effect: 'Cfx_Ship_Trait_Temporal_Anchor_Costumefx',
+      },
+      {
+        label: 'Temporal Vortex Probe',
+        effect:
+          'C1_Eventreward_Fcd_Temporal_Vortex_Costumefx,Fx_Eventreward_Fcd_Temporal_Vortex_Blast',
+      },
+      {
+        label: 'Timeline Collapse (5 effects!)',
+        effect:
+          'Cfx_Ship_Temp_Tcollapse_Costume,Fx_Ship_Temp_Tcollapse_Hitfx,Fx_Ship_Temp_Tcollapse_Explode,Fx_Ship_Temp_Tcollapse_Beamhitfx,Fx_Ship_Temp_Tcollapse',
+      },
+      {
+        label: "V'Ger Torpedo (Volatile Digital Transformation)",
+        effect:
+          'Fx_Ship_Torpedo_Plasma_Vger_Anniv_Explode,Cfx_Ship_Torpedo_Vger_Disintegrate_In_Tintable',
+      },
+      {
+        label: 'Viral Impulse Burst',
+        effect: 'Fx_Spc_Boffpowers_int_Viralimpulse',
+      },
+      {
+        label: 'Vulcan Jelly Fish Eject Red Matter',
+        effect: 'Cfx_ship_jellyfish_eject_red_matter_costumefx',
+      },
+      {
+        label: 'Vulnerability Assessment Sweep',
+        effect: 'Fx_Capt_Powers_Ship_Tac_Vulnerability_Assessment_Sweep',
+      },
+    ],
+    ground: [
+      {
+        label: 'Agony Field Generator',
+        effect: 'Fx_Ground_Lockboxfx_Cb29_Agony_Field_Generator',
+      },
+      {
+        label: 'Anti-time ground',
+        effect:
+          'Cfx_Rep_Temp_Char_Kit_Sci_Antitime_Entanglement_Field_Costumefx',
+      },
+      {
+        label: 'Ball Lightning',
+        effect: 'Cfx_Char_Kit_Univ_Sum_Ball_Lightning_Costumefx',
+      },
+      { label: 'Chaos Blaze', effect: 'Cfx_Char_Chaos_Blaze_Aoe' },
+      {
+        label: 'Conussive Tachyon Emission',
+        effect: 'fx_Char_Delta_Rep_Cte_Aoe',
+      },
+      { label: 'Disco Ball (Party Bomb)', effect: 'Cfx_Char_Device_Partybomb' },
+      {
+        label: 'Dot-7 Drone Support Field',
+        effect: 'Cfx_Er_Bbs_char_Dot7_Drone_support_Field',
+      },
+      {
+        label: 'Eng Proficiency (Character Glow)',
+        effect: 'Cfx_Ground_Kit_Eng_Engineeringproficiency',
+      },
+      {
+        label: 'Ever Watchful',
+        effect:
+          'Cfx_Ground_Kit_Tac_Overwatch_Bufffx,Fx_Ground_Kit_Tac_Overwatch_Activatefx',
+      },
+      {
+        label: 'Herald AP Beam Projector ground weapon',
+        effect:
+          'Fx_Char_Icoenergy_Rifle_Energyblast,Fx_Char_Icoenergy_Assault_Beam_Lockbox',
+      },
+      {
+        label: 'Lava Floor',
+        effect:
+          'Cfx_Char_Kit_Univ_Sum_The_Floor_Is_Lava_Costumefx,Cfx_Char_Kit_Univ_Sum_The_Floor_Is_Lava_Geyser',
+      },
+      {
+        label: 'Less Obvious Loot Drop Common',
+        effect: 'Cfx_Gnd_Loot_Drop_Common_Costumefx',
+      },
+      {
+        label: 'Less Obvious Loot Drop Uncommon',
+        effect: 'Cfx_Gnd_Loot_Drop_Uncommon_Costumefx',
+      },
+      {
+        label: 'Less Obvious Loot Drop Rare',
+        effect: 'Cfx_Gnd_Loot_Drop_Rare_Costumefx',
+      },
+      {
+        label: 'Less Obvious Loot Drop Very Rare',
+        effect: 'Cfx_Gnd_Loot_Drop_Veryrare_Costumefx',
+      },
+      {
+        label: 'Less Obvious Loot Drop Lock Box',
+        effect: 'Cfx_Gnd_Loot_Drop_Chancebox_Costumefx',
+      },
+      {
+        label: 'Less Obvious Loot Drop Dilithium',
+        effect: 'Cfx_Gnd_Loot_Drop_Dilithium_Costumefx',
+      },
+      {
+        label: 'Motivation (Tac Kit Module)',
+        effect:
+          'Cfx_Ground_Kit_Tac_Motivation_Buff,Fx_Ground_Kit_Tac_Motivation',
+      },
+      {
+        label: 'Orbital Devastation',
+        effect: 'Fx_Char_Voth_Orbitalstrike_Chasebeam',
+      },
+      {
+        label: 'Pahvan Crystal Prism noisy tether',
+        effect: 'Cfx_Er_Tfo_Pahvan_Crystal_Prism_Tether_Beam',
+      },
+      { label: 'Rally Cry', effect: 'Fx_Ground_Kit_Tac_Rallycry' },
+      {
+        label: 'Red Riker Gun Sound effect',
+        effect: 'Cfx_Ep_Winterevent_Redriker_Sniper_Chargefx',
+      },
+      {
+        label: 'Scientific Aptitude (character glow)',
+        effect: 'Cfx_Ground_Kit_Sci_Scientificaptitude',
+      },
+      {
+        label: 'Solar Gateway',
+        effect: 'Fx_Char_Ico_Capt_Portal,Fx_Char_Ico_Capt_Portal_Sunbeam',
+      },
+      {
+        label: 'Smoke Grenade',
+        effect: 'Fx_Char_Grenade_smoke_costume,Fx_Char_Grenade_Smoke_Explode',
+      },
+      {
+        label: 'Sompek Energy Rebounder',
+        effect: 'Fx_Env_Gnd_Qadhos_Arena_Phaserhazard_Cylinder_Turret',
+      },
+      {
+        label: 'Strike Team III (character red glow)',
+        effect: 'Cfx_Ground_Kit_Tac_Striketeam',
+      },
+      {
+        label: 'Symphony of Lightning Char Glow',
+        effect: 'Fx_Er_Featured_Char_Kuumaarke_Wristgun_Tir_bufffx',
+      },
+      {
+        label: 'Symphony of Lightning Drone AoE',
+        effect:
+          'Cfx_Er_Featured_Char_Kuumaarke_Set_Symphony_Of_Lightning_Drone_Aoe',
+      },
+      {
+        label: 'Symphony of Lightning STRIKE',
+        effect:
+          'Fx_Er_Featured_Char_Kuumaarke_Set_Symphony_Of_Lightning_Strike',
+      },
+      {
+        label: 'Trajectory Bending',
+        effect: 'Cfx_Char_Xindi_Cb15_Tac_Kit_Trajectory_Bending',
+      },
+      {
+        label: 'Visual Dampening Field',
+        effect: 'Cfx_Char_Trait_Mirror_Vdfield',
+      },
+    ],
+  }
+document.addEventListener('DOMContentLoaded', () => {
+  const t = document.getElementById('appVersion')
+  t && (t.textContent = e)
+  const a = document.getElementById('aboutVersion')
+  a && (a.textContent = e)
+})
+const m = new (class {
+    constructor() {
+      ;(this.storageKey = 'sto_keybind_manager'),
+        (this.backupKey = 'sto_keybind_manager_backup'),
+        (this.settingsKey = 'sto_keybind_settings'),
+        (this.version = '1.0.0'),
+        this.init()
+    }
+    init() {
+      this.migrateData(), this.ensureStorageStructure()
+    }
+    getAllData() {
+      try {
+        const e = localStorage.getItem(this.storageKey),
+          t = localStorage.getItem('sto_app_reset')
+        if (!e)
+          return t
+            ? (localStorage.removeItem('sto_app_reset'), this.getEmptyData())
+            : this.getDefaultData()
+        const a = JSON.parse(e)
+        return this.isValidDataStructure(a) ? a : this.getDefaultData()
+      } catch (e) {
+        return (
+          console.error('Error loading data from storage:', e),
+          this.getDefaultData()
+        )
+      }
+    }
+    saveAllData(e) {
+      try {
+        this.createBackup()
+        const t = {
+          ...e,
+          version: this.version,
+          lastModified: new Date().toISOString(),
+          lastBackup: new Date().toISOString(),
+        }
+        return localStorage.setItem(this.storageKey, JSON.stringify(t)), !0
+      } catch (e) {
+        return console.error('Error saving data to storage:', e), !1
+      }
+    }
+    getProfile(e) {
+      return this.getAllData().profiles[e] || null
+    }
+    saveProfile(e, t) {
+      const a = this.getAllData()
+      return (
+        (a.profiles[e] = { ...t, lastModified: new Date().toISOString() }),
+        this.saveAllData(a)
+      )
+    }
+    deleteProfile(e) {
+      const t = this.getAllData()
+      if (t.profiles[e]) {
+        if ((delete t.profiles[e], t.currentProfile === e)) {
+          const e = Object.keys(t.profiles)
+          t.currentProfile = e.length > 0 ? e[0] : null
+        }
+        return this.saveAllData(t)
+      }
+      return !1
+    }
+    getSettings() {
+      try {
+        const e = localStorage.getItem(this.settingsKey)
+        return e ? JSON.parse(e) : this.getDefaultSettings()
+      } catch (e) {
+        return (
+          console.error('Error loading settings:', e), this.getDefaultSettings()
+        )
+      }
+    }
+    saveSettings(e) {
+      try {
+        return localStorage.setItem(this.settingsKey, JSON.stringify(e)), !0
+      } catch (e) {
+        return console.error('Error saving settings:', e), !1
+      }
+    }
+    createBackup() {
+      try {
+        const e = localStorage.getItem(this.storageKey)
+        if (e) {
+          const t = {
+            data: e,
+            timestamp: new Date().toISOString(),
+            version: this.version,
+          }
+          localStorage.setItem(this.backupKey, JSON.stringify(t))
+        }
+      } catch (e) {
+        console.error('Error creating backup:', e)
+      }
+    }
+    restoreFromBackup() {
+      try {
+        const e = localStorage.getItem(this.backupKey)
+        if (e) {
+          const t = JSON.parse(e)
+          return localStorage.setItem(this.storageKey, t.data), !0
+        }
+      } catch (e) {
+        console.error('Error restoring from backup:', e)
+      }
+      return !1
+    }
+    exportData() {
+      const e = this.getAllData()
+      return JSON.stringify(e, null, 2)
+    }
+    importData(e) {
+      try {
+        const t = JSON.parse(e)
+        return !!this.isValidDataStructure(t) && this.saveAllData(t)
+      } catch (t) {
+        return (
+          (t instanceof SyntaxError && e.includes('invalid')) ||
+            console.error('Error importing data:', t),
+          !1
+        )
+      }
+    }
+    clearAllData() {
+      try {
+        return (
+          localStorage.removeItem(this.storageKey),
+          localStorage.removeItem(this.backupKey),
+          localStorage.removeItem(this.settingsKey),
+          localStorage.setItem('sto_app_reset', 'true'),
+          !0
+        )
+      } catch (e) {
+        return console.error('Error clearing data:', e), !1
+      }
+    }
+    getStorageInfo() {
+      try {
+        const e = localStorage.getItem(this.storageKey)?.length || 0,
+          t = localStorage.getItem(this.backupKey)?.length || 0,
+          a = localStorage.getItem(this.settingsKey)?.length || 0
+        return {
+          totalSize: e + t + a,
+          dataSize: e,
+          backupSize: t,
+          settingsSize: a,
+          available: this.getAvailableStorage(),
+        }
+      } catch (e) {
+        return console.error('Error getting storage info:', e), null
+      }
+    }
+    getDefaultData() {
+      return {
+        version: this.version,
+        created: new Date().toISOString(),
+        lastModified: new Date().toISOString(),
+        currentProfile: 'default_space',
+        profiles: {
+          default_space: { ...STO_DATA.defaultProfiles.default_space },
+          tactical_space: { ...STO_DATA.defaultProfiles.tactical_space },
+        },
+        globalAliases: {},
+        settings: this.getDefaultSettings(),
+      }
+    }
+    getEmptyData() {
+      return {
+        version: this.version,
+        created: new Date().toISOString(),
+        lastModified: new Date().toISOString(),
+        currentProfile: null,
+        profiles: {},
+        globalAliases: {},
+        settings: this.getDefaultSettings(),
+      }
+    }
+    getDefaultSettings() {
+      return {
+        theme: 'default',
+        autoSave: !0,
+        showTooltips: !0,
+        confirmDeletes: !0,
+        maxUndoSteps: 50,
+        defaultMode: 'space',
+        compactView: !1,
+      }
+    }
+    isValidDataStructure(e) {
+      if (!e || 'object' != typeof e) return !1
+      const t = ['profiles', 'currentProfile']
+      for (const a of t) if (!(a in e)) return !1
+      if ('object' != typeof e.profiles) return !1
+      for (const [t, a] of Object.entries(e.profiles))
+        if (!this.isValidProfile(a)) return !1
+      return !0
+    }
+    isValidProfile(e) {
+      if (!e || 'object' != typeof e) return !1
+      if (e.builds) {
+        if (!e.name || 'object' != typeof e.builds) return !1
+        const t = e.builds
+        if (!t.space && !t.ground) return !1
+        for (const [e, a] of Object.entries(t))
+          if ('space' === e || 'ground' === e) {
+            if (!a || 'object' != typeof a) return !1
+            if (!a.keys || 'object' != typeof a.keys) return !1
+          }
+        return !0
+      }
+      const t = ['name', 'mode', 'keys']
+      for (const a of t) if (!(a in e)) return !1
+      return 'object' == typeof e.keys
+    }
+    ensureStorageStructure() {
+      const e = this.getAllData()
+      e.globalAliases || (e.globalAliases = {}),
+        e.settings || (e.settings = this.getDefaultSettings()),
+        0 === Object.keys(e.profiles).length &&
+          null !== e.currentProfile &&
+          ((e.profiles = {
+            default_space: { ...STO_DATA.defaultProfiles.default_space },
+          }),
+          (e.currentProfile = 'default_space')),
+        Object.keys(e.profiles).length > 0 &&
+          !e.profiles[e.currentProfile] &&
+          (e.currentProfile = Object.keys(e.profiles)[0]),
+        this.saveAllData(e)
+    }
+    migrateData() {
+      const e = this.getAllData()
+      e.version !== this.version &&
+        (console.log(`Migrating data from ${e.version} to ${this.version}`),
+        (e.version = this.version),
+        this.saveAllData(e))
+    }
+    getAvailableStorage() {
+      try {
+        let e = 'storage_test',
+          t = '0',
+          a = 0,
+          n = 0,
+          o = 10485760
+        for (; n <= o; ) {
+          let i = Math.floor((n + o) / 2)
+          t = '0'.repeat(i)
+          try {
+            localStorage.setItem(e, t),
+              localStorage.removeItem(e),
+              (a = i),
+              (n = i + 1)
+          } catch (e) {
+            o = i - 1
+          }
+        }
+        return a
+      } catch (e) {
+        return 0
+      }
+    }
+    loadDefaultData() {
+      const e = this.getDefaultData()
+      return this.saveAllData(e)
+    }
+  })(),
+  p = new (class {
+    constructor() {
+      this.currentModal = null
+    }
+    init() {
+      this.setupEventListeners()
+    }
+    setupEventListeners() {
+      const e = document.getElementById('profileSelect')
+      e &&
+        e.addEventListener('change', (e) => {
+          app.switchProfile(e.target.value)
+        }),
+        i.onDom('newProfileBtn', 'click', 'profile-new', () => {
+          this.showNewProfileModal()
+        }),
+        i.onDom('cloneProfileBtn', 'click', 'profile-clone', () => {
+          this.showCloneProfileModal()
+        }),
+        i.onDom('renameProfileBtn', 'click', 'profile-rename', () => {
+          this.showRenameProfileModal()
+        }),
+        i.onDom('deleteProfileBtn', 'click', 'profile-delete', () => {
+          this.confirmDeleteProfile()
+        }),
+        i.onDom('saveProfileBtn', 'click', 'profile-save', () => {
+          this.handleProfileSave()
+        }),
+        i.onDom('settingsBtn', 'click', 'settings-menu', (e) => {
+          e.stopPropagation(), this.toggleSettingsMenu()
+        }),
+        i.onDom('keybindsBtn', 'click', 'keybinds-menu', (e) => {
+          e.stopPropagation(), this.toggleKeybindsMenu()
+        }),
+        i.onDom('aliasesBtn', 'click', 'aliases-menu', (e) => {
+          e.stopPropagation(), this.toggleAliasesMenu()
+        }),
+        i.onDom('importKeybindsBtn', 'click', 'keybinds-import', () => {
+          this.importKeybinds(), this.closeKeybindsMenu()
+        }),
+        i.onDom('exportKeybindsBtn', 'click', 'keybinds-export', () => {
+          this.exportKeybinds(), this.closeKeybindsMenu()
+        }),
+        i.onDom('importAliasesBtn', 'click', 'aliases-import', () => {
+          this.importAliases(), this.closeAliasesMenu()
+        }),
+        i.onDom('exportAliasesBtn', 'click', 'aliases-export', () => {
+          this.exportAliases(), this.closeAliasesMenu()
+        }),
+        i.onDom('loadDefaultDataBtn', 'click', 'load-default-data', () => {
+          this.loadDefaultData(), this.closeSettingsMenu()
+        }),
+        i.onDom('resetAppBtn', 'click', 'reset-app', () => {
+          this.confirmResetApp(), this.closeSettingsMenu()
+        }),
+        i.onDom('aboutBtn', 'click', 'about-open', () => {
+          modalManager.show('aboutModal')
+        }),
+        i.onDom('themeToggleBtn', 'click', 'theme-toggle', () => {
+          app.toggleTheme(), this.closeSettingsMenu()
+        }),
+        document.addEventListener('click', () => {
+          this.closeSettingsMenu(),
+            this.closeKeybindsMenu(),
+            this.closeAliasesMenu()
+        })
+    }
+    showNewProfileModal() {
+      document.getElementById('profileModal')
+      const e = document.getElementById('profileModalTitle'),
+        t = document.getElementById('profileName'),
+        a = document.getElementById('profileDescription')
+      e && (e.textContent = 'New Profile'),
+        t && ((t.value = ''), (t.placeholder = 'Enter profile name')),
+        a && (a.value = ''),
+        (this.currentModal = 'new'),
+        modalManager.show('profileModal')
+    }
+    showCloneProfileModal() {
+      const e = app.getCurrentProfile()
+      if (!e)
+        return void stoUI.showToast('No profile selected to clone', 'warning')
+      document.getElementById('profileModal')
+      const t = document.getElementById('profileModalTitle'),
+        a = document.getElementById('profileName'),
+        n = document.getElementById('profileDescription')
+      t && (t.textContent = 'Clone Profile'),
+        a &&
+          ((a.value = `${e.name} Copy`),
+          (a.placeholder = 'Enter new profile name')),
+        n && (n.value = `Copy of ${e.name}`),
+        (this.currentModal = 'clone'),
+        modalManager.show('profileModal')
+    }
+    showRenameProfileModal() {
+      const e = app.getCurrentProfile()
+      if (!e)
+        return void stoUI.showToast('No profile selected to rename', 'warning')
+      document.getElementById('profileModal')
+      const t = document.getElementById('profileModalTitle'),
+        a = document.getElementById('profileName'),
+        n = document.getElementById('profileDescription')
+      t && (t.textContent = 'Rename Profile'),
+        a && ((a.value = e.name), (a.placeholder = 'Enter profile name')),
+        n && (n.value = e.description || ''),
+        (this.currentModal = 'rename'),
+        modalManager.show('profileModal')
+    }
+    handleProfileSave() {
+      const e = document.getElementById('profileName'),
+        t = document.getElementById('profileDescription')
+      if (!e) return
+      const a = e.value.trim(),
+        n = t?.value.trim() || ''
+      if (!a)
+        return (
+          stoUI.showToast('Profile name is required', 'error'), void e.focus()
+        )
+      if (a.length > 50)
+        return (
+          stoUI.showToast(
+            'Profile name is too long (max 50 characters)',
+            'error'
+          ),
+          void e.focus()
+        )
+      const o = stoStorage.getAllData()
+      if (
+        Object.values(o.profiles).find(
+          (e) =>
+            e.name.toLowerCase() === a.toLowerCase() &&
+            ('rename' !== this.currentModal ||
+              e.name !== app.getCurrentProfile()?.name)
+        )
+      )
+        return (
+          stoUI.showToast('A profile with this name already exists', 'error'),
+          void e.focus()
+        )
+      try {
+        switch (this.currentModal) {
+          case 'new':
+            this.createNewProfile(a, n)
+            break
+          case 'clone':
+            this.cloneCurrentProfile(a, n)
+            break
+          case 'rename':
+            this.renameCurrentProfile(a, n)
+        }
+        modalManager.hide('profileModal'), (this.currentModal = null)
+      } catch (e) {
+        stoUI.showToast('Failed to save profile: ' + e.message, 'error')
+      }
+    }
+    createNewProfile(e, t) {
+      const a = app.generateProfileId(e),
+        n = {
+          name: e,
+          description: t,
+          mode: 'space',
+          keys: {},
+          aliases: {},
+          created: new Date().toISOString(),
+          lastModified: new Date().toISOString(),
+        }
+      if (!stoStorage.saveProfile(a, n))
+        throw new Error('Failed to save profile')
+      app.switchProfile(a),
+        app.renderProfiles(),
+        stoUI.showToast(`Profile "${e}" created`, 'success')
+    }
+    cloneCurrentProfile(e, t) {
+      const a = app.getCurrentProfile()
+      if (!a) throw new Error('No profile to clone')
+      const n = app.generateProfileId(e),
+        o = {
+          ...JSON.parse(JSON.stringify(a)),
+          name: e,
+          description: t,
+          created: new Date().toISOString(),
+          lastModified: new Date().toISOString(),
+        }
+      if (!stoStorage.saveProfile(n, o))
+        throw new Error('Failed to save cloned profile')
+      app.switchProfile(n),
+        app.renderProfiles(),
+        stoUI.showToast(`Profile "${e}" created from "${a.name}"`, 'success')
+    }
+    renameCurrentProfile(e, t) {
+      const a = app.getCurrentProfile()
+      if (!a) throw new Error('No profile to rename')
+      const n = a.name
+      if (
+        ((a.name = e),
+        (a.description = t),
+        (a.lastModified = new Date().toISOString()),
+        !stoStorage.saveProfile(l.currentProfile, a))
+      )
+        throw new Error('Failed to save renamed profile')
+      app.renderProfiles(),
+        app.setModified(!0),
+        stoUI.showToast(`Profile renamed from "${n}" to "${e}"`, 'success')
+    }
+    async confirmDeleteProfile() {
+      const e = app.getCurrentProfile()
+      if (!e)
+        return void stoUI.showToast('No profile selected to delete', 'warning')
+      const t = stoStorage.getAllData()
+      Object.keys(t.profiles).length <= 1
+        ? stoUI.showToast('Cannot delete the last profile', 'warning')
+        : (await stoUI.confirm(
+            `Are you sure you want to delete the profile "${e.name}"?\n\nThis action cannot be undone.`,
+            'Delete Profile',
+            'danger'
+          )) && this.deleteCurrentProfile()
+    }
+    deleteCurrentProfile() {
+      const e = app.getCurrentProfile()
+      if (!e) return
+      const t = e.name
+      app.deleteProfile(app.currentProfile)
+        ? stoUI.showToast(`Profile "${t}" deleted`, 'success')
+        : stoUI.showToast('Failed to delete profile', 'error')
+    }
+    toggleSettingsMenu() {
+      const e = document.getElementById('settingsBtn')
+      if (e) {
+        const t = e.closest('.dropdown')
+        t && t.classList.toggle('active')
+      }
+    }
+    closeSettingsMenu() {
+      const e = document.getElementById('settingsBtn')
+      if (e) {
+        const t = e.closest('.dropdown')
+        t && t.classList.remove('active')
+      }
+    }
+    toggleKeybindsMenu() {
+      this.closeSettingsMenu(), this.closeAliasesMenu()
+      const e = document.getElementById('keybindsBtn')
+      if (e) {
+        const t = e.closest('.dropdown')
+        t && t.classList.toggle('active')
+      }
+    }
+    closeKeybindsMenu() {
+      const e = document.getElementById('keybindsBtn')
+      if (e) {
+        const t = e.closest('.dropdown')
+        t && t.classList.remove('active')
+      }
+    }
+    toggleAliasesMenu() {
+      this.closeSettingsMenu(), this.closeKeybindsMenu()
+      const e = document.getElementById('aliasesBtn')
+      if (e) {
+        const t = e.closest('.dropdown')
+        t && t.classList.toggle('active')
+      }
+    }
+    closeAliasesMenu() {
+      const e = document.getElementById('aliasesBtn')
+      if (e) {
+        const t = e.closest('.dropdown')
+        t && t.classList.remove('active')
+      }
+    }
+    importKeybinds() {
+      const e = document.getElementById('fileInput')
+      e &&
+        ((e.accept = '.txt'),
+        (e.onchange = (e) => {
+          const t = e.target.files[0]
+          if (t) {
+            const e = new FileReader()
+            ;(e.onload = (e) => {
+              try {
+                stoKeybinds.importKeybindFile(e.target.result)
+              } catch (e) {
+                stoUI.showToast(
+                  'Failed to import keybind file: ' + e.message,
+                  'error'
+                )
+              }
+            }),
+              e.readAsText(t)
+          }
+          e.target.value = ''
+        }),
+        e.click())
+    }
+    exportKeybinds() {
+      const e = app.getCurrentProfile()
+      e
+        ? e.keys && 0 !== Object.keys(e.keys).length
+          ? stoExport.exportSTOKeybindFile(e)
+          : stoUI.showToast('No keybinds to export', 'warning')
+        : stoUI.showToast('No profile selected to export', 'warning')
+    }
+    importAliases() {
+      const e = document.createElement('input')
+      ;(e.type = 'file'),
+        (e.accept = '.txt'),
+        (e.onchange = (e) => {
+          const t = e.target.files[0]
+          if (t) {
+            const e = new FileReader()
+            ;(e.onload = (e) => {
+              try {
+                const t = e.target.result
+                stoKeybinds.importAliasFile(t),
+                  window.stoAliases &&
+                    'function' == typeof window.stoAliases.renderAliasList &&
+                    window.stoAliases.renderAliasList()
+              } catch (e) {
+                stoUI.showToast(
+                  'Failed to import aliases: ' + e.message,
+                  'error'
+                )
+              }
+            }),
+              e.readAsText(t)
+          }
+        }),
+        e.click()
+    }
+    exportAliases() {
+      const e = app.getCurrentProfile()
+      e
+        ? e.aliases && 0 !== Object.keys(e.aliases).length
+          ? stoExport.exportAliases(e)
+          : stoUI.showToast('No aliases to export', 'warning')
+        : stoUI.showToast('No profile selected to export', 'warning')
+    }
+    async confirmResetApp() {
+      ;(await stoUI.confirm(
+        'Are you sure you want to reset the application?\n\nThis will delete all profiles, keybinds, and settings. This action cannot be undone.',
+        'Reset Application',
+        'danger'
+      )) && this.resetApplication()
+    }
+    resetApplication() {
+      try {
+        stoStorage.clearAllData(),
+          (app.currentProfile = null),
+          (app.selectedKey = null),
+          app.setModified(!1),
+          app.renderProfiles(),
+          app.renderKeyGrid(),
+          app.renderCommandChain(),
+          app.updateProfileInfo(),
+          stoUI.showToast(
+            'Application reset successfully. All data cleared.',
+            'success'
+          )
+      } catch (e) {
+        stoUI.showToast('Failed to reset application: ' + e.message, 'error')
+      }
+    }
+    loadDefaultData() {
+      try {
+        if (stoStorage.loadDefaultData()) {
+          const e = stoStorage.getAllData()
+          ;(app.currentProfile = e.currentProfile),
+            (app.selectedKey = null),
+            app.setModified(!1),
+            app.renderProfiles(),
+            app.renderKeyGrid(),
+            app.renderCommandChain(),
+            app.updateProfileInfo(),
+            stoUI.showToast('Default demo data loaded successfully', 'success')
+        } else stoUI.showToast('Failed to load default data', 'error')
+      } catch (e) {
+        stoUI.showToast('Failed to load default data: ' + e.message, 'error')
+      }
+    }
+    getProfileAnalysis(e) {
+      const t = {
+        keyCount: Object.keys(e.keys).length,
+        commandCount: 0,
+        aliasCount: Object.keys(e.aliases || {}).length,
+        commandTypes: {},
+        keyTypes: {
+          function: 0,
+          number: 0,
+          letter: 0,
+          special: 0,
+          modifier: 0,
+        },
+        complexity: 'Simple',
+        recommendations: [],
+      }
+      return (
+        Object.entries(e.keys).forEach(([e, a]) => {
+          ;(t.commandCount += a.length),
+            /^F\d+$/.test(e)
+              ? t.keyTypes.function++
+              : /^\d+$/.test(e)
+                ? t.keyTypes.number++
+                : /^[A-Z]$/.test(e)
+                  ? t.keyTypes.letter++
+                  : e.includes('+')
+                    ? t.keyTypes.modifier++
+                    : t.keyTypes.special++,
+            a.forEach((e) => {
+              t.commandTypes[e.type] = (t.commandTypes[e.type] || 0) + 1
+            })
+        }),
+        t.commandCount > 50
+          ? (t.complexity = 'Complex')
+          : t.commandCount > 20 && (t.complexity = 'Moderate'),
+        this.generateRecommendations(t, e),
+        t
+      )
+    }
+    generateRecommendations(e, t) {
+      const a = []
+      e.commandTypes.targeting ||
+        e.commandTypes.combat ||
+        a.push({
+          type: 'setup',
+          title: 'Add Basic Combat Commands',
+          description:
+            'Consider adding targeting and firing commands for basic combat functionality.',
+          priority: 'high',
+        }),
+        e.commandTypes.power ||
+          a.push({
+            type: 'defensive',
+            title: 'Add Defensive Abilities',
+            description:
+              'Add shield management commands like shield distribution and shield routing.',
+            priority: 'medium',
+          }),
+        e.keyTypes.modifier < 3 &&
+          e.keyCount > 10 &&
+          a.push({
+            type: 'efficiency',
+            title: 'Use Modifier Keys',
+            description:
+              'Consider using Ctrl+, Alt+, and Shift+ combinations to access more commands efficiently.',
+            priority: 'low',
+          }),
+        0 === e.aliasCount &&
+          e.commandCount > 15 &&
+          a.push({
+            type: 'organization',
+            title: 'Create Command Aliases',
+            description:
+              'Use aliases to group related commands and simplify complex sequences.',
+            priority: 'medium',
+          })
+      const n = ['FireAll', 'target_nearest_enemy', '+fullimpulse'],
+        o = Object.values(t.keys).some((e) =>
+          e.some((e) => n.some((t) => e.command.includes(t)))
+        )
+      'ground' === t.mode &&
+        o &&
+        a.push({
+          type: 'mode',
+          title: 'Check Profile Mode',
+          description:
+            'This profile contains space combat commands but is set to ground mode.',
+          priority: 'medium',
+        }),
+        (e.recommendations = a)
+    }
+    getProfileTemplates() {
+      return {
+        basic_space: {
+          name: 'Basic Space Combat',
+          description: 'Essential space combat keybinds for new players',
+          mode: 'space',
+          keys: {
+            Space: [
+              {
+                command: 'target_nearest_enemy',
+                type: 'targeting',
+                icon: '🎯',
+                text: 'Target nearest enemy',
+              },
+              {
+                command: 'FireAll',
+                type: 'combat',
+                icon: '🔥',
+                text: 'Fire all weapons',
+              },
+            ],
+            Tab: [
+              {
+                command: 'target_nearest_friend',
+                type: 'targeting',
+                icon: '🤝',
+                text: 'Target nearest friend',
+              },
+            ],
+            F1: [
+              {
+                command: 'target_self',
+                type: 'targeting',
+                icon: '👤',
+                text: 'Target self',
+              },
+              {
+                command: '+power_exec Distribute_Shields',
+                type: 'power',
+                icon: '🛡️',
+                text: 'Distribute shields',
+              },
+            ],
+          },
+          aliases: {},
+        },
+        advanced_tactical: {
+          name: 'Advanced Tactical',
+          description: 'Comprehensive DPS-focused space build',
+          mode: 'space',
+          keys: {
+            Space: [
+              {
+                command: 'target_nearest_enemy',
+                type: 'targeting',
+                icon: '🎯',
+                text: 'Target nearest enemy',
+              },
+              {
+                command: '+STOTrayExecByTray 0 0',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Execute Tray 1 Slot 1',
+              },
+              {
+                command: 'FireAll',
+                type: 'combat',
+                icon: '🔥',
+                text: 'Fire all weapons',
+              },
+            ],
+            1: [
+              {
+                command: '+STOTrayExecByTray 1 0',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Execute Tray 2 Slot 1',
+              },
+            ],
+            2: [
+              {
+                command: '+STOTrayExecByTray 1 1',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Execute Tray 2 Slot 2',
+              },
+            ],
+            F1: [
+              {
+                command: 'target_self',
+                type: 'targeting',
+                icon: '👤',
+                text: 'Target self',
+              },
+            ],
+            F2: [
+              {
+                command: 'target_self',
+                type: 'targeting',
+                icon: '👤',
+                text: 'Target self',
+              },
+            ],
+          },
+          aliases: {
+            AlphaStrike: {
+              name: 'AlphaStrike',
+              commands:
+                'target_nearest_enemy $$ +STOTrayExecByTray 0 0 $$ +STOTrayExecByTray 0 1',
+              description: 'Full alpha strike sequence',
+            },
+          },
+        },
+        ground_combat: {
+          name: 'Ground Combat',
+          description: 'Ground combat and away team keybinds',
+          mode: 'ground',
+          keys: {
+            Space: [
+              {
+                command: 'target_nearest_enemy',
+                type: 'targeting',
+                icon: '🎯',
+                text: 'Target nearest enemy',
+              },
+              {
+                command: '+STOTrayExecByTray 0 0',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Primary attack',
+              },
+            ],
+            1: [
+              {
+                command: '+STOTrayExecByTray 0 1',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Secondary attack',
+              },
+            ],
+            2: [
+              {
+                command: '+STOTrayExecByTray 0 2',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Kit ability 1',
+              },
+            ],
+            F1: [
+              {
+                command: 'target_self',
+                type: 'targeting',
+                icon: '👤',
+                text: 'Target self',
+              },
+              {
+                command: '+STOTrayExecByTray 1 0',
+                type: 'tray',
+                icon: '💊',
+                text: 'Heal self',
+              },
+            ],
+          },
+          aliases: {},
+        },
+      }
+    }
+    createProfileFromTemplate(e) {
+      const t = this.getProfileTemplates()[e]
+      if (!t) return void stoUI.showToast('Template not found', 'error')
+      let a = t.name,
+        n = 1
+      const o = stoStorage.getAllData()
+      for (; Object.values(o.profiles).some((e) => e.name === a); )
+        (a = `${t.name} ${n}`), n++
+      const i = app.generateProfileId(a),
+        r = {
+          ...t,
+          name: a,
+          created: new Date().toISOString(),
+          lastModified: new Date().toISOString(),
+        }
+      Object.values(r.keys).forEach((e) => {
+        e.forEach((e) => {
+          e.id = app.generateCommandId()
+        })
+      }),
+        stoStorage.saveProfile(i, r)
+          ? (app.switchProfile(i),
+            app.renderProfiles(),
+            stoUI.showToast(`Profile "${a}" created from template`, 'success'))
+          : stoUI.showToast('Failed to create profile from template', 'error')
+    }
+    exportProfile(e) {
+      const t = stoStorage.getProfile(e)
+      if (!t) return void stoUI.showToast('Profile not found', 'error')
+      const a = {
+          version: '1.0.0',
+          exported: new Date().toISOString(),
+          profile: t,
+        },
+        n = new Blob([JSON.stringify(a, null, 2)], {
+          type: 'application/json',
+        }),
+        o = URL.createObjectURL(n),
+        i = document.createElement('a')
+      ;(i.href = o),
+        (i.download = `${t.name.replace(/[^a-zA-Z0-9]/g, '_')}_profile.json`),
+        i.click(),
+        URL.revokeObjectURL(o),
+        stoUI.showToast(`Profile "${t.name}" exported`, 'success')
+    }
+    async importProfile(e) {
+      try {
+        const t = JSON.parse(e)
+        if (!t.profile) throw new Error('Invalid profile file format')
+        const a = t.profile
+        let n = a.name,
+          o = 1
+        const i = stoStorage.getAllData()
+        for (; Object.values(i.profiles).some((e) => e.name === n); )
+          (n = `${a.name} (${o})`), o++
+        ;(a.name = n),
+          (a.imported = new Date().toISOString()),
+          (a.lastModified = new Date().toISOString())
+        const r = app.generateProfileId(n)
+        if (stoStorage.saveProfile(r, a))
+          return (
+            app.renderProfiles(),
+            stoUI.showToast(`Profile "${n}" imported successfully`, 'success'),
+            !0
+          )
+        throw new Error('Failed to save imported profile')
+      } catch (e) {
+        return (
+          stoUI.showToast('Failed to import profile: ' + e.message, 'error'), !1
+        )
+      }
+    }
+  })(),
+  u = new (class {
+    constructor() {
+      ;(this.keybindPatterns = {
+        standard: /^([a-zA-Z0-9_+\-\s\[\]]+)\s+"([^"]*)"(?:\s+"([^"]*)")?$/,
+        bind: /^\/bind\s+([a-zA-Z0-9_+\-\s\[\]]+)\s+(.+)$/,
+        alias:
+          /^alias\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+(?:"([^"]+)"|<&\s+(.+?)\s+&>)$/,
+        comment: /^[#;].*$/,
+      }),
+        (this.validKeys = this.generateValidKeys())
+    }
+    init() {
+      this.setupEventListeners()
+    }
+    generateValidKeys() {
+      const e = new Set()
+      for (let t = 1; t <= 12; t++) e.add(`F${t}`)
+      for (let t = 0; t <= 9; t++) e.add(t.toString())
+      for (let t = 65; t <= 90; t++) e.add(String.fromCharCode(t))
+      ;[
+        'Space',
+        'Tab',
+        'Enter',
+        'Escape',
+        'Backspace',
+        'Delete',
+        'Insert',
+        'Home',
+        'End',
+        'PageUp',
+        'PageDown',
+        'Up',
+        'Down',
+        'Left',
+        'Right',
+        'NumPad0',
+        'NumPad1',
+        'NumPad2',
+        'NumPad3',
+        'NumPad4',
+        'NumPad5',
+        'NumPad6',
+        'NumPad7',
+        'NumPad8',
+        'NumPad9',
+        'NumPadEnter',
+        'NumPadPlus',
+        'NumPadMinus',
+        'NumPadMultiply',
+        'NumPadDivide',
+        'numpad0',
+        'numpad1',
+        'numpad2',
+        'numpad3',
+        'numpad4',
+        'numpad5',
+        'numpad6',
+        'numpad7',
+        'numpad8',
+        'numpad9',
+        'divide',
+        'multiply',
+        'Button4',
+        'Button5',
+        'Button6',
+        'Button7',
+        'Button8',
+        'Lbutton',
+        'Rbutton',
+        'Mbutton',
+        'Leftdrag',
+        'Rightdrag',
+        'Middleclick',
+        'Mousechord',
+        'Wheelplus',
+        'Wheelminus',
+        'Semicolon',
+        'Equals',
+        'Comma',
+        'Minus',
+        'Period',
+        'Slash',
+        'Grave',
+        'LeftBracket',
+        'Backslash',
+        'RightBracket',
+        'Quote',
+        '[',
+        ']',
+      ].forEach((t) => e.add(t))
+      const t = Array.from(e)
+      return (
+        ['Ctrl', 'Alt', 'Shift', 'Control'].forEach((a) => {
+          t.forEach((t) => {
+            e.add(`${a}+${t}`)
+          })
+        }),
+        e.add('Ctrl+Alt'),
+        e.add('Ctrl+Shift'),
+        e.add('Alt+Shift'),
+        e.add('Control+Alt'),
+        e.add('Control+Shift'),
+        t.forEach((t) => {
+          e.add(`Ctrl+Alt+${t}`),
+            e.add(`Ctrl+Shift+${t}`),
+            e.add(`Alt+Shift+${t}`),
+            e.add(`Control+Alt+${t}`),
+            e.add(`Control+Shift+${t}`)
+        }),
+        Array.from(e).sort()
+      )
+    }
+    parseKeybindFile(e) {
+      const t = e.split('\n'),
+        a = { keybinds: {}, aliases: {}, comments: [], errors: [] }
+      return (
+        t.forEach((e, t) => {
+          const n = e.trim()
+          if (n)
+            try {
+              if (this.keybindPatterns.comment.test(n))
+                a.comments.push({ line: t + 1, content: n })
+              else if (this.keybindPatterns.alias.test(n)) {
+                const e = n.match(this.keybindPatterns.alias)
+                if (e) {
+                  const [, n, o, i] = e,
+                    r = o || i
+                  a.aliases[n] = { name: n, commands: r, line: t + 1 }
+                }
+              } else if (this.keybindPatterns.standard.test(n)) {
+                const e = n.match(this.keybindPatterns.standard)
+                if (e) {
+                  const [, n, o, i] = e,
+                    r = this.parseCommandString(o)
+                  a.keybinds[n] = {
+                    key: n,
+                    commands: r,
+                    line: t + 1,
+                    raw: o,
+                    optionalParam: i || null,
+                  }
+                }
+              } else if (this.keybindPatterns.bind.test(n)) {
+                const e = n.match(this.keybindPatterns.bind)
+                if (e) {
+                  const [, n, o] = e,
+                    i = o.replace(/^"(.*)"$/, '$1'),
+                    r = this.parseCommandString(i)
+                  a.keybinds[n] = { key: n, commands: r, line: t + 1, raw: i }
+                }
+              } else
+                a.errors.push({
+                  line: t + 1,
+                  content: n,
+                  error: 'Invalid keybind format',
+                })
+            } catch (e) {
+              a.errors.push({ line: t + 1, content: n, error: e.message })
+            }
+        }),
+        a
+      )
+    }
+    generateMirroredCommandString(e) {
+      if (!e || e.length <= 1) return e.map((e) => e.command || e).join(' $$ ')
+      const t = e.map((e) => e.command || e),
+        a = [...t].reverse().slice(1)
+      return [...t, ...a].join(' $$ ')
+    }
+    detectAndUnmirrorCommands(e) {
+      if (!e || 'string' != typeof e)
+        return { isMirrored: !1, originalCommands: [] }
+      const t = e
+        .split(' $$ ')
+        .map((e) => e.trim())
+        .filter((e) => e)
+      if (t.length <= 1) return { isMirrored: !1, originalCommands: t }
+      if (t.length < 3 || t.length % 2 == 0)
+        return { isMirrored: !1, originalCommands: t }
+      const a = Math.floor(t.length / 2),
+        n = t.slice(0, a + 1),
+        o = t.slice(a + 1),
+        i = n.slice(0, -1).reverse()
+      return o.length === i.length && o.every((e, t) => e === i[t])
+        ? { isMirrored: !0, originalCommands: n }
+        : { isMirrored: !1, originalCommands: t }
+    }
+    parseCommandString(e) {
+      return e
+        .split('$$')
+        .map((e) => e.trim())
+        .map((e, t) => {
+          const a = {
+            command: e,
+            type: window.stoCommands
+              ? window.stoCommands.detectCommandType(e)
+              : 'custom',
+            icon: window.stoCommands
+              ? window.stoCommands.getCommandIcon(e)
+              : '⚙️',
+            text: window.stoCommands ? window.stoCommands.getCommandText(e) : e,
+            id: `imported_${Date.now()}_${t}`,
+          }
+          if (e.includes('+STOTrayExecByTray')) {
+            const t = e.match(/\+STOTrayExecByTray\s+(\d+)\s+(\d+)/)
+            t &&
+              ((a.parameters = { tray: parseInt(t[1]), slot: parseInt(t[2]) }),
+              (a.text = `Execute Tray ${parseInt(t[1]) + 1} Slot ${parseInt(t[2]) + 1}`))
+          } else if (e.includes('"')) {
+            const t = e.match(/^(\w+)\s+"([^"]+)"$/)
+            t &&
+              ((a.parameters = { message: t[2] }),
+              (a.text = `${a.text}: ${t[2]}`))
+          }
+          return a
+        })
+    }
+    importKeybindFile(e) {
+      const t = stoStorage.getProfile(l.currentProfile)
+      if (!t)
+        return (
+          stoUI.showToast('No profile selected for import', 'warning'),
+          { success: !1, error: 'No active profile' }
+        )
+      try {
+        const a = this.parseKeybindFile(e),
+          n = Object.keys(a.keybinds).length
+        if (0 === n)
+          return (
+            stoUI.showToast('No keybinds found in file', 'warning'),
+            { success: !1, error: 'No keybinds found' }
+          )
+        t.builds || (t.builds = { space: { keys: {} }, ground: { keys: {} } }),
+          t.builds[l.currentEnvironment] ||
+            (t.builds[l.currentEnvironment] = { keys: {} })
+        const o = t.builds[l.currentEnvironment].keys
+        Object.entries(a.keybinds).forEach(([e, a]) => {
+          const n = a.commands.map((e) => e.command).join(' $$ '),
+            i = this.detectAndUnmirrorCommands(n)
+          if (i.isMirrored) {
+            o[e] = this.parseCommandString(i.originalCommands.join(' $$ '))
+            const a = l.currentEnvironment
+            t.keybindMetadata || (t.keybindMetadata = {}),
+              t.keybindMetadata[a] || (t.keybindMetadata[a] = {}),
+              (t.keybindMetadata[a][e] = { stabilizeExecutionOrder: !0 })
+          } else o[e] = a.commands
+        }),
+          stoStorage.saveProfile(l.currentProfile, t),
+          app.setModified(!0),
+          app.renderKeyGrid()
+        const i = `Import completed: ${n} keybinds`
+        return (
+          Object.keys(a.aliases).length > 0
+            ? stoUI.showToast(
+                i +
+                  ` (${Object.keys(a.aliases).length} aliases ignored - use Import Aliases)`,
+                'success'
+              )
+            : stoUI.showToast(i, 'success'),
+          { success: !0, imported: { keys: n }, errors: a.errors }
+        )
+      } catch (e) {
+        return (
+          stoUI.showToast('Import failed: ' + e.message, 'error'),
+          { success: !1, error: e.message }
+        )
+      }
+    }
+    importAliasFile(e) {
+      if (!app.getCurrentProfile())
+        return (
+          stoUI.showToast('No profile selected for import', 'warning'),
+          { success: !1, error: 'No active profile' }
+        )
+      try {
+        const t = this.parseKeybindFile(e),
+          a = Object.keys(t.aliases).length
+        if (0 === a)
+          return (
+            stoUI.showToast('No aliases found in file', 'warning'),
+            { success: !1, error: 'No aliases found' }
+          )
+        const n = stoStorage.getProfile(l.currentProfile)
+        if (!n)
+          return (
+            stoUI.showToast('Failed to get profile for import', 'error'),
+            { success: !1, error: 'Profile not found' }
+          )
+        n.aliases || (n.aliases = {}),
+          Object.entries(t.aliases).forEach(([e, t]) => {
+            n.aliases[e] = {
+              commands: t.commands,
+              description: t.description || '',
+            }
+          }),
+          stoStorage.saveProfile(l.currentProfile, n),
+          app.setModified(!0),
+          window.stoAliases &&
+            'function' == typeof window.stoAliases.updateCommandLibrary &&
+            window.stoAliases.updateCommandLibrary()
+        const o = `Import completed: ${a} aliases`
+        return (
+          stoUI.showToast(o, 'success'),
+          { success: !0, imported: { aliases: a }, errors: t.errors }
+        )
+      } catch (e) {
+        return (
+          stoUI.showToast('Import failed: ' + e.message, 'error'),
+          { success: !1, error: e.message }
+        )
+      }
+    }
+    exportProfile(e) {
+      let t = ''
+      return (
+        (t += `# ${e.name} - ${e.mode} mode\n`),
+        (t += '# Generated by STO Tools Keybind Manager\n'),
+        (t += `# ${new Date().toLocaleString()}\n\n`),
+        (t += '# Keybind Commands\n'),
+        Object.keys(e.keys)
+          .sort(this.compareKeys.bind(this))
+          .forEach((a) => {
+            const n = e.keys[a]
+            if (n && n.length > 0) {
+              let o,
+                i = !1
+              if (e.keybindMetadata) {
+                const t = e.mode || 'space'
+                e.keybindMetadata[t] && e.keybindMetadata[t][a]
+                  ? (i = !!e.keybindMetadata[t][a].stabilizeExecutionOrder)
+                  : e.keybindMetadata[a] &&
+                    (i = !!e.keybindMetadata[a].stabilizeExecutionOrder)
+              }
+              ;(o =
+                i && n.length > 1
+                  ? this.generateMirroredCommandString(n)
+                  : n.map((e) => e.command).join(' $$ ')),
+                (t += `${a} "${o}" ""\n`)
+            } else t += `${a} "" ""\n`
+          }),
+        t
+      )
+    }
+    compareKeys(e, t) {
+      const a = e.match(/^F(\d+)$/),
+        n = t.match(/^F(\d+)$/)
+      if (a && n) return parseInt(a[1]) - parseInt(n[1])
+      if (a && !n) return -1
+      if (!a && n) return 1
+      const o = /^\d+$/.test(e),
+        i = /^\d+$/.test(t)
+      if (o && i) return parseInt(e) - parseInt(t)
+      if (o && !i) return -1
+      if (!o && i) return 1
+      const r = /^[A-Z]$/.test(e),
+        s = /^[A-Z]$/.test(t)
+      if (r && s) return e.localeCompare(t)
+      if (r && !s) return -1
+      if (!r && s) return 1
+      const c = ['Space', 'Tab', 'Enter', 'Escape'],
+        l = c.indexOf(e),
+        d = c.indexOf(t)
+      return -1 !== l && -1 !== d
+        ? l - d
+        : -1 !== l && -1 === d
+          ? -1
+          : -1 === l && -1 !== d
+            ? 1
+            : e.localeCompare(t)
+    }
+    isValidKey(e) {
+      return (
+        !(!e || 'string' != typeof e) &&
+        this.validKeys.some((t) => t.toLowerCase() === e.toLowerCase())
+      )
+    }
+    isValidAliasName(e) {
+      return STO_DATA.validation.aliasNamePattern.test(e)
+    }
+    validateKeybind(e, t) {
+      const a = []
+      return (
+        this.isValidKey(e) || a.push(`Invalid key name: ${e}`),
+        t && 0 !== t.length
+          ? t.forEach((e, t) => {
+              ;(e.command && 0 !== e.command.trim().length) ||
+                a.push(`Command ${t + 1} is empty`)
+            })
+          : a.push('At least one command is required'),
+        t &&
+          t.length > STO_DATA.validation.maxCommandsPerKey &&
+          a.push(
+            `Too many commands (max ${STO_DATA.validation.maxCommandsPerKey})`
+          ),
+        { valid: 0 === a.length, errors: a }
+      )
+    }
+    suggestKeys(e = '') {
+      const t = e.toLowerCase()
+      return this.validKeys
+        .filter((e) => e.toLowerCase().includes(t))
+        .slice(0, 20)
+    }
+    getCommonKeys() {
+      return [
+        'Space',
+        'Tab',
+        'Enter',
+        'F1',
+        'F2',
+        'F3',
+        'F4',
+        'F5',
+        'F6',
+        'F7',
+        'F8',
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+        '6',
+        '7',
+        '8',
+        '9',
+        '0',
+        'Ctrl+1',
+        'Ctrl+2',
+        'Ctrl+3',
+        'Ctrl+4',
+        'Alt+1',
+        'Alt+2',
+        'Alt+3',
+        'Alt+4',
+        'Shift+1',
+        'Shift+2',
+        'Shift+3',
+        'Shift+4',
+      ]
+    }
+    setupEventListeners() {}
+    handleKeybindFileImport(e) {
+      const t = e.target.files[0]
+      if (!t) return
+      const a = new FileReader()
+      ;(a.onload = (e) => {
+        try {
+          this.importKeybindFile(e.target.result)
+        } catch (e) {
+          stoUI.showToast(
+            'Failed to import keybind file: ' + e.message,
+            'error'
+          )
+        }
+      }),
+        a.readAsText(t),
+        (e.target.value = '')
+    }
+    generateKeybindId() {
+      return (
+        'keybind_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9)
+      )
+    }
+    cloneKeybind(e) {
+      return JSON.parse(JSON.stringify(e))
+    }
+    getProfileStats(e) {
+      const t = {
+        totalKeys: Object.keys(e.keys).length,
+        totalCommands: 0,
+        totalAliases: Object.keys(e.aliases || {}).length,
+        commandTypes: {},
+        mostUsedCommands: {},
+      }
+      return (
+        Object.values(e.keys).forEach((e) => {
+          ;(t.totalCommands += e.length),
+            e.forEach((e) => {
+              ;(t.commandTypes[e.type] = (t.commandTypes[e.type] || 0) + 1),
+                (t.mostUsedCommands[e.command] =
+                  (t.mostUsedCommands[e.command] || 0) + 1)
+            })
+        }),
+        t
+      )
+    }
+  })(),
+  y = new (class {
+    constructor() {
+      this.currentAlias = null
+    }
+    init() {
+      this.setupEventListeners(), this.updateCommandLibrary()
+    }
+    setupEventListeners() {
+      i.onDom('addAliasBtn', 'click', 'alias-manager-open', () => {
+        this.showAliasManager()
+      }),
+        i.onDom('newAliasBtn', 'click', 'alias-new', () => {
+          this.showEditAliasModal()
+        }),
+        i.onDom('saveAliasBtn', 'click', 'alias-save', () => {
+          this.saveAlias()
+        }),
+        document.addEventListener('input', (e) => {
+          ;['aliasName', 'aliasCommands', 'aliasDescription'].includes(
+            e.target.id
+          ) && this.updateAliasPreview()
+        }),
+        document.addEventListener('click', (e) => {
+          if (
+            e.target.classList.contains('insert-target-btn') ||
+            e.target.closest('.insert-target-btn')
+          ) {
+            e.preventDefault()
+            const t = (
+                e.target.classList.contains('insert-target-btn')
+                  ? e.target
+                  : e.target.closest('.insert-target-btn')
+              ).closest('.textarea-with-button'),
+              a = t ? t.querySelector('textarea') : null
+            a && this.insertTargetVariable(a)
+          }
+        })
+    }
+    showAliasManager() {
+      this.renderAliasList(), modalManager.show('aliasManagerModal')
+    }
+    renderAliasList() {
+      const e = document.getElementById('aliasList')
+      if (!e) return
+      const t = app.getCurrentProfile()
+      if (!t || !t.aliases)
+        return void (e.innerHTML =
+          '\n                <div class="empty-state">\n                    <i class="fas fa-mask"></i>\n                    <h4>No Aliases</h4>\n                    <p>Create command aliases to simplify complex command sequences.</p>\n                </div>\n            ')
+      const a = Object.entries(t.aliases)
+      0 !== a.length
+        ? ((e.innerHTML = `\n            <div class="alias-grid">\n                ${a.map(([e, t]) => this.createAliasCard(e, t)).join('')}\n            </div>\n        `),
+          e.querySelectorAll('.alias-card').forEach((e) => {
+            const t = e.dataset.alias
+            e
+              .querySelector('.edit-alias-btn')
+              ?.addEventListener('click', () => {
+                this.editAlias(t)
+              }),
+              e
+                .querySelector('.delete-alias-btn')
+                ?.addEventListener('click', () => {
+                  this.confirmDeleteAlias(t)
+                }),
+              e
+                .querySelector('.use-alias-btn')
+                ?.addEventListener('click', () => {
+                  this.useAlias(t)
+                })
+          }))
+        : (e.innerHTML =
+            '\n                <div class="empty-state">\n                    <i class="fas fa-mask"></i>\n                    <h4>No Aliases</h4>\n                    <p>Create command aliases to simplify complex command sequences.</p>\n                </div>\n            ')
+    }
+    createAliasCard(e, t) {
+      const a =
+        t.commands.length > 60
+          ? t.commands.substring(0, 60) + '...'
+          : t.commands
+      return `\n            <div class="alias-card" data-alias="${e}">\n                <div class="alias-header">\n                    <h4>${e}</h4>\n                    <div class="alias-actions">\n                        <button class="btn btn-small-icon edit-alias-btn" title="Edit Alias">\n                            <i class="fas fa-edit"></i>\n                        </button>\n                        <button class="btn btn-small-icon use-alias-btn" title="Add to Current Key">\n                            <i class="fas fa-plus"></i>\n                        </button>\n                        <button class="btn btn-small-icon btn-danger delete-alias-btn" title="Delete Alias">\n                            <i class="fas fa-trash"></i>\n                        </button>\n                    </div>\n                </div>\n                <div class="alias-description">\n                    ${t.description || 'No description'}\n                </div>\n                <div class="alias-commands">\n                    <code>${a}</code>\n                </div>\n                <div class="alias-usage">\n                    Usage: <code>${e}</code>\n                </div>\n            </div>\n        `
+    }
+    showEditAliasModal(e = null) {
+      const t = document.getElementById('editAliasTitle'),
+        a = document.getElementById('aliasName'),
+        n = document.getElementById('aliasDescription'),
+        o = document.getElementById('aliasCommands')
+      if (e) {
+        const i = app.getCurrentProfile().aliases[e]
+        t && (t.textContent = 'Edit Alias'),
+          a && ((a.value = e), (a.disabled = !0)),
+          n && (n.value = i.description || ''),
+          o && (o.value = i.commands),
+          (this.currentAlias = e)
+      } else
+        t && (t.textContent = 'New Alias'),
+          a && ((a.value = ''), (a.disabled = !1)),
+          n && (n.value = ''),
+          o && (o.value = ''),
+          (this.currentAlias = null)
+      this.updateAliasPreview(),
+        modalManager.hide('aliasManagerModal'),
+        modalManager.show('editAliasModal')
+    }
+    editAlias(e) {
+      this.showEditAliasModal(e)
+    }
+    async confirmDeleteAlias(e) {
+      ;(await stoUI.confirm(
+        `Are you sure you want to delete the alias "${e}"?`,
+        'Delete Alias',
+        'danger'
+      )) && this.deleteAlias(e)
+    }
+    deleteAlias(e) {
+      const t = app.getCurrentProfile()
+      t &&
+        t.aliases &&
+        t.aliases[e] &&
+        (delete t.aliases[e],
+        app.saveProfile(),
+        app.setModified(!0),
+        this.renderAliasList(),
+        this.updateCommandLibrary(),
+        stoUI.showToast(`Alias "${e}" deleted`, 'success'))
+    }
+    useAlias(e) {
+      if (!l.selectedKey)
+        return void stoUI.showToast('Please select a key first', 'warning')
+      const t = {
+        command: e,
+        type: 'alias',
+        icon: '🎭',
+        text: `Alias: ${e}`,
+        id: app.generateCommandId(),
+      }
+      app.addCommand(l.selectedKey, t),
+        modalManager.hide('aliasManagerModal'),
+        stoUI.showToast(`Alias "${e}" added to ${l.selectedKey}`, 'success')
+    }
+    saveAlias() {
+      const e = document.getElementById('aliasName'),
+        t = document.getElementById('aliasDescription'),
+        a = document.getElementById('aliasCommands')
+      if (!e || !a) return
+      const n = e.value.trim(),
+        o = t?.value.trim() || '',
+        i = a.value.trim(),
+        r = this.validateAlias(n, i)
+      if (!r.valid) return void stoUI.showToast(r.error, 'error')
+      const s = app.getCurrentProfile()
+      if (!s) return void stoUI.showToast('No active profile', 'error')
+      if ((s.aliases || (s.aliases = {}), !this.currentAlias && s.aliases[n]))
+        return (
+          stoUI.showToast('An alias with this name already exists', 'error'),
+          void e.focus()
+        )
+      ;(s.aliases[n] = {
+        name: n,
+        description: o,
+        commands: i,
+        created: this.currentAlias
+          ? s.aliases[n]?.created
+          : new Date().toISOString(),
+        lastModified: new Date().toISOString(),
+      }),
+        app.saveProfile(),
+        app.setModified(!0),
+        this.updateCommandLibrary()
+      const c = this.currentAlias ? 'updated' : 'created'
+      stoUI.showToast(`Alias "${n}" ${c}`, 'success'),
+        modalManager.hide('editAliasModal'),
+        this.showAliasManager()
+    }
+    validateAlias(e, t) {
+      if (!e) return { valid: !1, error: 'Alias name is required' }
+      if (!STO_DATA.validation.aliasNamePattern.test(e))
+        return {
+          valid: !1,
+          error:
+            'Invalid alias name. Use only letters, numbers, and underscores. Must start with a letter.',
+        }
+      if (e.length > 30)
+        return {
+          valid: !1,
+          error: 'Alias name is too long (max 30 characters)',
+        }
+      if (
+        [
+          'alias',
+          'bind',
+          'unbind',
+          'bind_load_file',
+          'bind_save_file',
+        ].includes(e.toLowerCase())
+      )
+        return { valid: !1, error: 'This is a reserved command name' }
+      if (!t) return { valid: !1, error: 'Commands are required' }
+      if (t.length > 500)
+        return {
+          valid: !1,
+          error: 'Command sequence is too long (max 500 characters)',
+        }
+      if ('undefined' != typeof app && app.getCurrentProfile) {
+        const a = app.getCurrentProfile()
+        if (
+          a &&
+          a.aliases &&
+          Object.keys(a.aliases).some((a) => t.includes(a) && a !== e)
+        )
+          return { valid: !1, error: 'Potential circular reference detected' }
+      }
+      return { valid: !0 }
+    }
+    updateAliasPreview() {
+      const e = document.getElementById('aliasPreview'),
+        t = document.getElementById('aliasName'),
+        a = document.getElementById('aliasCommands')
+      if (!e || !t || !a) return
+      const n = t.value.trim() || 'AliasName',
+        o = a.value.trim() || 'command sequence'
+      e.textContent = `alias ${n} <& ${o} &>`
+    }
+    updateCommandLibrary() {
+      const e = app.getCurrentProfile()
+      if (!e || !e.aliases) return
+      const t = document.getElementById('commandCategories')
+      if (!t) return
+      const a = t.querySelector('[data-category="aliases"]')
+      a && a.remove()
+      const n = t.querySelector('[data-category="vertigo-aliases"]')
+      n && n.remove()
+      const o = Object.entries(e.aliases),
+        i = o.filter(([e, t]) => !e.startsWith('dynFxSetFXExlusionList_')),
+        r = o.filter(([e, t]) => e.startsWith('dynFxSetFXExlusionList_'))
+      if (i.length > 0) {
+        const e = this.createAliasCategoryElement(
+          i,
+          'aliases',
+          'Command Aliases',
+          'fas fa-mask'
+        )
+        t.appendChild(e)
+      }
+      if (r.length > 0) {
+        const e = this.createAliasCategoryElement(
+          r,
+          'vertigo-aliases',
+          'VFX Aliases',
+          'fas fa-eye-slash'
+        )
+        t.appendChild(e)
+      }
+    }
+    createAliasCategoryElement(
+      e,
+      t = 'aliases',
+      a = 'Command Aliases',
+      n = 'fas fa-mask'
+    ) {
+      const o = document.createElement('div')
+      ;(o.className = 'category'), (o.dataset.category = t)
+      const i = `commandCategory_${t}_collapsed`,
+        r = 'true' === localStorage.getItem(i),
+        s = 'vertigo-aliases' === t,
+        c = s ? '👁️' : '🎭',
+        l = s ? 'command-item vertigo-alias-item' : 'command-item alias-item'
+      return (
+        (o.innerHTML = `\n            <h4 class="${r ? 'collapsed' : ''}" data-category="${t}">\n                <i class="fas fa-chevron-right category-chevron"></i>\n                <i class="${n}"></i> \n                ${a}\n                <span class="command-count">(${e.length})</span>\n            </h4>\n            <div class="category-commands ${r ? 'collapsed' : ''}">\n                ${e.map(([e, t]) => `\n                    <div class="${l}" data-alias="${e}" title="${t.description || t.commands}">\n                        ${c} ${e}\n                    </div>\n                `).join('')}\n            </div>\n        `),
+        o.querySelector('h4').addEventListener('click', () => {
+          this.toggleAliasCategory(t, o)
+        }),
+        o.addEventListener('click', (e) => {
+          if (
+            e.target.classList.contains('alias-item') ||
+            e.target.classList.contains('vertigo-alias-item')
+          ) {
+            const t = e.target.dataset.alias
+            this.addAliasToKey(t)
+          }
+        }),
+        o
+      )
+    }
+    toggleAliasCategory(e, t) {
+      const a = t.querySelector('h4'),
+        n = t.querySelector('.category-commands'),
+        o = a.querySelector('.category-chevron'),
+        i = `commandCategory_${e}_collapsed`
+      n.classList.contains('collapsed')
+        ? (n.classList.remove('collapsed'),
+          a.classList.remove('collapsed'),
+          (o.style.transform = 'rotate(90deg)'),
+          localStorage.setItem(i, 'false'))
+        : (n.classList.add('collapsed'),
+          a.classList.add('collapsed'),
+          (o.style.transform = 'rotate(0deg)'),
+          localStorage.setItem(i, 'true'))
+    }
+    addAliasToKey(e) {
+      if (!l.selectedKey)
+        return void stoUI.showToast('Please select a key first', 'warning')
+      const t = app.getCurrentProfile().aliases[e]
+      if (!t) return void stoUI.showToast('Alias not found', 'error')
+      const a = {
+        command: e,
+        type: 'alias',
+        icon: '🎭',
+        text: `Alias: ${e}`,
+        description: t.description,
+        id: app.generateCommandId(),
+      }
+      app.addCommand(l.selectedKey, a)
+    }
+    getAliasTemplates() {
+      return {
+        space_combat: {
+          name: 'Space Combat',
+          description: 'Aliases for space combat scenarios',
+          templates: {
+            AttackRun: {
+              name: 'AttackRun',
+              description: 'Full attack sequence with targeting',
+              commands:
+                'target_nearest_enemy $$ +STOTrayExecByTray 0 0 $$ +STOTrayExecByTray 0 1',
+            },
+            DefensiveMode: {
+              name: 'DefensiveMode',
+              description: 'Defensive abilities and shield management',
+              commands:
+                'target_self $$ +power_exec Distribute_Shields $$ +STOTrayExecByTray 2 0 $$ +STOTrayExecByTray 2 1',
+            },
+            HealSelf: {
+              name: 'HealSelf',
+              description: 'Self-healing sequence',
+              commands:
+                'target_self $$ +STOTrayExecByTray 3 0 $$ +STOTrayExecByTray 3 1',
+            },
+          },
+        },
+        ground_combat: {
+          name: 'Ground Combat',
+          description: 'Aliases for ground combat scenarios',
+          templates: {
+            GroundAttack: {
+              name: 'GroundAttack',
+              description: 'Basic ground combat sequence',
+              commands:
+                'target_nearest_enemy $$ +STOTrayExecByTray 0 0 $$ +STOTrayExecByTray 0 1',
+            },
+            GroundHeal: {
+              name: 'GroundHeal',
+              description: 'Ground healing sequence',
+              commands:
+                'target_self $$ +STOTrayExecByTray 1 0 $$ +STOTrayExecByTray 1 1',
+            },
+          },
+        },
+        communication: {
+          name: 'Communication',
+          description: 'Aliases for team communication',
+          templates: {
+            TeamReady: {
+              name: 'TeamReady',
+              description: 'Announce ready status to team',
+              commands: 'team Ready!',
+            },
+            NeedHealing: {
+              name: 'NeedHealing',
+              description: 'Request healing from team',
+              commands: 'team Need healing!',
+            },
+            Incoming: {
+              name: 'Incoming',
+              description: 'Warn team of incoming enemies',
+              commands: 'team Incoming enemies!',
+            },
+          },
+        },
+      }
+    }
+    createAliasFromTemplate(e, t) {
+      const a = this.getAliasTemplates(),
+        n = a[e]?.templates?.[t]
+      if (!n) return void stoUI.showToast('Template not found', 'error')
+      const o = app.getCurrentProfile()
+      o.aliases && o.aliases[n.name]
+        ? stoUI.showToast(`Alias "${n.name}" already exists`, 'warning')
+        : (o.aliases || (o.aliases = {}),
+          (o.aliases[n.name] = {
+            ...n,
+            created: new Date().toISOString(),
+            lastModified: new Date().toISOString(),
+          }),
+          app.saveProfile(),
+          app.setModified(!0),
+          this.updateCommandLibrary(),
+          this.renderAliasList(),
+          stoUI.showToast(`Alias "${n.name}" created from template`, 'success'))
+    }
+    getAliasUsage(e) {
+      const t = app.getCurrentProfile()
+      if (!t) return []
+      const a = []
+      return (
+        Object.entries(t.keys).forEach(([t, n]) => {
+          n.forEach((n, o) => {
+            ;(n.command === e || n.command.includes(e)) &&
+              a.push({
+                type: 'keybind',
+                key: t,
+                position: o + 1,
+                context: `Key "${t}", command ${o + 1}`,
+              })
+          })
+        }),
+        Object.entries(t.aliases || {}).forEach(([t, n]) => {
+          t !== e &&
+            n.commands.includes(e) &&
+            a.push({ type: 'alias', alias: t, context: `Alias "${t}"` })
+        }),
+        a
+      )
+    }
+    insertTargetVariable(e) {
+      const t = e.selectionStart,
+        a = e.value,
+        n = a.slice(0, t) + '$Target' + a.slice(t)
+      ;(e.value = n),
+        e.setSelectionRange(t + 7, t + 7),
+        e.focus(),
+        e.dispatchEvent(new Event('input', { bubbles: !0 }))
+    }
+  })(),
+  f = new (class {
+    constructor() {
+      this.exportFormats = {
+        sto_keybind: 'STO Keybind File (.txt)',
+        json_profile: 'JSON Profile (.json)',
+        json_project: 'Complete Project (.json)',
+        csv_data: 'CSV Data (.csv)',
+        html_report: 'HTML Report (.html)',
+      }
+    }
+    init() {
+      this.setupEventListeners()
+    }
+    setupEventListeners() {
+      i.onDom('exportKeybindsBtn', 'click', 'exportKeybinds', () => {
+        this.showExportOptions()
+      }),
+        i.onDom('copyPreviewBtn', 'click', 'copyPreview', () => {
+          this.copyCommandPreview()
+        })
+    }
+    async showExportOptions() {
+      const e = app.getCurrentProfile()
+      e
+        ? this.exportSTOKeybindFile(e)
+        : stoUI.showToast('No profile selected to export', 'warning')
+    }
+    exportSTOKeybindFile(e) {
+      try {
+        const t = this.generateSTOKeybindFile(e)
+        this.downloadFile(t, this.generateFileName(e, 'txt'), 'text/plain'),
+          stoUI.showToast('Keybind file exported successfully', 'success')
+      } catch (e) {
+        stoUI.showToast('Failed to export keybind file: ' + e.message, 'error')
+      }
+    }
+    generateSTOKeybindFile(e, t = {}) {
+      let a = ''
+      return (
+        (a += this.generateFileHeader(e)),
+        (a += this.generateKeybindSection(e.keys, {
+          ...t,
+          profile: e,
+          environment: t.environment || e.mode || 'space',
+        })),
+        (a += this.generateFileFooter()),
+        a
+      )
+    }
+    generateFileHeader(e) {
+      const t = new Date().toLocaleString()
+      let a
+      return (
+        'undefined' != typeof stoKeybinds && stoKeybinds.getProfileStats
+          ? (a = stoKeybinds.getProfileStats(e))
+          : ((a = {
+              totalKeys: Object.keys(e.keys || {}).length,
+              totalCommands: 0,
+            }),
+            Object.values(e.keys || {}).forEach((e) => {
+              a.totalCommands += e.length
+            })),
+        `; ================================================================\n; ${e.name} - STO Keybind Configuration\n; ================================================================\n; Mode: ${e.mode.toUpperCase()}\n; Generated: ${t}\n; Created by: STO Tools Keybind Manager v${STO_DATA.settings.version}\n;\n; Keybind Statistics:\n; - Keys bound: ${a.totalKeys}\n; - Total commands: ${a.totalCommands}\n;\n; Note: Aliases are exported separately\n; To use this file in Star Trek Online:\n; 1. Save this file to your STO Live folder\n; 2. In game, type: /bind_load_file ${this.generateFileName(e, 'txt')}\n; ================================================================\n\n`
+      )
+    }
+    generateAliasSection(e) {
+      if (!e || 0 === Object.keys(e).length) return ''
+      let t =
+        '; Command Aliases\n; ================================================================\n; Aliases allow you to create custom commands that execute\n; multiple commands in sequence. Use them in keybinds like any\n; other command.\n; ================================================================\n\n'
+      return (
+        Object.entries(e)
+          .sort(([e], [t]) => e.localeCompare(t))
+          .forEach(([e, a]) => {
+            a.description && (t += `; ${a.description}\n`),
+              (t += `alias ${e} <& ${a.commands} &>\n\n`)
+          }),
+        t
+      )
+    }
+    generateKeybindSection(e, t = {}) {
+      if (!e || 0 === Object.keys(e).length) return '; No keybinds defined\n\n'
+      let a,
+        n =
+          '; Keybind Commands\n; ================================================================\n; Each line binds a key to one or more commands.\n; Multiple commands are separated by $$'
+      t.stabilizeExecutionOrder &&
+        (n +=
+          '\n; EXECUTION ORDER STABILIZATION: ON\n; Commands are mirrored to ensure consistent execution order\n; Phase 1: left-to-right, Phase 2: right-to-left'),
+        (n +=
+          '\n; ================================================================\n\n'),
+        (a =
+          'undefined' != typeof stoKeybinds && stoKeybinds.compareKeys
+            ? Object.keys(e).sort(stoKeybinds.compareKeys.bind(stoKeybinds))
+            : Object.keys(e).sort(this.compareKeys.bind(this)))
+      const o = this.groupKeysByType(a, e)
+      return (
+        Object.entries(o).forEach(([a, o]) => {
+          0 !== o.length &&
+            ((n += `; ${a}\n`),
+            (n += `; ${'-'.repeat(a.length)}\n`),
+            o.forEach((a) => {
+              const o = e[a]
+              if (o && o.length > 0) {
+                let e
+                const i = t.stabilizeExecutionOrder
+                let r = !1
+                if (t.profile && t.profile.keybindMetadata)
+                  if (
+                    t.environment &&
+                    t.profile.keybindMetadata[t.environment]
+                  ) {
+                    const e = t.profile.keybindMetadata[t.environment]
+                    r = !!(e && e[a] && e[a].stabilizeExecutionOrder)
+                  } else
+                    r = !(
+                      !t.profile.keybindMetadata[a] ||
+                      !t.profile.keybindMetadata[a].stabilizeExecutionOrder
+                    )
+                ;(e =
+                  (i || r) && o.length > 1 && stoKeybinds
+                    ? stoKeybinds.generateMirroredCommandString(o)
+                    : o.map((e) => e.command).join(' $$ ')),
+                  (n += `${a} "${e}"\n`)
+              }
+            }),
+            (n += '\n'))
+        }),
+        n
+      )
+    }
+    compareKeys(e, t) {
+      const a = e.match(/^F(\d+)$/),
+        n = t.match(/^F(\d+)$/)
+      if (a && n) return parseInt(a[1]) - parseInt(n[1])
+      if (a && !n) return -1
+      if (!a && n) return 1
+      const o = /^\d+$/.test(e),
+        i = /^\d+$/.test(t)
+      if (o && i) return parseInt(e) - parseInt(t)
+      if (o && !i) return -1
+      if (!o && i) return 1
+      const r = /^[A-Z]$/.test(e),
+        s = /^[A-Z]$/.test(t)
+      if (r && s) return e.localeCompare(t)
+      if (r && !s) return -1
+      if (!r && s) return 1
+      const c = ['Space', 'Tab', 'Enter', 'Escape'],
+        l = c.indexOf(e),
+        d = c.indexOf(t)
+      return -1 !== l && -1 !== d
+        ? l - d
+        : -1 !== l && -1 === d
+          ? -1
+          : -1 === l && -1 !== d
+            ? 1
+            : e.localeCompare(t)
+    }
+    groupKeysByType(e, t) {
+      const a = {
+        'Function Keys': [],
+        'Number Keys': [],
+        'Letter Keys': [],
+        'Special Keys': [],
+        'Modifier Combinations': [],
+      }
+      return (
+        e.forEach((e) => {
+          ;/^F\d+$/.test(e)
+            ? a['Function Keys'].push(e)
+            : /^\d+$/.test(e)
+              ? a['Number Keys'].push(e)
+              : /^[A-Z]$/.test(e)
+                ? a['Letter Keys'].push(e)
+                : e.includes('+')
+                  ? a['Modifier Combinations'].push(e)
+                  : a['Special Keys'].push(e)
+        }),
+        a
+      )
+    }
+    generateFileFooter() {
+      return '; ================================================================\n; End of keybind file\n; ================================================================\n; \n; Additional STO Commands Reference:\n; \n; Targeting:\n;   target_nearest_enemy    - Target closest hostile\n;   target_nearest_friend   - Target closest friendly\n;   target_self            - Target your own ship\n; \n; Combat:\n;   FireAll               - Fire all weapons\n;   FirePhasers          - Fire beam weapons only\n;   FireTorps            - Fire torpedo weapons only\n; \n; Shield Management:\n;   +power_exec <ability> - Execute bridge officer ability\n;   Examples: +power_exec Distribute_Shields \n; \n; Tray Execution:\n;   +STOTrayExecByTray <tray> <slot> - Execute ability from tray\n;   Example: +STOTrayExecByTray 0 0  (Tray 1, Slot 1)\n; \n; For more commands and help, visit the STO Wiki or community forums.\n; ================================================================\n'
+    }
+    exportJSONProfile(e) {
+      try {
+        const t = {
+            version: STO_DATA.settings.version,
+            exported: new Date().toISOString(),
+            type: 'profile',
+            profile: this.sanitizeProfileForExport(e),
+          },
+          a = JSON.stringify(t, null, 2)
+        this.downloadFile(
+          a,
+          this.generateFileName(e, 'json'),
+          'application/json'
+        ),
+          stoUI.showToast('Profile exported as JSON', 'success')
+      } catch (e) {
+        stoUI.showToast('Failed to export profile: ' + e.message, 'error')
+      }
+    }
+    exportCompleteProject() {
+      try {
+        const e = stoStorage.getAllData(),
+          t = {
+            version: STO_DATA.settings.version,
+            exported: new Date().toISOString(),
+            type: 'project',
+            data: e,
+          },
+          a = JSON.stringify(t, null, 2),
+          n = `STO_Tools_Keybinds_Project_${new Date().toISOString().split('T')[0]}.json`
+        this.downloadFile(a, n, 'application/json'),
+          stoUI.showToast('Complete project exported', 'success')
+      } catch (e) {
+        stoUI.showToast('Failed to export project: ' + e.message, 'error')
+      }
+    }
+    exportCSVData(e) {
+      try {
+        const t = this.generateCSVData(e)
+        this.downloadFile(t, this.generateFileName(e, 'csv'), 'text/csv'),
+          stoUI.showToast('Data exported as CSV', 'success')
+      } catch (e) {
+        stoUI.showToast('Failed to export CSV: ' + e.message, 'error')
+      }
+    }
+    generateCSVData(e) {
+      let t = 'Key,Command,Type,Description,Position\n'
+      return (
+        Object.entries(e.keys).forEach(([e, a]) => {
+          a.forEach((a, n) => {
+            const o = [
+              this.escapeCSV(e),
+              this.escapeCSV(a.command),
+              this.escapeCSV(a.type),
+              this.escapeCSV(a.text || ''),
+              n + 1,
+            ].join(',')
+            t += o + '\n'
+          })
+        }),
+        t
+      )
+    }
+    escapeCSV(e) {
+      return (
+        'string' != typeof e && (e = String(e)),
+        e.includes(',') || e.includes('"') || e.includes('\n')
+          ? '"' + e.replace(/"/g, '""') + '"'
+          : e
+      )
+    }
+    exportHTMLReport(e) {
+      try {
+        const t = this.generateHTMLReport(e)
+        this.downloadFile(t, this.generateFileName(e, 'html'), 'text/html'),
+          stoUI.showToast('HTML report exported', 'success')
+      } catch (e) {
+        stoUI.showToast('Failed to export HTML report: ' + e.message, 'error')
+      }
+    }
+    generateHTMLReport(e) {
+      const t = stoKeybinds.getProfileStats(e),
+        a = new Date().toLocaleString()
+      return `<!DOCTYPE html>\n<html lang="en">\n<head>\n    <meta charset="UTF-8">\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>${e.name} - STO Keybind Report</title>\n    <style>\n        body { font-family: Arial, sans-serif; margin: 40px; line-height: 1.6; }\n        .header { border-bottom: 2px solid #333; padding-bottom: 20px; margin-bottom: 30px; }\n        .stats { background: #f5f5f5; padding: 20px; border-radius: 5px; margin-bottom: 30px; }\n        .keybind-group { margin-bottom: 30px; }\n        .keybind-group h3 { color: #333; border-bottom: 1px solid #ccc; padding-bottom: 5px; }\n        .keybind { margin-bottom: 15px; padding: 10px; background: #fafafa; border-left: 4px solid #007acc; }\n        .key { font-weight: bold; color: #007acc; }\n        .commands { margin-top: 5px; }\n        .command { display: inline-block; margin: 2px 5px 2px 0; padding: 2px 8px; background: #e0e0e0; border-radius: 3px; font-size: 0.9em; }\n        .command.targeting { background: #d4edda; }\n        .command.combat { background: #f8d7da; }\n        .command.tray { background: #cce5ff; }\n        .command.power { background: #fff3cd; }\n        .command.alias { background: #e2e3e5; }\n        .aliases { margin-top: 30px; }\n        .alias { margin-bottom: 15px; padding: 10px; background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 5px; }\n        .alias-name { font-weight: bold; color: #495057; }\n        .alias-commands { font-family: monospace; background: #e9ecef; padding: 5px; margin-top: 5px; border-radius: 3px; }\n    </style>\n</head>\n<body>\n    <div class="header">\n        <h1>${e.name}</h1>\n        <p><strong>Mode:</strong> ${e.mode.toUpperCase()}</p>\n        <p><strong>Generated:</strong> ${a}</p>\n        <p><strong>Created by:</strong> STO Tools Keybind Manager v${STO_DATA.settings.version}</p>\n    </div>\n\n    <div class="stats">\n        <h2>Statistics</h2>\n        <ul>\n            <li><strong>Keys Bound:</strong> ${t.totalKeys}</li>\n            <li><strong>Total Commands:</strong> ${t.totalCommands}</li>\n            <li><strong>Aliases Defined:</strong> ${t.totalAliases}</li>\n        </ul>\n    </div>\n\n    ${this.generateHTMLKeybindSection(e.keys)}\n    ${this.generateHTMLAliasSection(e.aliases)}\n\n    <div style="margin-top: 50px; padding-top: 20px; border-top: 1px solid #ccc; color: #666; font-size: 0.9em;">\n        <p>This report was generated by STO Tools Keybind Manager. For more information about Star Trek Online keybinds, visit the STO Wiki.</p>\n    </div>\n</body>\n</html>`
+    }
+    generateHTMLKeybindSection(e) {
+      if (!e || 0 === Object.keys(e).length)
+        return '<div class="keybind-group"><h2>Keybinds</h2><p>No keybinds defined.</p></div>'
+      const t = Object.keys(e).sort(stoKeybinds.compareKeys.bind(stoKeybinds)),
+        a = this.groupKeysByType(t, e)
+      let n = '<div class="keybind-group"><h2>Keybinds</h2>'
+      return (
+        Object.entries(a).forEach(([t, a]) => {
+          0 !== a.length &&
+            ((n += `<h3>${t}</h3>`),
+            a.forEach((t) => {
+              const a = e[t]
+              a &&
+                a.length > 0 &&
+                (n += `<div class="keybind">\n                        <div class="key">${t}</div>\n                        <div class="commands">\n                            ${a.map((e) => `<span class="command ${e.type}">${e.text || e.command}</span>`).join('')}\n                        </div>\n                    </div>`)
+            }))
+        }),
+        (n += '</div>'),
+        n
+      )
+    }
+    generateHTMLAliasSection(e) {
+      if (!e || 0 === Object.keys(e).length) return ''
+      let t = '<div class="aliases"><h2>Command Aliases</h2>'
+      return (
+        Object.entries(e)
+          .sort(([e], [t]) => e.localeCompare(t))
+          .forEach(([e, a]) => {
+            t += `<div class="alias">\n                <div class="alias-name">${e}</div>\n                ${a.description ? `<div>${a.description}</div>` : ''}\n                <div class="alias-commands">${a.commands}</div>\n            </div>`
+          }),
+        (t += '</div>'),
+        t
+      )
+    }
+    copyCommandPreview() {
+      const e = document.getElementById('commandPreview')
+      e && e.textContent.trim()
+        ? stoUI.copyToClipboard(e.textContent)
+        : stoUI.showToast('No command to copy', 'warning')
+    }
+    generateFileName(e, t) {
+      const a = e.name.replace(/[^a-zA-Z0-9\-_]/g, '_'),
+        n = new Date().toISOString().split('T')[0]
+      return `${a}_${e.mode || 'space'}_${n}.${t}`
+    }
+    downloadFile(e, t, a) {
+      const n = new Blob([e], { type: a }),
+        o = URL.createObjectURL(n),
+        i = document.createElement('a')
+      ;(i.href = o),
+        (i.download = t),
+        document.body.appendChild(i),
+        i.click(),
+        document.body.removeChild(i),
+        URL.revokeObjectURL(o)
+    }
+    sanitizeProfileForExport(e) {
+      const t = JSON.parse(JSON.stringify(e))
+      return (
+        t.keys &&
+          Object.values(t.keys).forEach((e) => {
+            e.forEach((e) => {
+              delete e.id
+            })
+          }),
+        t
+      )
+    }
+    exportAllProfiles() {
+      const e = stoStorage.getAllData().profiles
+      e && 0 !== Object.keys(e).length
+        ? (Object.entries(e).forEach(([e, t]) => {
+            setTimeout(() => {
+              this.exportSTOKeybindFile(t)
+            }, 100)
+          }),
+          stoUI.showToast(
+            `Exporting ${Object.keys(e).length} profiles...`,
+            'info'
+          ))
+        : stoUI.showToast('No profiles to export', 'warning')
+    }
+    async importFromFile(e) {
+      return new Promise((t, a) => {
+        const n = new FileReader()
+        ;(n.onload = (n) => {
+          try {
+            const o = n.target.result
+            switch (e.name.split('.').pop().toLowerCase()) {
+              case 'txt':
+                t(stoKeybinds.importKeybindFile(o))
+                break
+              case 'json':
+                t(this.importJSONFile(o))
+                break
+              default:
+                a(new Error('Unsupported file format'))
+            }
+          } catch (e) {
+            a(e)
+          }
+        }),
+          (n.onerror = () => a(new Error('Failed to read file'))),
+          n.readAsText(e)
+      })
+    }
+    importJSONFile(e) {
+      try {
+        const t = JSON.parse(e)
+        if ('profile' === t.type && t.profile)
+          return stoProfiles.importProfile(e)
+        if ('project' === t.type && t.data)
+          return stoStorage.importData(JSON.stringify(t.data))
+        throw new Error('Unknown JSON file format')
+      } catch (e) {
+        throw new Error('Invalid JSON file: ' + e.message)
+      }
+    }
+    exportAliases(e) {
+      try {
+        const t = this.generateAliasFile(e)
+        this.downloadFile(
+          t,
+          this.generateAliasFileName(e, 'txt'),
+          'text/plain'
+        ),
+          stoUI.showToast('Aliases exported successfully', 'success')
+      } catch (e) {
+        stoUI.showToast('Failed to export aliases: ' + e.message, 'error')
+      }
+    }
+    generateAliasFile(e) {
+      let t = ''
+      const a = new Date().toLocaleString(),
+        n = Object.keys(e.aliases || {}).length
+      return (
+        (t += `; ================================================================\n; ${e.name} - STO Alias Configuration\n; ================================================================\n; Mode: ${e.mode.toUpperCase()}\n; Generated: ${a}\n; Created by: STO Tools Keybind Manager v${STO_DATA.settings.version}\n;\n; Alias Statistics:\n; - Total aliases: ${n}\n;\n; To use these aliases in Star Trek Online:\n; 1. Save this file as "CommandAliases.txt" (exactly, without quotes)\n; 2. Place it in your STO directory:\n;    [STO Install]\\Star Trek Online\\Live\\localdata\\CommandAliases.txt\n; 3. The aliases will be available when you start the game\n;\n; Alternative: You can append these aliases to an existing CommandAliases.txt\n; file if you already have one with other aliases.\n;\n; Common STO installation paths:\n; - Steam: C:\\Program Files (x86)\\Steam\\steamapps\\common\\Star Trek Online\n; - Epic: C:\\Program Files\\Epic Games\\Star Trek Online  \n; - Arc: C:\\Program Files (x86)\\Perfect World Entertainment\\Arc Games\\Star Trek Online\n; ================================================================\n\n`),
+        e.aliases && Object.keys(e.aliases).length > 0
+          ? (t += this.generateAliasSection(e.aliases))
+          : (t += '; No aliases defined\n\n'),
+        t
+      )
+    }
+    generateAliasFileName(e, t) {
+      const a = e.name.replace(/[^a-zA-Z0-9\-_]/g, '_'),
+        n = new Date().toISOString().split('T')[0]
+      return `${a}_aliases_${e.mode || 'space'}_${n}.${t}`
+    }
+  })(),
+  h = new (class {
+    constructor() {
+      this.overlayId = 'modalOverlay'
+    }
+    getOverlay() {
+      return document.getElementById(this.overlayId)
+    }
+    show(e) {
+      const t = 'string' == typeof e ? document.getElementById(e) : e,
+        a = this.getOverlay()
+      if (a && t) {
+        a.classList.add('active'),
+          t.classList.add('active'),
+          document.body.classList.add('modal-open')
+        const e = t.querySelector('input, textarea, select')
+        return e && setTimeout(() => e.focus(), 100), !0
+      }
+      return !1
+    }
+    hide(e) {
+      const t = 'string' == typeof e ? document.getElementById(e) : e,
+        a = this.getOverlay()
+      return !(
+        !a ||
+        !t ||
+        (t.classList.remove('active'),
+        document.querySelector('.modal.active') ||
+          (a.classList.remove('active'),
+          document.body.classList.remove('modal-open')),
+        0)
+      )
+    }
+  })(),
+  g = new (class {
+    constructor() {
+      ;(this.toastQueue = []),
+        (this.dragState = {
+          isDragging: !1,
+          dragElement: null,
+          dragData: null,
+        }),
+        this.init()
+    }
+    init() {
+      this.setupGlobalEventListeners(), this.setupTooltips()
+    }
+    showToast(e, t = 'info', a = 3e3) {
+      const n = this.createToast(e, t, a),
+        o = document.getElementById('toastContainer')
+      o &&
+        (o.appendChild(n),
+        requestAnimationFrame(() => {
+          n.classList.add('show')
+        }),
+        setTimeout(() => {
+          this.removeToast(n)
+        }, a))
+    }
+    createToast(e, t, a) {
+      const n = document.createElement('div')
+      n.className = `toast toast-${t}`
+      const o = {
+        success: 'fa-check-circle',
+        error: 'fa-exclamation-circle',
+        warning: 'fa-exclamation-triangle',
+        info: 'fa-info-circle',
+      }
+      return (
+        (n.innerHTML = `\n            <div class="toast-content">\n                <i class="fas ${o[t] || o.info}"></i>\n                <span class="toast-message">${e}</span>\n                <button class="toast-close">\n                    <i class="fas fa-times"></i>\n                </button>\n            </div>\n        `),
+        n.querySelector('.toast-close').addEventListener('click', () => {
+          this.removeToast(n)
+        }),
+        n
+      )
+    }
+    hideToast(e) {
+      e && e.parentNode && this.removeToast(e)
+    }
+    removeToast(e) {
+      e.classList.add('removing'),
+        setTimeout(() => {
+          e.parentNode && e.parentNode.removeChild(e)
+        }, 300)
+    }
+    showModal(e, t = null) {
+      return (
+        document.getElementById(e),
+        !!modalManager.show(e) && (t && this.populateModalData(e, t), !0)
+      )
+    }
+    hideModal(e) {
+      return (
+        document.getElementById(e),
+        !!modalManager.hide(e) && (this.clearModalData(e), !0)
+      )
+    }
+    hideAllModals() {
+      document.querySelectorAll('.modal.active').forEach((e) => {
+        modalManager.hide(e.id)
+      })
+    }
+    populateModalData(e, t) {
+      const a = document.getElementById(e)
+      a &&
+        Object.entries(t).forEach(([e, t]) => {
+          const n = a.querySelector(`[data-field="${e}"], #${e}`)
+          n && ('checkbox' === n.type ? (n.checked = t) : (n.value = t))
+        })
+    }
+    clearModalData(e) {
+      const t = document.getElementById(e)
+      t &&
+        t.querySelectorAll('input, textarea, select').forEach((e) => {
+          'checkbox' === e.type ? (e.checked = !1) : (e.value = '')
+        })
+    }
+    showLoading(e, t = 'Loading...') {
+      if (('string' == typeof e && (e = document.getElementById(e)), e)) {
+        e.classList.add('loading')
+        const a = e.innerHTML
+        ;(e.dataset.originalContent = a),
+          (e.innerHTML = `\n                <div class="loading-spinner">\n                    <i class="fas fa-spinner fa-spin"></i>\n                    <span>${t}</span>\n                </div>\n            `),
+          (e.disabled = !0)
+      }
+    }
+    hideLoading(e) {
+      'string' == typeof e && (e = document.getElementById(e)),
+        e &&
+          e.classList.contains('loading') &&
+          (e.classList.remove('loading'),
+          (e.innerHTML = e.dataset.originalContent || ''),
+          (e.disabled = !1),
+          delete e.dataset.originalContent)
+    }
+    async confirm(e, t = 'Confirm', a = 'warning') {
+      return new Promise((n) => {
+        const o = this.createConfirmModal(e, t, a),
+          i = 'confirmModal'
+        ;(o.id = i), document.body.appendChild(o)
+        const r = (e) => {
+          modalManager.hide(i), document.body.removeChild(o), n(e)
+        }
+        o.querySelector('.confirm-yes').addEventListener('click', () => {
+          r(!0)
+        }),
+          o.querySelector('.confirm-no').addEventListener('click', () => {
+            r(!1)
+          }),
+          requestAnimationFrame(() => {
+            modalManager.show(i)
+          })
+      })
+    }
+    createConfirmModal(e, t, a) {
+      const n = document.createElement('div')
+      n.className = 'modal confirm-modal'
+      const o = {
+        warning: 'fa-exclamation-triangle',
+        danger: 'fa-exclamation-circle',
+        info: 'fa-info-circle',
+      }
+      return (
+        (n.innerHTML = `\n            <div class="modal-content">\n                <div class="modal-header">\n                    <h3>\n                        <i class="fas ${o[a] || o.warning}"></i>\n                        ${t}\n                    </h3>\n                </div>\n                <div class="modal-body">\n                    <p>${e}</p>\n                </div>\n                <div class="modal-footer">\n                    <button class="btn btn-primary confirm-yes">Yes</button>\n                    <button class="btn btn-secondary confirm-no">No</button>\n                </div>\n            </div>\n        `),
+        n
+      )
+    }
+    initDragAndDrop(e, t = {}) {
+      const {
+        dragSelector: a = '.draggable',
+        dropZoneSelector: n = '.drop-zone',
+        onDragStart: o = null,
+        onDragEnd: i = null,
+        onDrop: r = null,
+      } = t
+      e.addEventListener('dragstart', (e) => {
+        e.target.matches(a) &&
+          ((this.dragState.isDragging = !0),
+          (this.dragState.dragElement = e.target),
+          (this.dragState.dragData = e.target.dataset),
+          e.target.classList.add('dragging'),
+          (e.dataTransfer.effectAllowed = 'move'),
+          o && o(e, this.dragState))
+      }),
+        e.addEventListener('dragend', (e) => {
+          e.target.matches(a) &&
+            (e.target.classList.remove('dragging'),
+            (this.dragState.isDragging = !1),
+            (this.dragState.dragElement = null),
+            (this.dragState.dragData = null),
+            i && i(e))
+        }),
+        e.addEventListener('dragover', (e) => {
+          e.preventDefault()
+          const t = e.target.closest(n)
+          t && t.classList.add('drag-over')
+        }),
+        e.addEventListener('dragleave', (e) => {
+          const t = e.target.closest(n)
+          t && t.classList.remove('drag-over')
+        }),
+        e.addEventListener('drop', (e) => {
+          e.preventDefault()
+          const t = e.target.closest(n)
+          t && (t.classList.remove('drag-over'), r && r(e, this.dragState, t))
+        })
+    }
+    validateForm(e) {
+      const t = []
+      return (
+        e
+          .querySelectorAll(
+            'input[required], textarea[required], select[required]'
+          )
+          .forEach((e) => {
+            const a = e.value.trim(),
+              n = e.dataset.fieldName || e.name || e.id
+            a
+              ? (e.classList.remove('error'),
+                'email' !== e.type ||
+                  this.isValidEmail(a) ||
+                  (t.push(`${n} must be a valid email`),
+                  e.classList.add('error')))
+              : (t.push(`${n} is required`), e.classList.add('error'))
+          }),
+        { isValid: 0 === t.length, errors: t }
+      )
+    }
+    isValidEmail(e) {
+      return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e)
+    }
+    async copyToClipboard(e) {
+      try {
+        return (
+          await navigator.clipboard.writeText(e),
+          this.showToast('Copied to clipboard', 'success'),
+          !0
+        )
+      } catch (t) {
+        const a = document.createElement('textarea')
+        ;(a.value = e), document.body.appendChild(a), a.select()
+        try {
+          return (
+            document.execCommand('copy'),
+            this.showToast('Copied to clipboard', 'success'),
+            !0
+          )
+        } catch (e) {
+          return this.showToast('Failed to copy to clipboard', 'error'), !1
+        } finally {
+          document.body.removeChild(a)
+        }
+      }
+    }
+    fadeIn(e, t = 300) {
+      ;(e.style.opacity = '0'), (e.style.display = 'block')
+      let a = null
+      const n = (o) => {
+        a || (a = o)
+        const i = o - a,
+          r = Math.min(i / t, 1)
+        ;(e.style.opacity = r), i < t && requestAnimationFrame(n)
+      }
+      requestAnimationFrame(n)
+    }
+    fadeOut(e, t = 300) {
+      let a = null
+      const n = (o) => {
+        a || (a = o)
+        const i = o - a,
+          r = Math.max(1 - i / t, 0)
+        ;(e.style.opacity = r),
+          i < t ? requestAnimationFrame(n) : (e.style.display = 'none')
+      }
+      requestAnimationFrame(n)
+    }
+    debounce(e, t) {
+      let a
+      return function (...n) {
+        clearTimeout(a),
+          (a = setTimeout(() => {
+            clearTimeout(a), e(...n)
+          }, t))
+      }
+    }
+    throttle(e, t) {
+      let a
+      return function () {
+        const n = arguments
+        a || (e.apply(this, n), (a = !0), setTimeout(() => (a = !1), t))
+      }
+    }
+    setupGlobalEventListeners() {
+      document.addEventListener('keydown', (e) => {
+        'Escape' === e.key && this.hideAllModals()
+      }),
+        document.addEventListener('click', (e) => {
+          e.target.classList.contains('modal-overlay') && this.hideAllModals()
+        })
+    }
+    setupTooltips() {
+      document.addEventListener(
+        'mouseenter',
+        (e) => {
+          e.target &&
+            'function' == typeof e.target.hasAttribute &&
+            e.target.hasAttribute('title') &&
+            e.target.getAttribute('title').trim() &&
+            this.showTooltip(e.target, e.target.getAttribute('title'))
+        },
+        !0
+      ),
+        document.addEventListener(
+          'mouseleave',
+          (e) => {
+            e.target &&
+              'function' == typeof e.target.hasAttribute &&
+              e.target.hasAttribute('title') &&
+              this.hideTooltip()
+          },
+          !0
+        )
+    }
+    showTooltip(e, t) {
+      this.hideTooltip()
+      const a = document.createElement('div')
+      ;(a.className = 'tooltip'),
+        (a.textContent = t),
+        (a.id = 'active-tooltip'),
+        document.body.appendChild(a)
+      const n = e.getBoundingClientRect(),
+        o = a.getBoundingClientRect()
+      let i = n.left + n.width / 2 - o.width / 2,
+        r = n.top - o.height - 8
+      i < 8 && (i = 8),
+        i + o.width > window.innerWidth - 8 &&
+          (i = window.innerWidth - o.width - 8),
+        r < 8 && ((r = n.bottom + 8), a.classList.add('tooltip-bottom')),
+        (a.style.left = i + 'px'),
+        (a.style.top = r + 'px'),
+        requestAnimationFrame(() => {
+          a.classList.add('show')
+        })
+    }
+    hideTooltip() {
+      const e = document.getElementById('active-tooltip')
+      e && e.remove()
+    }
+  })(),
+  _ = new (class {
+    constructor() {
+      ;(this.currentCommand = null),
+        (this.commandBuilders = new Map()),
+        this.init()
+    }
+    init() {
+      this.setupCommandBuilders(), this.setupEventListeners()
+    }
+    setupCommandBuilders() {
+      this.commandBuilders.set('targeting', {
+        build: (e, t = {}) => {
+          const a = STO_DATA.commands.targeting.commands[e]
+          return a
+            ? {
+                command: a.command,
+                type: 'targeting',
+                icon: a.icon,
+                text: a.name,
+                description: a.description,
+              }
+            : null
+        },
+        getUI: () => this.createTargetingUI(),
+      }),
+        this.commandBuilders.set('combat', {
+          build: (e, t = {}) => {
+            const a = STO_DATA.commands.combat.commands[e]
+            return a
+              ? {
+                  command: a.command,
+                  type: 'combat',
+                  icon: a.icon,
+                  text: a.name,
+                  description: a.description,
+                }
+              : null
+          },
+          getUI: () => this.createCombatUI(),
+        }),
+        this.commandBuilders.set('tray', {
+          build: (e, t = {}) => {
+            const a = t.tray || 0,
+              n = t.slot || 0
+            if ('tray_with_backup' === e) {
+              const e = t.backup_tray || 0,
+                o = t.backup_slot || 0,
+                i = t.active || 'on'
+              return {
+                command: `TrayExecByTrayWithBackup ${a} ${n} ${e} ${o} ${'on' === i ? 1 : 0}`,
+                type: 'tray',
+                icon: '⚡',
+                text: `Execute Tray ${a + 1} Slot ${n + 1} (with backup)`,
+                description: `Execute ability in tray ${a + 1}, slot ${n + 1} with backup in tray ${e + 1}, slot ${o + 1}`,
+                parameters: {
+                  tray: a,
+                  slot: n,
+                  backup_tray: e,
+                  backup_slot: o,
+                  active: i,
+                },
+              }
+            }
+            if ('tray_range' === e) {
+              const e = t.start_tray || 0,
+                a = t.start_slot || 0,
+                n = t.end_tray || 0,
+                o = t.end_slot || 0,
+                i = t.command_type || 'STOTrayExecByTray'
+              return this.generateTrayRangeCommands(e, a, n, o, i).map(
+                (t, r) => ({
+                  command: t,
+                  type: 'tray',
+                  icon: '⚡',
+                  text:
+                    0 === r
+                      ? `Execute Range: Tray ${e + 1} Slot ${a + 1} to Tray ${n + 1} Slot ${o + 1}`
+                      : t,
+                  description:
+                    0 === r
+                      ? `Execute abilities from tray ${e + 1} slot ${a + 1} to tray ${n + 1} slot ${o + 1}`
+                      : t,
+                  parameters:
+                    0 === r
+                      ? {
+                          start_tray: e,
+                          start_slot: a,
+                          end_tray: n,
+                          end_slot: o,
+                          command_type: i,
+                        }
+                      : void 0,
+                })
+              )
+            }
+            if ('tray_range_with_backup' === e) {
+              const e = t.active || 1,
+                a = t.start_tray || 0,
+                n = t.start_slot || 0,
+                o = t.end_tray || 0,
+                i = t.end_slot || 0,
+                r = t.backup_start_tray || 0,
+                s = t.backup_start_slot || 0,
+                c = t.backup_end_tray || 0,
+                l = t.backup_end_slot || 0
+              return this.generateTrayRangeWithBackupCommands(
+                e,
+                a,
+                n,
+                o,
+                i,
+                r,
+                s,
+                c,
+                l
+              ).map((t, d) => ({
+                command: t,
+                type: 'tray',
+                icon: '⚡',
+                text:
+                  0 === d
+                    ? `Execute Range with Backup: Tray ${a + 1}-${o + 1}`
+                    : t,
+                description:
+                  0 === d
+                    ? `Execute abilities from tray ${a + 1} to ${o + 1} with backup range`
+                    : t,
+                parameters:
+                  0 === d
+                    ? {
+                        active: e,
+                        start_tray: a,
+                        start_slot: n,
+                        end_tray: o,
+                        end_slot: i,
+                        backup_start_tray: r,
+                        backup_start_slot: s,
+                        backup_end_tray: c,
+                        backup_end_slot: l,
+                      }
+                    : void 0,
+              }))
+            }
+            if ('whole_tray' === e) {
+              const e = t.command_type || 'STOTrayExecByTray'
+              return this.generateWholeTrayCommands(a, e).map((t, n) => ({
+                command: t,
+                type: 'tray',
+                icon: '⚡',
+                text: 0 === n ? `Execute Whole Tray ${a + 1}` : t,
+                description:
+                  0 === n ? `Execute all abilities in tray ${a + 1}` : t,
+                parameters: 0 === n ? { tray: a, command_type: e } : void 0,
+              }))
+            }
+            if ('whole_tray_with_backup' === e) {
+              const e = t.active || 1,
+                n = t.backup_tray || 0
+              return this.generateWholeTrayWithBackupCommands(e, a, n).map(
+                (t, o) => ({
+                  command: t,
+                  type: 'tray',
+                  icon: '⚡',
+                  text:
+                    0 === o
+                      ? `Execute Whole Tray ${a + 1} (with backup Tray ${n + 1})`
+                      : t,
+                  description:
+                    0 === o
+                      ? `Execute all abilities in tray ${a + 1} with backup from tray ${n + 1}`
+                      : t,
+                  parameters:
+                    0 === o ? { active: e, tray: a, backup_tray: n } : void 0,
+                })
+              )
+            }
+            const o = t.command_type || 'STOTrayExecByTray'
+            return {
+              command: `+${o} ${a} ${n}`,
+              type: 'tray',
+              icon: '⚡',
+              text: `Execute Tray ${a + 1} Slot ${n + 1}`,
+              description: `Execute ability in tray ${a + 1}, slot ${n + 1}`,
+              parameters: { tray: a, slot: n, command_type: o },
+            }
+          },
+          getUI: () => this.createTrayUI(),
+        }),
+        this.commandBuilders.set('power', {
+          build: (e, t = {}) => {
+            const a = STO_DATA.commands.power.commands[e]
+            return a
+              ? {
+                  command: a.command,
+                  type: 'power',
+                  icon: a.icon,
+                  text: a.name,
+                  description: a.description,
+                }
+              : null
+          },
+          getUI: () => this.createPowerUI(),
+        }),
+        this.commandBuilders.set('movement', {
+          build: (e, t = {}) => {
+            const a = STO_DATA.commands.movement.commands[e]
+            if (!a) return null
+            let n = a.command
+            return (
+              a.customizable &&
+                t &&
+                ('throttle_adjust' === e && void 0 !== t.amount
+                  ? (n = `${a.command} ${t.amount}`)
+                  : 'throttle_set' === e &&
+                    void 0 !== t.position &&
+                    (n = `${a.command} ${t.position}`)),
+              {
+                command: n,
+                type: 'movement',
+                icon: a.icon,
+                text: a.name,
+                description: a.description,
+              }
+            )
+          },
+          getUI: () => this.createMovementUI(),
+        }),
+        this.commandBuilders.set('camera', {
+          build: (e, t = {}) => {
+            const a = STO_DATA.commands.camera.commands[e]
+            if (!a) return null
+            let n = a.command
+            return (
+              a.customizable &&
+                t &&
+                'cam_distance' === e &&
+                void 0 !== t.distance &&
+                (n = `${a.command} ${t.distance}`),
+              {
+                command: n,
+                type: 'camera',
+                icon: a.icon,
+                text: a.name,
+                description: a.description,
+              }
+            )
+          },
+          getUI: () => this.createCameraUI(),
+        }),
+        this.commandBuilders.set('communication', {
+          build: (e, t = {}) => {
+            const a = STO_DATA.commands.communication.commands[e]
+            if (!a) return null
+            const n = t.message || 'Message text here'
+            return {
+              command: `${a.command} ${n}`,
+              type: 'communication',
+              icon: a.icon,
+              text: `${a.name}: ${n}`,
+              description: a.description,
+              parameters: { message: n },
+            }
+          },
+          getUI: () => this.createCommunicationUI(),
+        }),
+        this.commandBuilders.set('system', {
+          build: (e, t = {}) => {
+            const a = STO_DATA.commands.system.commands[e]
+            if (!a) return null
+            let n = a.command
+            return (
+              a.customizable &&
+                t &&
+                (('bind_save_file' !== e && 'bind_load_file' !== e) ||
+                !t.filename
+                  ? 'combat_log' === e &&
+                    void 0 !== t.state &&
+                    (n = `${a.command} ${t.state}`)
+                  : (n = `${a.command} ${t.filename}`)),
+              {
+                command: n,
+                type: 'system',
+                icon: a.icon,
+                text: a.name,
+                description: a.description,
+              }
+            )
+          },
+          getUI: () => this.createSystemUI(),
+        }),
+        this.commandBuilders.set('alias', {
+          build: (e, t = {}) => {
+            const a = t.alias_name || ''
+            return a.trim()
+              ? {
+                  command: a,
+                  type: 'alias',
+                  icon: '📝',
+                  text: `Alias: ${a}`,
+                  description: 'Execute custom alias',
+                  parameters: { alias_name: a },
+                }
+              : null
+          },
+          getUI: () => this.createAliasUI(),
+        }),
+        this.commandBuilders.set('custom', {
+          build: (e, t = {}) => {
+            const a = t.command || '',
+              n = t.text || 'Custom Command'
+            return {
+              command: a,
+              type: 'custom',
+              icon: '⚙️',
+              text: n,
+              description: 'Custom command',
+              parameters: { command: a, text: n },
+            }
+          },
+          getUI: () => this.createCustomUI(),
+        })
+    }
+    createTargetingUI() {
+      const e = STO_DATA.commands.targeting.commands
+      return `\n            <div class="command-selector">\n                <label for="targetingCommand">Targeting Command:</label>\n                <select id="targetingCommand">\n                    <option value="">Select targeting command...</option>\n                    ${Object.entries(
+        e
+      )
+        .map(([e, t]) => `<option value="${e}">${t.name}</option>`)
+        .join('')}\n                </select>\n            </div>\n        `
+    }
+    createCombatUI() {
+      const e = STO_DATA.commands.combat.commands
+      return `\n            <div class="command-selector">\n                <label for="combatCommand">Combat Command:</label>\n                <select id="combatCommand">\n                    <option value="">Select combat command...</option>\n                    ${Object.entries(
+        e
+      )
+        .map(([e, t]) => `<option value="${e}">${t.name}</option>`)
+        .join(
+          ''
+        )}\n                </select>\n                <div id="combatCommandWarning" class="command-warning" style="display: none;">\n                    <i class="fas fa-exclamation-triangle"></i>\n                    <span id="combatWarningText"></span>\n                </div>\n            </div>\n        `
+    }
+    createTrayUI() {
+      return `\n            <div class="tray-builder">\n                <div class="form-group">\n                    <label for="trayCommandType">Command Type:</label>\n                    <select id="trayCommandType">\n                        <option value="custom_tray">Single Tray Slot</option>\n                        <option value="tray_with_backup">Single Tray with Backup</option>\n                        <option value="tray_range">Tray Range</option>\n                        <option value="tray_range_with_backup">Tray Range with Backup</option>\n                        <option value="whole_tray">Whole Tray</option>\n                        <option value="whole_tray_with_backup">Whole Tray with Backup</option>\n                    </select>\n                </div>\n                \n                \x3c!-- Single Tray Configuration --\x3e\n                <div id="singleTrayConfig" class="tray-config-section">\n                    <div class="form-row">\n                        <div class="form-group">\n                            <label for="trayNumber">Tray Number:</label>\n                            <select id="trayNumber">\n                                ${Array.from({ length: 10 }, (e, t) => `<option value="${t}">Tray ${t + 1}</option>`).join('')}\n                            </select>\n                        </div>\n                        <div class="form-group">\n                            <label for="slotNumber">Slot Number:</label>\n                            <select id="slotNumber">\n                                ${Array.from({ length: 10 }, (e, t) => `<option value="${t}">Slot ${t + 1}</option>`).join('')}\n                            </select>\n                        </div>\n                    </div>\n                </div>\n                \n                \x3c!-- Backup Configuration --\x3e\n                <div id="backupConfig" class="tray-config-section" style="display: none;">\n                    <h4>Backup Configuration</h4>\n                    <div class="form-row">\n                        <div class="form-group">\n                            <label for="backupTrayNumber">Backup Tray:</label>\n                            <select id="backupTrayNumber">\n                                ${Array.from({ length: 10 }, (e, t) => `<option value="${t}">Tray ${t + 1}</option>`).join('')}\n                            </select>\n                        </div>\n                        <div class="form-group">\n                            <label for="backupSlotNumber">Backup Slot:</label>\n                            <select id="backupSlotNumber">\n                                ${Array.from({ length: 10 }, (e, t) => `<option value="${t}">Slot ${t + 1}</option>`).join('')}\n                            </select>\n                        </div>\n                    </div>\n                    <div class="form-group">\n                        <label for="activeState">Active State:</label>\n                        <select id="activeState">\n                            <option value="1">Active (1)</option>\n                            <option value="0">Inactive (0)</option>\n                        </select>\n                    </div>\n                </div>\n                \n                \x3c!-- Range Configuration --\x3e\n                <div id="rangeConfig" class="tray-config-section" style="display: none;">\n                    <h4>Range Configuration</h4>\n                    <div class="form-row">\n                        <div class="form-group">\n                            <label for="startTrayNumber">Start Tray:</label>\n                            <select id="startTrayNumber">\n                                ${Array.from({ length: 10 }, (e, t) => `<option value="${t}">Tray ${t + 1}</option>`).join('')}\n                            </select>\n                        </div>\n                        <div class="form-group">\n                            <label for="startSlotNumber">Start Slot:</label>\n                            <select id="startSlotNumber">\n                                ${Array.from({ length: 10 }, (e, t) => `<option value="${t}">Slot ${t + 1}</option>`).join('')}\n                            </select>\n                        </div>\n                    </div>\n                    <div class="form-row">\n                        <div class="form-group">\n                            <label for="endTrayNumber">End Tray:</label>\n                            <select id="endTrayNumber">\n                                ${Array.from({ length: 10 }, (e, t) => `<option value="${t}">Tray ${t + 1}</option>`).join('')}\n                            </select>\n                        </div>\n                        <div class="form-group">\n                            <label for="endSlotNumber">End Slot:</label>\n                            <select id="endSlotNumber">\n                                ${Array.from({ length: 10 }, (e, t) => `<option value="${t}">Slot ${t + 1}</option>`).join('')}\n                            </select>\n                        </div>\n                    </div>\n                </div>\n                \n                \x3c!-- Backup Range Configuration --\x3e\n                <div id="backupRangeConfig" class="tray-config-section" style="display: none;">\n                    <h4>Backup Range Configuration</h4>\n                    <div class="form-row">\n                        <div class="form-group">\n                            <label for="backupStartTrayNumber">Backup Start Tray:</label>\n                            <select id="backupStartTrayNumber">\n                                ${Array.from({ length: 10 }, (e, t) => `<option value="${t}">Tray ${t + 1}</option>`).join('')}\n                            </select>\n                        </div>\n                        <div class="form-group">\n                            <label for="backupStartSlotNumber">Backup Start Slot:</label>\n                            <select id="backupStartSlotNumber">\n                                ${Array.from({ length: 10 }, (e, t) => `<option value="${t}">Slot ${t + 1}</option>`).join('')}\n                            </select>\n                        </div>\n                    </div>\n                    <div class="form-row">\n                        <div class="form-group">\n                            <label for="backupEndTrayNumber">Backup End Tray:</label>\n                            <select id="backupEndTrayNumber">\n                                ${Array.from({ length: 10 }, (e, t) => `<option value="${t}">Tray ${t + 1}</option>`).join('')}\n                            </select>\n                        </div>\n                        <div class="form-group">\n                            <label for="backupEndSlotNumber">Backup End Slot:</label>\n                            <select id="backupEndSlotNumber">\n                                ${Array.from({ length: 10 }, (e, t) => `<option value="${t}">Slot ${t + 1}</option>`).join('')}\n                            </select>\n                        </div>\n                    </div>\n                </div>\n                \n                \x3c!-- Command Type Selection --\x3e\n                <div id="commandTypeConfig" class="tray-config-section" style="display: none;">\n                    <div class="form-group">\n                        <label for="trayCommandVariant">Command Variant:</label>\n                        <select id="trayCommandVariant">\n                            <option value="STOTrayExecByTray">STOTrayExecByTray (shows key binding on UI)</option>\n                            <option value="TrayExecByTray">TrayExecByTray (no UI indication)</option>\n                        </select>\n                    </div>\n                </div>\n                \n                <div class="tray-visual" id="trayVisual">\n                    \x3c!-- Visual tray representation will be generated here --\x3e\n                </div>\n            </div>\n        `
+    }
+    createPowerUI() {
+      const e = STO_DATA.commands.power.commands
+      return `\n            <div class="command-selector">\n                <label for="powerCommand">Shield Command:</label>\n                <select id="powerCommand">\n                    <option value="">Select shield command...</option>\n                    ${Object.entries(
+        e
+      )
+        .map(([e, t]) => `<option value="${e}">${t.name}</option>`)
+        .join(
+          ''
+        )}\n                </select>\n                <div id="powerCommandWarning" class="command-warning" style="display: none;">\n                    <i class="fas fa-exclamation-triangle"></i>\n                    <span id="powerWarningText"></span>\n                </div>\n            </div>\n        `
+    }
+    createMovementUI() {
+      const e = STO_DATA.commands.movement.commands
+      return `\n            <div class="command-selector">\n                <label for="movementCommand">Movement Command:</label>\n                <select id="movementCommand">\n                    <option value="">Select movement command...</option>\n                    ${Object.entries(
+        e
+      )
+        .map(([e, t]) => `<option value="${e}">${t.name}</option>`)
+        .join(
+          ''
+        )}\n                </select>\n                <div id="movementParams" style="display: none;">\n                    <div class="form-group">\n                        <label for="movementAmount">Amount (-1 to 1):</label>\n                        <input type="number" id="movementAmount" min="-1" max="1" step="0.05" value="0.25">\n                    </div>\n                    <div class="form-group">\n                        <label for="movementPosition">Position (-1 to 1):</label>\n                        <input type="number" id="movementPosition" min="-1" max="1" step="0.1" value="1">\n                    </div>\n                </div>\n            </div>\n        `
+    }
+    createCommunicationUI() {
+      const e = STO_DATA.commands.communication.commands
+      return `\n            <div class="communication-builder">\n                <div class="form-group">\n                    <label for="commCommand">Communication Type:</label>\n                    <select id="commCommand">\n                        <option value="">Select communication type...</option>\n                        ${Object.entries(
+        e
+      )
+        .map(([e, t]) => `<option value="${e}">${t.name}</option>`)
+        .join(
+          ''
+        )}\n                    </select>\n                </div>\n                <div class="form-group">\n                    <label for="commMessage">Message:</label>\n                    <div class="input-with-button">\n                        <input type="text" id="commMessage" placeholder="Enter your message" maxlength="100">\n                        <button type="button" class="btn btn-small insert-target-btn" title="Insert $Target variable">\n                            <i class="fas fa-crosshairs"></i> $Target\n                        </button>\n                    </div>\n                    <small>Maximum 100 characters</small>\n                </div>\n                <div class="variable-help">\n                    <h4><i class="fas fa-info-circle"></i> STO Variables</h4>\n                    <div class="variable-info">\n                        <strong>$Target</strong> - Replaced with your current target's name<br>\n                        <em>Example:</em> <code>team Attacking [$Target]</code> → <code>team Attacking [Borg Cube]</code>\n                    </div>\n                </div>\n            </div>\n        `
+    }
+    createCameraUI() {
+      const e = STO_DATA.commands.camera.commands
+      return `\n            <div class="command-selector">\n                <label for="cameraCommand">Camera Command:</label>\n                <select id="cameraCommand">\n                    <option value="">Select camera command...</option>\n                    ${Object.entries(
+        e
+      )
+        .map(([e, t]) => `<option value="${e}">${t.name}</option>`)
+        .join(
+          ''
+        )}\n                </select>\n                <div id="cameraParams" style="display: none;">\n                    <div class="form-group">\n                        <label for="cameraDistance">Distance:</label>\n                        <input type="number" id="cameraDistance" min="1" max="500" value="50">\n                    </div>\n                </div>\n            </div>\n        `
+    }
+    createSystemUI() {
+      const e = STO_DATA.commands.system.commands
+      return `\n            <div class="command-selector">\n                <label for="systemCommand">System Command:</label>\n                <select id="systemCommand">\n                    <option value="">Select system command...</option>\n                    ${Object.entries(
+        e
+      )
+        .map(([e, t]) => `<option value="${e}">${t.name}</option>`)
+        .join(
+          ''
+        )}\n                </select>\n                <div id="systemParams" style="display: none;">\n                    <div class="form-group">\n                        <label for="systemFilename">Filename:</label>\n                        <input type="text" id="systemFilename" value="my_binds.txt">\n                    </div>\n                    <div class="form-group">\n                        <label for="systemState">State (0/1):</label>\n                        <input type="number" id="systemState" min="0" max="1" value="1">\n                    </div>\n                </div>\n            </div>\n        `
+    }
+    createAliasUI() {
+      const e = app?.getCurrentProfile(),
+        t = e?.aliases || {},
+        a = Object.entries(t)
+      return 0 === a.length
+        ? '\n                <div class="alias-builder">\n                    <div class="empty-state">\n                        <i class="fas fa-mask"></i>\n                        <h4>No Aliases Available</h4>\n                        <p>Create aliases in the Alias Manager first.</p>\n                        <button type="button" class="btn btn-primary" id="openAliasManager">\n                            <i class="fas fa-plus"></i> Create Alias\n                        </button>\n                    </div>\n                </div>\n            '
+        : `\n            <div class="alias-builder">\n                <div class="form-group">\n                    <label for="aliasSelect">Available Aliases:</label>\n                    <select id="aliasSelect">\n                        <option value="">Select an alias...</option>\n                        ${a.map(([e, t]) => `<option value="${e}">${e}${t.description ? ' - ' + t.description : ''}</option>`).join('')}\n                    </select>\n                </div>\n                <div id="aliasPreviewSection" style="display: none;">\n                    <div class="alias-info">\n                        <label>Alias Commands:</label>\n                        <div class="command-preview" id="selectedAliasPreview"></div>\n                    </div>\n                </div>\n            </div>\n        `
+    }
+    createCustomUI() {
+      return '\n            <div class="custom-builder">\n                <div class="form-group">\n                    <label for="customCommand">Command:</label>\n                    <div class="input-with-button">\n                        <input type="text" id="customCommand" placeholder="Enter STO command" autocomplete="off">\n                        <button type="button" class="btn btn-small insert-target-btn" title="Insert $Target variable">\n                            <i class="fas fa-crosshairs"></i> $Target\n                        </button>\n                    </div>\n                    <small>Enter the exact STO command syntax</small>\n                </div>\n                <div class="form-group">\n                    <label for="customText">Display Text:</label>\n                    <input type="text" id="customText" placeholder="Descriptive name for this command" autocomplete="off">\n                </div>\n                <div class="command-help">\n                    <h4>Common Commands:</h4>\n                    <div class="command-examples">\n                        <button type="button" class="example-cmd" data-cmd="target_nearest_enemy">target_nearest_enemy</button>\n                        <button type="button" class="example-cmd" data-cmd="FireAll">FireAll</button>\n                        <button type="button" class="example-cmd" data-cmd="+power_exec Distribute_Shields">+power_exec Distribute_Shields</button>\n                        <button type="button" class="example-cmd" data-cmd="+STOTrayExecByTray 0 0">+STOTrayExecByTray 0 0</button>\n                        <button type="button" class="example-cmd" data-cmd=\'team Attacking [$Target]\'>team Attacking [$Target]</button>\n                    </div>\n                </div>\n                <div class="variable-help">\n                    <h4><i class="fas fa-info-circle"></i> STO Variables</h4>\n                    <div class="variable-info">\n                        <strong>$Target</strong> - Replaced with your current target\'s name<br>\n                        <em>Example:</em> <code>team Focus fire on [$Target]</code>\n                    </div>\n                </div>\n            </div>\n        '
+    }
+    setupEventListeners() {
+      document.addEventListener('change', (e) => {
+        'commandType' === e.target.id &&
+          this.handleCommandTypeChange(e.target.value)
+      }),
+        document.addEventListener('change', (e) => {
+          ;('trayNumber' !== e.target.id && 'slotNumber' !== e.target.id) ||
+            (this.updateTrayVisual(), this.updateCommandPreview())
+        }),
+        document.addEventListener('input', (e) => {
+          'commMessage' === e.target.id && this.updateCommandPreview()
+        }),
+        document.addEventListener('input', (e) => {
+          ;('customCommand' !== e.target.id && 'customText' !== e.target.id) ||
+            this.updateCommandPreview()
+        }),
+        document.addEventListener('click', (e) => {
+          if (e.target.classList.contains('example-cmd')) {
+            const t = e.target.dataset.cmd,
+              a = document.getElementById('customCommand')
+            a && ((a.value = t), this.updateCommandPreview())
+          }
+        }),
+        document.addEventListener('click', (e) => {
+          if (
+            e.target.classList.contains('insert-target-btn') ||
+            e.target.closest('.insert-target-btn')
+          ) {
+            e.preventDefault()
+            const t = (
+                e.target.classList.contains('insert-target-btn')
+                  ? e.target
+                  : e.target.closest('.insert-target-btn')
+              ).closest('.input-with-button'),
+              a = t ? t.querySelector('input') : null
+            a && this.insertTargetVariable(a)
+          }
+        }),
+        document.addEventListener('change', (e) => {
+          ;[
+            'targetingCommand',
+            'combatCommand',
+            'powerCommand',
+            'movementCommand',
+            'cameraCommand',
+            'systemCommand',
+            'commCommand',
+            'aliasSelect',
+          ].includes(e.target.id) && this.updateCommandPreview()
+        })
+    }
+    handleCommandTypeChange(e) {
+      const t = document.getElementById('commandBuilder'),
+        a = document.getElementById('modalCommandPreview'),
+        n = document.getElementById('saveCommandBtn')
+      if (t)
+        if (e && this.commandBuilders.has(e)) {
+          const a = this.commandBuilders.get(e).getUI()
+          ;(t.innerHTML = a),
+            this.setupTypeSpecificListeners(e),
+            n && (n.disabled = !1),
+            this.updateCommandPreview()
+        } else
+          (t.innerHTML =
+            '<p class="text-muted">Select a command type to configure options.</p>'),
+            a && (a.textContent = 'Select a command type to see preview'),
+            n && (n.disabled = !0)
+    }
+    setupTypeSpecificListeners(e) {
+      if ('tray' === e) {
+        this.updateTrayVisual()
+        const e = document.getElementById('trayCommandType')
+        e &&
+          (e.addEventListener('change', () => {
+            this.updateTrayConfigSections(e.value), this.updateCommandPreview()
+          }),
+          this.updateTrayConfigSections(e.value)),
+          [
+            'trayNumber',
+            'slotNumber',
+            'backupTrayNumber',
+            'backupSlotNumber',
+            'activeState',
+            'startTrayNumber',
+            'startSlotNumber',
+            'endTrayNumber',
+            'endSlotNumber',
+            'backupStartTrayNumber',
+            'backupStartSlotNumber',
+            'backupEndTrayNumber',
+            'backupEndSlotNumber',
+            'trayCommandVariant',
+          ].forEach((e) => {
+            const t = document.getElementById(e)
+            t &&
+              t.addEventListener('change', () => {
+                this.updateTrayVisual(), this.updateCommandPreview()
+              })
+          })
+      } else if ('power' === e) {
+        const e = document.getElementById('powerCommand')
+        e &&
+          e.addEventListener('change', () => {
+            this.showPowerWarning(e.value)
+          })
+      } else if ('combat' === e) {
+        const e = document.getElementById('combatCommand')
+        e &&
+          e.addEventListener('change', () => {
+            this.showCombatWarning(e.value)
+          })
+      } else if ('alias' === e) {
+        const e = document.getElementById('aliasSelect')
+        e &&
+          e.addEventListener('change', () => {
+            this.updateAliasPreview(e.value), this.updateCommandPreview()
+          })
+        const t = document.getElementById('openAliasManager')
+        t &&
+          t.addEventListener('click', () => {
+            'undefined' != typeof stoAliases && stoAliases.showAliasManager
+              ? stoAliases.showAliasManager()
+              : (stoUI.hideModal('addCommandModal'),
+                stoUI.showModal('aliasManagerModal'))
+          })
+      }
+    }
+    updateTrayConfigSections(e) {
+      const t = {
+        singleTrayConfig: document.getElementById('singleTrayConfig'),
+        backupConfig: document.getElementById('backupConfig'),
+        rangeConfig: document.getElementById('rangeConfig'),
+        backupRangeConfig: document.getElementById('backupRangeConfig'),
+        commandTypeConfig: document.getElementById('commandTypeConfig'),
+      }
+      switch (
+        (Object.values(t).forEach((e) => {
+          e && (e.style.display = 'none')
+        }),
+        e)
+      ) {
+        case 'custom_tray':
+        case 'whole_tray':
+          t.singleTrayConfig && (t.singleTrayConfig.style.display = 'block'),
+            t.commandTypeConfig && (t.commandTypeConfig.style.display = 'block')
+          break
+        case 'tray_with_backup':
+        case 'whole_tray_with_backup':
+          t.singleTrayConfig && (t.singleTrayConfig.style.display = 'block'),
+            t.backupConfig && (t.backupConfig.style.display = 'block')
+          break
+        case 'tray_range':
+          t.rangeConfig && (t.rangeConfig.style.display = 'block'),
+            t.commandTypeConfig && (t.commandTypeConfig.style.display = 'block')
+          break
+        case 'tray_range_with_backup':
+          t.rangeConfig && (t.rangeConfig.style.display = 'block'),
+            t.backupRangeConfig &&
+              (t.backupRangeConfig.style.display = 'block'),
+            t.backupConfig && (t.backupConfig.style.display = 'block')
+      }
+    }
+    showPowerWarning(e) {
+      const t = document.getElementById('powerCommandWarning'),
+        a = document.getElementById('powerWarningText')
+      if (t && a) {
+        if (e && STO_DATA.commands.power.commands[e]) {
+          const n = STO_DATA.commands.power.commands[e]
+          if (n.warning)
+            return (a.textContent = n.warning), void (t.style.display = 'block')
+        }
+        t.style.display = 'none'
+      }
+    }
+    showCombatWarning(e) {
+      const t = document.getElementById('combatCommandWarning'),
+        a = document.getElementById('combatWarningText')
+      if (t && a) {
+        if (e && STO_DATA.commands.combat.commands[e]) {
+          const n = STO_DATA.commands.combat.commands[e]
+          if (n.warning)
+            return (a.textContent = n.warning), void (t.style.display = 'block')
+        }
+        t.style.display = 'none'
+      }
+    }
+    updateAliasPreview(e) {
+      const t = document.getElementById('aliasPreviewSection'),
+        a = document.getElementById('selectedAliasPreview')
+      if (t && a)
+        if (e) {
+          const n = app?.getCurrentProfile(),
+            o = n?.aliases?.[e]
+          o
+            ? ((a.textContent = o.commands), (t.style.display = 'block'))
+            : (t.style.display = 'none')
+        } else t.style.display = 'none'
+    }
+    updateCommandPreview() {
+      const e = document.getElementById('modalCommandPreview')
+      if (!e)
+        return void console.log('DEBUG: modalCommandPreview element not found')
+      const t = this.buildCurrentCommand()
+      if ((console.log('DEBUG: buildCurrentCommand returned:', t), t)) {
+        if (Array.isArray(t)) {
+          console.log('DEBUG: Command is array with length:', t.length)
+          const a = t.map((e) => e.command)
+          console.log('DEBUG: Command strings:', a),
+            (e.textContent = a.join(' $$ '))
+        } else
+          console.log('DEBUG: Command is single object:', t.command),
+            (e.textContent = t.command)
+        e.className = 'command-preview valid'
+      } else
+        console.log('DEBUG: No command returned, showing default message'),
+          (e.textContent = 'Configure command options to see preview'),
+          (e.className = 'command-preview')
+    }
+    buildCurrentCommand() {
+      const e = document.getElementById('commandType')
+      if (!e || !e.value) return null
+      const t = e.value,
+        a = this.commandBuilders.get(t)
+      if (!a) return null
+      let n = null,
+        o = {}
+      switch (t) {
+        case 'targeting':
+          n = document.getElementById('targetingCommand')?.value
+          break
+        case 'combat':
+          n = document.getElementById('combatCommand')?.value
+          break
+        case 'tray':
+          switch (
+            ((n =
+              document.getElementById('trayCommandType')?.value ||
+              'custom_tray'),
+            n)
+          ) {
+            case 'custom_tray':
+              o = {
+                tray: parseInt(
+                  document.getElementById('trayNumber')?.value || 0
+                ),
+                slot: parseInt(
+                  document.getElementById('slotNumber')?.value || 0
+                ),
+                command_type:
+                  document.getElementById('trayCommandVariant')?.value ||
+                  'STOTrayExecByTray',
+              }
+              break
+            case 'tray_with_backup':
+              o = {
+                tray: parseInt(
+                  document.getElementById('trayNumber')?.value || 0
+                ),
+                slot: parseInt(
+                  document.getElementById('slotNumber')?.value || 0
+                ),
+                backup_tray: parseInt(
+                  document.getElementById('backupTrayNumber')?.value || 0
+                ),
+                backup_slot: parseInt(
+                  document.getElementById('backupSlotNumber')?.value || 0
+                ),
+                active: parseInt(
+                  document.getElementById('activeState')?.value || 1
+                ),
+              }
+              break
+            case 'tray_range':
+              o = {
+                start_tray: parseInt(
+                  document.getElementById('startTrayNumber')?.value || 0
+                ),
+                start_slot: parseInt(
+                  document.getElementById('startSlotNumber')?.value || 0
+                ),
+                end_tray: parseInt(
+                  document.getElementById('endTrayNumber')?.value || 0
+                ),
+                end_slot: parseInt(
+                  document.getElementById('endSlotNumber')?.value || 0
+                ),
+                command_type:
+                  document.getElementById('trayCommandVariant')?.value ||
+                  'STOTrayExecByTray',
+              }
+              break
+            case 'tray_range_with_backup':
+              o = {
+                active: parseInt(
+                  document.getElementById('activeState')?.value || 1
+                ),
+                start_tray: parseInt(
+                  document.getElementById('startTrayNumber')?.value || 0
+                ),
+                start_slot: parseInt(
+                  document.getElementById('startSlotNumber')?.value || 0
+                ),
+                end_tray: parseInt(
+                  document.getElementById('endTrayNumber')?.value || 0
+                ),
+                end_slot: parseInt(
+                  document.getElementById('endSlotNumber')?.value || 0
+                ),
+                backup_start_tray: parseInt(
+                  document.getElementById('backupStartTrayNumber')?.value || 0
+                ),
+                backup_start_slot: parseInt(
+                  document.getElementById('backupStartSlotNumber')?.value || 0
+                ),
+                backup_end_tray: parseInt(
+                  document.getElementById('backupEndTrayNumber')?.value || 0
+                ),
+                backup_end_slot: parseInt(
+                  document.getElementById('backupEndSlotNumber')?.value || 0
+                ),
+              }
+              break
+            case 'whole_tray':
+              o = {
+                tray: parseInt(
+                  document.getElementById('trayNumber')?.value || 0
+                ),
+                command_type:
+                  document.getElementById('trayCommandVariant')?.value ||
+                  'STOTrayExecByTray',
+              }
+              break
+            case 'whole_tray_with_backup':
+              o = {
+                active: parseInt(
+                  document.getElementById('activeState')?.value || 1
+                ),
+                tray: parseInt(
+                  document.getElementById('trayNumber')?.value || 0
+                ),
+                backup_tray: parseInt(
+                  document.getElementById('backupTrayNumber')?.value || 0
+                ),
+              }
+          }
+          break
+        case 'power':
+          n = document.getElementById('powerCommand')?.value
+          break
+        case 'movement':
+          ;(n = document.getElementById('movementCommand')?.value),
+            'throttle_adjust' === n
+              ? (o.amount = parseFloat(
+                  document.getElementById('movementAmount')?.value || 0.25
+                ))
+              : 'throttle_set' === n &&
+                (o.position = parseFloat(
+                  document.getElementById('movementPosition')?.value || 1
+                ))
+          break
+        case 'camera':
+          ;(n = document.getElementById('cameraCommand')?.value),
+            'cam_distance' === n &&
+              (o.distance = parseInt(
+                document.getElementById('cameraDistance')?.value || 50
+              ))
+          break
+        case 'communication':
+          ;(n = document.getElementById('commCommand')?.value),
+            (o = {
+              message:
+                document.getElementById('commMessage')?.value ||
+                'Message text here',
+            })
+          break
+        case 'system':
+          ;(n = document.getElementById('systemCommand')?.value),
+            'bind_save_file' === n || 'bind_load_file' === n
+              ? (o.filename =
+                  document.getElementById('systemFilename')?.value ||
+                  'my_binds.txt')
+              : 'combat_log' === n &&
+                (o.state = parseInt(
+                  document.getElementById('systemState')?.value || 1
+                ))
+          break
+        case 'alias':
+          ;(n = 'alias'),
+            (o = {
+              alias_name: document.getElementById('aliasSelect')?.value || '',
+            })
+          break
+        case 'custom':
+          ;(n = 'custom'),
+            (o = {
+              command: document.getElementById('customCommand')?.value || '',
+              text:
+                document.getElementById('customText')?.value ||
+                'Custom Command',
+            })
+      }
+      return n || 'custom' === t ? a.build(n, o) : null
+    }
+    updateTrayVisual() {
+      const e = document.getElementById('trayVisual'),
+        t = document.getElementById('trayNumber')?.value || 0,
+        a = document.getElementById('slotNumber')?.value || 0
+      e &&
+        ((e.innerHTML = `\n            <div class="tray-grid">\n                <div class="tray-label">Tray ${parseInt(t) + 1}</div>\n                <div class="slot-grid">\n                    ${Array.from({ length: 10 }, (e, t) => `\n                        <div class="slot ${t == a ? 'selected' : ''}" data-slot="${t}">\n                            ${t + 1}\n                        </div>\n                    `).join('')}\n                </div>\n            </div>\n        `),
+        e.querySelectorAll('.slot').forEach((e) => {
+          e.addEventListener('click', () => {
+            const t = document.getElementById('slotNumber')
+            t &&
+              ((t.value = e.dataset.slot),
+              this.updateTrayVisual(),
+              this.updateCommandPreview())
+          })
+        }))
+    }
+    generateTrayRangeCommands(e, t, a, n, o) {
+      const i = [],
+        r = 'STOTrayExecByTray' === o ? '+' : ''
+      if (e === a) for (let a = t; a <= n; a++) i.push(`${r}${o} ${e} ${a}`)
+      else {
+        for (let a = t; a <= 9; a++) i.push(`${r}${o} ${e} ${a}`)
+        for (let t = e + 1; t < a; t++)
+          for (let e = 0; e <= 9; e++) i.push(`${r}${o} ${t} ${e}`)
+        if (a > e) for (let e = 0; e <= n; e++) i.push(`${r}${o} ${a} ${e}`)
+      }
+      return i
+    }
+    generateTrayRangeWithBackupCommands(e, t, a, n, o, i, r, s, c) {
+      const l = [],
+        d = this.generateTraySlotList(t, a, n, o),
+        m = this.generateTraySlotList(i, r, s, c)
+      for (let t = 0; t < Math.max(d.length, m.length); t++) {
+        const a = d[t] || d[d.length - 1],
+          n = m[t] || m[m.length - 1]
+        l.push(
+          `TrayExecByTrayWithBackup ${e} ${a.tray} ${a.slot} ${n.tray} ${n.slot}`
+        )
+      }
+      return l
+    }
+    generateWholeTrayCommands(e, t) {
+      const a = [],
+        n = 'STOTrayExecByTray' === t ? '+' : ''
+      for (let o = 0; o <= 9; o++) a.push(`${n}${t} ${e} ${o}`)
+      return a
+    }
+    generateWholeTrayWithBackupCommands(e, t, a) {
+      const n = []
+      for (let o = 0; o <= 9; o++)
+        n.push(`TrayExecByTrayWithBackup ${e} ${t} ${o} ${a} ${o}`)
+      return n
+    }
+    generateTraySlotList(e, t, a, n) {
+      const o = []
+      if (e === a) for (let a = t; a <= n; a++) o.push({ tray: e, slot: a })
+      else {
+        for (let a = t; a <= 9; a++) o.push({ tray: e, slot: a })
+        for (let t = e + 1; t < a; t++)
+          for (let e = 0; e <= 9; e++) o.push({ tray: t, slot: e })
+        if (a > e) for (let e = 0; e <= n; e++) o.push({ tray: a, slot: e })
+      }
+      return o
+    }
+    getCurrentCommand() {
+      return this.buildCurrentCommand()
+    }
+    validateCommand(e) {
+      if (Array.isArray(e)) {
+        for (let t = 0; t < e.length; t++) {
+          const a = this.validateCommand(e[t])
+          if (!a.valid)
+            return { valid: !1, error: `Command ${t + 1}: ${a.error}` }
+        }
+        return { valid: !0 }
+      }
+      let t
+      if ('string' == typeof e) t = e
+      else {
+        if (!e || !e.command) return { valid: !1, error: 'No command provided' }
+        t = e.command
+      }
+      if (!t || 0 === t.trim().length)
+        return { valid: !1, error: 'Command cannot be empty' }
+      const a = t.trim()
+      return ['quit', 'exit', 'shutdown'].some((e) =>
+        a.toLowerCase().includes(e)
+      )
+        ? { valid: !1, error: 'Dangerous command not allowed' }
+        : this.hasUnquotedPipeCharacter(a)
+          ? { valid: !1, error: 'Invalid characters in command (|)' }
+          : { valid: !0 }
+    }
+    hasUnquotedPipeCharacter(e) {
+      let t = !1,
+        a = null
+      for (let n = 0; n < e.length; n++) {
+        const o = e[n]
+        if (t || ('"' !== o && "'" !== o)) {
+          if (t && o === a) {
+            let o = 0
+            for (let t = n - 1; t >= 0 && '\\' === e[t]; t--) o++
+            o % 2 == 0 && ((t = !1), (a = null))
+          } else if (!t && '|' === o) return !0
+        } else (t = !0), (a = o)
+      }
+      return !1
+    }
+    getTemplateCommands(e) {
+      if (!STO_DATA.templates) return []
+      const t = []
+      return (
+        Object.entries(STO_DATA.templates).forEach(([a, n]) => {
+          Object.entries(n).forEach(([n, o]) => {
+            o.commands.some((t) => this.detectCommandType(t) === e) &&
+              t.push({
+                id: `${a}_${n}`,
+                name: o.name,
+                description: o.description,
+                scenario: a,
+                commands: o.commands.map((e) => ({
+                  command: e,
+                  type: this.detectCommandType(e),
+                  icon: this.getCommandIcon(e),
+                  text: this.getCommandText(e),
+                })),
+              })
+          })
+        }),
+        t
+      )
+    }
+    detectCommandType(e) {
+      if (!e || 'string' != typeof e) return 'custom'
+      const t = e.toLowerCase().trim()
+      return t.includes('+stotrayexecbytray')
+        ? 'tray'
+        : t.startsWith('say ') ||
+            t.startsWith('team ') ||
+            t.startsWith('zone ') ||
+            t.startsWith('tell ') ||
+            t.includes('"')
+          ? 'communication'
+          : t.includes('+power_exec') ||
+              t.includes('distribute_shields') ||
+              t.includes('reroute_shields')
+            ? 'power'
+            : t.includes('+fullimpulse') ||
+                t.includes('+reverse') ||
+                t.includes('throttle') ||
+                t.includes('+turn') ||
+                t.includes('+up') ||
+                t.includes('+down') ||
+                t.includes('+left') ||
+                t.includes('+right') ||
+                t.includes('+forward') ||
+                t.includes('+backward') ||
+                t.includes('follow')
+              ? 'movement'
+              : t.includes('cam') || t.includes('look') || t.includes('zoom')
+                ? 'camera'
+                : t.includes('fire') ||
+                    t.includes('attack') ||
+                    'fireall' === t ||
+                    'firephasers' === t ||
+                    'firetorps' === t ||
+                    'firephaserstorps' === t
+                  ? 'combat'
+                  : t.includes('target') ||
+                      'target_enemy_near' === t ||
+                      'target_self' === t ||
+                      'target_friend_near' === t ||
+                      'target_clear' === t
+                    ? 'targeting'
+                    : t.includes('+gentoggle') ||
+                        'screenshot' === t ||
+                        t.includes('hud') ||
+                        'interactwindow' === t
+                      ? 'system'
+                      : 'custom'
+    }
+    getCommandIcon(e) {
+      return (
+        {
+          targeting: '🎯',
+          combat: '🔥',
+          tray: '⚡',
+          power: '🔋',
+          communication: '💬',
+          movement: '🚀',
+          camera: '📹',
+          system: '⚙️',
+        }[this.detectCommandType(e)] || '⚙️'
+      )
+    }
+    getCommandText(e) {
+      if (e.includes('+STOTrayExecByTray')) {
+        const t = e.match(/\+STOTrayExecByTray\s+(\d+)\s+(\d+)/)
+        if (t)
+          return `Execute Tray ${parseInt(t[1]) + 1} Slot ${parseInt(t[2]) + 1}`
+      }
+      for (const [t, a] of Object.entries(STO_DATA.commands))
+        for (const [t, n] of Object.entries(a.commands))
+          if (n.command === e) return n.name
+      return e
+        .replace(/[_+]/g, ' ')
+        .replace(/([A-Z])/g, ' $1')
+        .trim()
+    }
+    insertTargetVariable(e) {
+      const t = e.selectionStart,
+        a = e.value,
+        n = a.slice(0, t) + '$Target' + a.slice(t)
+      ;(e.value = n),
+        e.setSelectionRange(t + 7, t + 7),
+        e.focus(),
+        e.dispatchEvent(new Event('input', { bubbles: !0 }))
+    }
+  })(),
+  b = new (class {
+    constructor() {
+      ;(this.modalId = 'fileExplorerModal'),
+        (this.treeId = 'fileTree'),
+        (this.contentId = 'fileContent')
+    }
+    init() {
+      this.setupEventListeners()
+    }
+    setupEventListeners() {
+      i.onDom('fileExplorerBtn', 'click', 'fileExplorer-open', () => {
+        this.openExplorer()
+      }),
+        i.onDom(this.treeId, 'click', 'fileExplorer-tree-click', (e) => {
+          const t = e.target.closest('.tree-node')
+          t && this.selectNode(t)
+        }),
+        i.onDom('copyFileContentBtn', 'click', 'copyFileContent', () => {
+          const e = document.getElementById(this.contentId)
+          if (!e) return
+          const t = e.textContent || ''
+          t.trim()
+            ? (stoUI.copyToClipboard(t),
+              stoUI.showToast('Content copied to clipboard', 'success'))
+            : stoUI.showToast('Nothing to copy', 'warning')
+        })
+    }
+    openExplorer() {
+      this.buildTree()
+      const e = document.getElementById(this.contentId)
+      e && (e.textContent = 'Select an item on the left to preview export'),
+        stoUI.showModal(this.modalId)
+    }
+    buildTree() {
+      const e = document.getElementById(this.treeId)
+      if (!e) return
+      e.innerHTML = ''
+      const t = stoStorage.getAllData().profiles || {}
+      Object.entries(t).forEach(([t, a]) => {
+        const n = this.createNode('profile', a.name, { profileId: t }),
+          o = document.createElement('div')
+        if (((o.className = 'tree-children'), a.builds && a.builds.space)) {
+          const e = this.createNode('build', 'Space Build', {
+            profileId: t,
+            environment: 'space',
+          })
+          o.appendChild(e)
+        }
+        if (a.builds && a.builds.ground) {
+          const e = this.createNode('build', 'Ground Build', {
+            profileId: t,
+            environment: 'ground',
+          })
+          o.appendChild(e)
+        }
+        const i = this.createNode('aliases', 'Aliases', { profileId: t })
+        o.appendChild(i), n.appendChild(o), e.appendChild(n)
+      })
+    }
+    createNode(e, t, a = {}) {
+      const n = document.createElement('div')
+      return (
+        (n.className = `tree-node ${e}`),
+        (n.textContent = t),
+        (n.dataset.type = e),
+        Object.entries(a).forEach(([e, t]) => {
+          n.setAttribute(`data-${e}`, t)
+        }),
+        n
+      )
+    }
+    selectNode(e) {
+      const t = document.querySelector('.tree-node.selected')
+      t && t.classList.remove('selected'), e.classList.add('selected')
+      const a = e.dataset.type || e.getAttribute('data-type'),
+        n = e.getAttribute('data-profileid'),
+        o = e.getAttribute('data-environment')
+      if (n)
+        try {
+          let e = ''
+          e =
+            'build' === a
+              ? this.generateBuildExport(n, o)
+              : 'aliases' === a
+                ? this.generateAliasExport(n)
+                : 'Select a Space/Ground build or Aliases to preview export.'
+          const t = document.getElementById(this.contentId)
+          t && (t.textContent = e || 'No content available.')
+        } catch (e) {
+          console.error('Failed to generate export content:', e),
+            stoUI.showToast('Failed to generate export', 'error')
+        }
+    }
+    generateBuildExport(e, t) {
+      const a = stoStorage.getProfile(e)
+      if (!a || !a.builds || !a.builds[t]) return ''
+      const n = a.builds[t],
+        o = {
+          name: `${a.name} ${t}`,
+          mode: t,
+          keys: n.keys || {},
+          keybindMetadata: a.keybindMetadata || {},
+          aliases: n.aliases || {},
+        }
+      return stoExport.generateSTOKeybindFile(o, { environment: t })
+    }
+    generateAliasExport(e) {
+      const t = stoStorage.getProfile(e)
+      if (!t) return ''
+      const a = {
+          ...(t.aliases || {}),
+          ...(t.builds?.space?.aliases || {}),
+          ...(t.builds?.ground?.aliases || {}),
+        },
+        n = { name: t.name, mode: t.currentEnvironment || 'space', aliases: a }
+      return stoExport.generateAliasFile(n)
+    }
+  })(),
+  v = new (class {
+    constructor() {
+      ;(this.selectedEffects = { space: new Set(), ground: new Set() }),
+        (this.showPlayerSay = !1)
+    }
+    generateAlias(e) {
+      if (!this.selectedEffects[e]) throw new InvalidEnvironmentError(e)
+      const t = Array.from(this.selectedEffects[e])
+      if (0 === t.length) return ''
+      let a = `alias dynFxSetFXExlusionList_${e.charAt(0).toUpperCase() + e.slice(1)} <& dynFxSetFXExlusionList ${t.join(',')}`
+      return (
+        this.showPlayerSay && (a += ' $$ PlayerSay VFX Supression Loaded'),
+        (a += ' &>'),
+        a
+      )
+    }
+    getSelectedEffects(e) {
+      if (!this.selectedEffects[e]) throw new InvalidEnvironmentError(e)
+      return Array.from(this.selectedEffects[e])
+    }
+    toggleEffect(e, t) {
+      if (!this.selectedEffects[e]) throw new InvalidEnvironmentError(e)
+      if (!t) throw new InvalidEffectError(t, e)
+      this.selectedEffects[e].has(t)
+        ? this.selectedEffects[e].delete(t)
+        : this.selectedEffects[e].add(t)
+    }
+    clearAllEffects() {
+      this.selectedEffects.space.clear(), this.selectedEffects.ground.clear()
+    }
+    selectAllEffects(e) {
+      if (!d[e]) throw new InvalidEnvironmentError(e)
+      if (!this.selectedEffects[e]) throw new InvalidEnvironmentError(e)
+      d[e].forEach((t) => {
+        this.selectedEffects[e].add(t.effect)
+      })
+    }
+    getEffectCount(e) {
+      if (!this.selectedEffects[e]) throw new InvalidEnvironmentError(e)
+      return this.selectedEffects[e].size
+    }
+    isEffectSelected(e, t) {
+      if (!this.selectedEffects[e]) throw new InvalidEnvironmentError(e)
+      return this.selectedEffects[e].has(t)
+    }
+    saveState(e) {
+      e.vertigoSettings || (e.vertigoSettings = {}),
+        (e.vertigoSettings = {
+          selectedEffects: {
+            space: Array.from(this.selectedEffects.space),
+            ground: Array.from(this.selectedEffects.ground),
+          },
+          showPlayerSay: this.showPlayerSay,
+        })
+    }
+    loadState(e) {
+      if (e && e.vertigoSettings) {
+        const t = e.vertigoSettings
+        ;(this.selectedEffects.space = new Set(t.selectedEffects?.space || [])),
+          (this.selectedEffects.ground = new Set(
+            t.selectedEffects?.ground || []
+          )),
+          (this.showPlayerSay = t.showPlayerSay || !1)
+      } else
+        this.selectedEffects.space.clear(),
+          this.selectedEffects.ground.clear(),
+          (this.showPlayerSay = !1)
+    }
+  })()
+Object.assign(window, {
+  stoStorage: m,
+  stoProfiles: p,
+  stoKeybinds: u,
+  stoAliases: y,
+  stoExport: f,
+  modalManager: h,
+  stoUI: g,
+  stoCommands: _,
+  stoFileExplorer: b,
+  vertigoManager: v,
+  VFX_EFFECTS: d,
+  VERTIGO_EFFECTS: d,
+})
+const T = new (class {
+  constructor() {
+    ;(this.store = l),
+      (this.eventListeners = new Map()),
+      'loading' === document.readyState
+        ? document.addEventListener('DOMContentLoaded', () => this.init())
+        : this.init()
+  }
+  get currentProfile() {
+    return this.store.currentProfile
+  }
+  set currentProfile(e) {
+    this.store.currentProfile = e
+  }
+  get currentMode() {
+    return this.store.currentMode
+  }
+  set currentMode(e) {
+    this.store.currentMode = e
+  }
+  get currentEnvironment() {
+    return this.store.currentEnvironment
+  }
+  set currentEnvironment(e) {
+    this.store.currentEnvironment = e
+  }
+  get selectedKey() {
+    return this.store.selectedKey
+  }
+  set selectedKey(e) {
+    this.store.selectedKey = e
+  }
+  get isModified() {
+    return this.store.isModified
+  }
+  set isModified(e) {
+    this.store.isModified = e
+  }
+  get undoStack() {
+    return this.store.undoStack
+  }
+  set undoStack(e) {
+    this.store.undoStack = e
+  }
+  get redoStack() {
+    return this.store.redoStack
+  }
+  set redoStack(e) {
+    this.store.redoStack = e
+  }
+  get maxUndoSteps() {
+    return this.store.maxUndoSteps
+  }
+  set maxUndoSteps(e) {
+    this.store.maxUndoSteps = e
+  }
+  get commandIdCounter() {
+    return this.store.commandIdCounter
+  }
+  set commandIdCounter(e) {
+    this.store.commandIdCounter = e
+  }
+  async init() {
+    try {
+      if ('undefined' == typeof stoStorage || 'undefined' == typeof stoUI)
+        throw new Error('Required dependencies not loaded')
+      await this.loadData(),
+        this.applyTheme(),
+        this.setupEventListeners(),
+        this.setupCommandLibrary(),
+        this.setupDragAndDrop(),
+        this.renderProfiles(),
+        this.renderKeyGrid(),
+        this.renderCommandChain()
+      const e = stoStorage.getSettings()
+      this.updateThemeToggleButton(e.theme || 'default'),
+        this.isFirstTime() && this.showWelcomeMessage(),
+        stoUI.showToast(
+          'STO Tools Keybind Manager loaded successfully',
+          'success'
+        ),
+        i.emit('sto-app-ready', { app: this })
+    } catch (e) {
+      console.error('Failed to initialize application:', e),
+        'undefined' != typeof stoUI &&
+          stoUI.showToast &&
+          stoUI.showToast('Failed to load application', 'error'),
+        i.emit('sto-app-error', { error: e })
+    }
+  }
+  async loadData() {
+    const e = stoStorage.getAllData()
+    this.currentProfile = e.currentProfile
+    const t = e.profiles[this.currentProfile]
+    ;(this.currentEnvironment = (t && t.currentEnvironment) || 'space'),
+      e.profiles[this.currentProfile] ||
+        ((this.currentProfile = Object.keys(e.profiles)[0]),
+        this.saveCurrentProfile())
+  }
+  saveData() {
+    const e = stoStorage.getAllData()
+    return (
+      (e.currentProfile = this.currentProfile),
+      (e.lastModified = new Date().toISOString()),
+      !!stoStorage.saveAllData(e) && (this.setModified(!1), !0)
+    )
+  }
+  saveCurrentProfile() {
+    const e = stoStorage.getAllData()
+    return (e.currentProfile = this.currentProfile), stoStorage.saveAllData(e)
+  }
+  setModified(e = !0) {
+    this.isModified = e
+    const t = document.getElementById('modifiedIndicator')
+    t && (t.style.display = e ? 'inline' : 'none')
+  }
+  getCurrentProfile() {
+    const e = stoStorage.getProfile(this.currentProfile)
+    return e ? this.getCurrentBuild(e) : null
+  }
+  getCurrentBuild(e) {
+    return e
+      ? (e.builds ||
+          ((e.builds = { space: { keys: e.keys || {} }, ground: { keys: {} } }),
+          (e.currentEnvironment = e.mode || 'space'),
+          delete e.mode,
+          delete e.keys,
+          stoStorage.saveProfile(this.currentProfile, e)),
+        e.builds || (e.builds = { space: { keys: {} }, ground: { keys: {} } }),
+        e.builds[this.currentEnvironment] ||
+          (e.builds[this.currentEnvironment] = { keys: {} }),
+        e.builds[this.currentEnvironment].keys ||
+          (e.builds[this.currentEnvironment].keys = {}),
+        {
+          ...e,
+          keys: e.builds[this.currentEnvironment].keys,
+          aliases: e.aliases || {},
+          mode: this.currentEnvironment,
+        })
+      : null
+  }
+  switchProfile(e) {
+    if (e !== this.currentProfile) {
+      ;(this.currentProfile = e), (this.selectedKey = null)
+      const t = stoStorage.getProfile(e)
+      t && (this.currentEnvironment = t.currentEnvironment || 'space'),
+        this.saveCurrentProfile(),
+        this.renderKeyGrid(),
+        this.renderCommandChain(),
+        this.updateProfileInfo()
+      const a = this.getCurrentProfile()
+      stoUI.showToast(
+        `Switched to profile: ${a.name} (${this.currentEnvironment})`,
+        'success'
+      )
+    }
+  }
+  createProfile(e, t = '', a = 'space') {
+    const n = this.generateProfileId(e),
+      o = {
+        name: e,
+        description: t,
+        mode: a,
+        keys: {},
+        aliases: {},
+        created: new Date().toISOString(),
+        lastModified: new Date().toISOString(),
+      }
+    return stoStorage.saveProfile(n, o)
+      ? (this.switchProfile(n),
+        this.renderProfiles(),
+        stoUI.showToast(`Profile "${e}" created`, 'success'),
+        n)
+      : (stoUI.showToast('Failed to create profile', 'error'), null)
+  }
+  cloneProfile(e, t) {
+    const a = stoStorage.getProfile(e)
+    if (!a) return null
+    const n = this.generateProfileId(t),
+      o = {
+        ...JSON.parse(JSON.stringify(a)),
+        name: t,
+        description: `Copy of ${a.name}`,
+        created: new Date().toISOString(),
+        lastModified: new Date().toISOString(),
+      }
+    return stoStorage.saveProfile(n, o)
+      ? (this.renderProfiles(),
+        stoUI.showToast(`Profile "${t}" created from "${a.name}"`, 'success'),
+        n)
+      : (stoUI.showToast('Failed to clone profile', 'error'), null)
+  }
+  deleteProfile(e) {
+    const t = stoStorage.getProfile(e)
+    if (!t) return !1
+    const a = stoStorage.getAllData()
+    if (Object.keys(a.profiles).length <= 1)
+      return stoUI.showToast('Cannot delete the last profile', 'warning'), !1
+    if (stoStorage.deleteProfile(e)) {
+      if (this.currentProfile === e) {
+        const e = Object.keys(stoStorage.getAllData().profiles)
+        this.switchProfile(e[0])
+      }
+      return (
+        this.renderProfiles(),
+        stoUI.showToast(`Profile "${t.name}" deleted`, 'success'),
+        !0
+      )
+    }
+    return stoUI.showToast('Failed to delete profile', 'error'), !1
+  }
+  generateProfileId(e) {
+    const t = e.toLowerCase().replace(/[^a-z0-9]/g, '_')
+    let a = t,
+      n = 1
+    const o = stoStorage.getAllData()
+    for (; o.profiles[a]; ) (a = `${t}_${n}`), n++
+    return a
+  }
+  selectKey(e) {
+    this.selectedKey = e
+    const t = this.getCurrentProfile(),
+      a = document.getElementById('stabilizeExecutionOrder')
+    if (a && t && t.keybindMetadata) {
+      let n = !1
+      if (t.keybindMetadata[this.currentEnvironment]) {
+        const a = t.keybindMetadata[this.currentEnvironment]
+        n = !(!a[e] || !a[e].stabilizeExecutionOrder)
+      }
+      !n &&
+        t.keybindMetadata[e] &&
+        (n = !!t.keybindMetadata[e].stabilizeExecutionOrder),
+        (a.checked = n)
+    } else a && (a.checked = !1)
+    this.renderKeyGrid(), this.renderCommandChain(), this.updateChainActions()
+  }
+  addKey(e) {
+    if (!this.isValidKeyName(e))
+      return stoUI.showToast('Invalid key name', 'error'), !1
+    const t = this.getCurrentProfile()
+    return t.keys[e]
+      ? (stoUI.showToast(`Key "${e}" already exists`, 'warning'), !1)
+      : ((t.keys[e] = []),
+        stoStorage.saveProfile(this.currentProfile, t),
+        this.renderKeyGrid(),
+        this.selectKey(e),
+        this.setModified(!0),
+        stoUI.showToast(`Key "${e}" added`, 'success'),
+        !0)
+  }
+  deleteKey(e) {
+    const t = this.getCurrentProfile()
+    return (
+      !!t.keys[e] &&
+      (delete t.keys[e],
+      stoStorage.saveProfile(this.currentProfile, t),
+      this.selectedKey === e && (this.selectedKey = null),
+      this.renderKeyGrid(),
+      this.renderCommandChain(),
+      this.setModified(!0),
+      stoUI.showToast(`Key "${e}" deleted`, 'success'),
+      !0)
+    )
+  }
+  isValidKeyName(e) {
+    return STO_DATA.validation.keyNamePattern.test(e) && e.length <= 20
+  }
+  addCommand(e, t) {
+    const a = this.getCurrentProfile()
+    a.keys[e] || (a.keys[e] = []),
+      Array.isArray(t)
+        ? (t.forEach((t) => {
+            t.id || (t.id = this.generateCommandId()), a.keys[e].push(t)
+          }),
+          stoUI.showToast(`${t.length} commands added`, 'success'))
+        : (t.id || (t.id = this.generateCommandId()),
+          a.keys[e].push(t),
+          stoUI.showToast('Command added', 'success')),
+      stoStorage.saveProfile(this.currentProfile, a),
+      this.renderCommandChain(),
+      this.renderKeyGrid(),
+      this.setModified(!0)
+  }
+  deleteCommand(e, t) {
+    const a = this.getCurrentProfile()
+    a.keys[e] &&
+      a.keys[e][t] &&
+      (a.keys[e].splice(t, 1),
+      stoStorage.saveProfile(this.currentProfile, a),
+      this.renderCommandChain(),
+      this.renderKeyGrid(),
+      this.setModified(!0),
+      stoUI.showToast('Command deleted', 'success'))
+  }
+  moveCommand(e, t, a) {
+    const n = this.getCurrentProfile(),
+      o = n.keys[e]
+    if (o && t >= 0 && t < o.length && a >= 0 && a < o.length) {
+      const [e] = o.splice(t, 1)
+      o.splice(a, 0, e),
+        stoStorage.saveProfile(this.currentProfile, n),
+        this.renderCommandChain(),
+        this.setModified(!0)
+    }
+  }
+  generateCommandId() {
+    return 'cmd_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9)
+  }
+  renderProfiles() {
+    const e = document.getElementById('profileSelect')
+    if (!e) return
+    const t = stoStorage.getAllData()
+    if (((e.innerHTML = ''), 0 === Object.keys(t.profiles).length)) {
+      const t = document.createElement('option')
+      ;(t.value = ''),
+        (t.textContent = 'No profiles available'),
+        (t.disabled = !0),
+        e.appendChild(t)
+    } else
+      Object.entries(t.profiles).forEach(([t, a]) => {
+        const n = document.createElement('option')
+        ;(n.value = t),
+          (n.textContent = a.name),
+          t === this.currentProfile && (n.selected = !0),
+          e.appendChild(n)
+      })
+    this.updateProfileInfo()
+  }
+  updateProfileInfo() {
+    const e = this.getCurrentProfile()
+    document.querySelectorAll('.mode-btn').forEach((t) => {
+      t.classList.toggle(
+        'active',
+        e && t.dataset.mode === this.currentEnvironment
+      ),
+        (t.disabled = !e)
+    })
+    const t = document.getElementById('keyCount')
+    if (t)
+      if (e) {
+        const a = Object.keys(e.keys).length
+        t.textContent = `${a} key${1 !== a ? 's' : ''}`
+      } else t.textContent = 'No profile'
+  }
+  renderKeyGrid() {
+    const e = document.getElementById('keyGrid')
+    if (!e) return
+    const t = this.getCurrentProfile()
+    if (!t) return
+    if (((e.innerHTML = ''), !t))
+      return void (e.innerHTML =
+        '\n                <div class="empty-state">\n                    <i class="fas fa-folder-open"></i>\n                    <h4>No Profile Selected</h4>\n                    <p>Create a new profile or load default data to get started.</p>\n                </div>\n            ')
+    const a = Object.keys(t.keys),
+      n = [
+        ...new Set([
+          ...a,
+          'Space',
+          '1',
+          '2',
+          '3',
+          '4',
+          '5',
+          'F1',
+          'F2',
+          'F3',
+          'F4',
+        ]),
+      ].sort(),
+      o = localStorage.getItem('keyViewMode') || 'key-types'
+    'categorized' === o
+      ? this.renderCategorizedKeyView(e, t, n)
+      : 'key-types' === o
+        ? this.renderKeyTypeView(e, t, n)
+        : this.renderSimpleKeyGrid(e, n),
+      this.updateViewToggleButton(o)
+    const i = document.getElementById('keyFilter')
+    i && i.value.trim() && this.filterKeys(i.value.trim())
+  }
+  renderSimpleKeyGrid(e, t) {
+    e.classList.remove('categorized'),
+      t.forEach((t) => {
+        const a = this.createKeyElement(t)
+        e.appendChild(a)
+      })
+  }
+  renderCategorizedKeyView(e, t, a) {
+    e.classList.add('categorized')
+    const n = this.categorizeKeys(t.keys, a)
+    Object.entries(n)
+      .sort(([e, t], [a, n]) =>
+        t.priority !== n.priority
+          ? t.priority - n.priority
+          : t.name.localeCompare(n.name)
+      )
+      .forEach(([t, a]) => {
+        const n = this.createKeyCategoryElement(t, a)
+        e.appendChild(n)
+      })
+  }
+  categorizeKeys(e, t) {
+    const a = {}
+    return (
+      (a.unknown = {
+        name: 'Unknown',
+        icon: 'fas fa-question-circle',
+        keys: new Set(),
+        priority: 0,
+      }),
+      Object.entries(STO_DATA.commands).forEach(([e, t]) => {
+        a[e] = { name: t.name, icon: t.icon, keys: new Set(), priority: 1 }
+      }),
+      t.forEach((t) => {
+        const n = e[t] || []
+        if (!n || 0 === n.length) return void a.unknown.keys.add(t)
+        const o = new Set()
+        n.forEach((e) => {
+          if (e.type && a[e.type]) o.add(e.type)
+          else if (window.stoCommands) {
+            const t = window.stoCommands.detectCommandType(e.command)
+            a[t] && o.add(t)
+          }
+        }),
+          o.size > 0
+            ? o.forEach((e) => {
+                a[e].keys.add(t)
+              })
+            : (a.custom ||
+                (a.custom = {
+                  name: 'Custom Commands',
+                  icon: 'fas fa-cog',
+                  keys: new Set(),
+                  priority: 2,
+                }),
+              a.custom.keys.add(t))
+      }),
+      Object.values(a).forEach((e) => {
+        e.keys = Array.from(e.keys).sort(this.compareKeys.bind(this))
+      }),
+      a
+    )
+  }
+  createKeyCategoryElement(e, t, a = 'command') {
+    const n = document.createElement('div')
+    ;(n.className = 'category'), (n.dataset.category = e)
+    const o =
+        'key-type' === a
+          ? `keyTypeCategory_${e}_collapsed`
+          : `keyCategory_${e}_collapsed`,
+      i = 'true' === localStorage.getItem(o)
+    return (
+      (n.innerHTML = `\n            <h4 class="${i ? 'collapsed' : ''}" data-category="${e}" data-mode="${a}">\n                <i class="fas fa-chevron-right category-chevron"></i>\n                <i class="${t.icon}"></i> \n                ${t.name} \n                <span class="key-count">(${t.keys.length})</span>\n            </h4>\n            <div class="category-commands ${i ? 'collapsed' : ''}">\n                ${t.keys.map((e) => this.createKeyElementHTML(e)).join('')}\n            </div>\n        `),
+      n.querySelector('h4').addEventListener('click', () => {
+        this.toggleKeyCategory(e, n, a)
+      }),
+      n.querySelectorAll('.command-item').forEach((e) => {
+        e.addEventListener('click', () => {
+          const t = e.dataset.key
+          this.selectKey(t)
+        })
+      }),
+      n
+    )
+  }
+  createKeyElementHTML(e) {
+    const t = this.getCurrentProfile().keys[e] || [],
+      a = this.selectedKey === e,
+      n = e.length
+    let o
+    return (
+      (o = n <= 6 ? 'short' : n <= 12 ? 'medium' : 'long'),
+      `\n            <div class="command-item ${a ? 'active' : ''}" data-key="${e}" data-length="${o}">\n                <span class="key-label">${e}</span>\n                ${t.length > 0 ? `\n                    <span class="command-count-badge">${t.length}</span>\n                ` : ''}\n            </div>\n        `
+    )
+  }
+  toggleKeyCategory(e, t, a = 'command') {
+    const n = t.querySelector('h4'),
+      o = t.querySelector('.category-commands'),
+      i = n.querySelector('.category-chevron'),
+      r =
+        'key-type' === a
+          ? `keyTypeCategory_${e}_collapsed`
+          : `keyCategory_${e}_collapsed`
+    o.classList.contains('collapsed')
+      ? (o.classList.remove('collapsed'),
+        n.classList.remove('collapsed'),
+        (i.style.transform = 'rotate(90deg)'),
+        localStorage.setItem(r, 'false'))
+      : (o.classList.add('collapsed'),
+        n.classList.add('collapsed'),
+        (i.style.transform = 'rotate(0deg)'),
+        localStorage.setItem(r, 'true'))
+  }
+  formatKeyName(e) {
+    return e.includes('+') ? e.replace(/\+/g, '<br>+<br>') : e
+  }
+  detectKeyTypes(e) {
+    const t = []
+    e.includes('+') &&
+      e
+        .split('+')
+        .some((e) => e.match(/^(Ctrl|Control|Alt|Shift|Win|Cmd|Super)$/i)) &&
+      t.push('modifiers')
+    const a = e.split('+').pop()
+    return (
+      a.match(/^F\d+$/)
+        ? t.push('function')
+        : a.match(
+              /^(Lbutton|Rbutton|Mbutton|Leftdrag|Rightdrag|Middledrag|Leftclick|Rightclick|Middleclick|Leftdoubleclick|Rightdoubleclick|Middledoubleclick|Wheelplus|Wheelminus|Mousechord|Mouse|Wheel|LMouse|RMouse|MMouse|XMouse|Drag)/i
+            )
+          ? t.push('mouse')
+          : a.match(/^(Numpad|Keypad)/i)
+            ? t.push('numberpad')
+            : a.match(/^(Ctrl|Control|Alt|Shift|Win|Cmd|Super)$/i)
+              ? t.includes('modifiers') || t.push('modifiers')
+              : a.match(
+                    /^(Up|Down|Left|Right|Home|End|PageUp|PageDown|Insert|Delete)$/i
+                  )
+                ? t.push('navigation')
+                : a.match(
+                      /^(Space|Tab|Enter|Return|Escape|Esc|Backspace|CapsLock|ScrollLock|NumLock|PrintScreen|Pause|Break)$/i
+                    )
+                  ? t.push('system')
+                  : a.match(/^[0-9]$/) || a.match(/^[A-Za-z]$/)
+                    ? t.push('alphanumeric')
+                    : a.match(/^[`~!@#$%^&*()_+\-=\[\]{}\\|;':",./<>?]$/) ||
+                        a.match(
+                          /^(Comma|Period|Semicolon|Quote|Slash|Backslash|Minus|Plus|Equals|Bracket|Grave|Tilde)$/i
+                        )
+                      ? t.push('symbols')
+                      : t.push('other'),
+      t.length > 0 ? t : ['other']
+    )
+  }
+  categorizeKeysByType(e, t) {
+    const a = {
+      function: {
+        name: 'Function Keys',
+        icon: 'fas fa-keyboard',
+        keys: new Set(),
+        priority: 1,
+      },
+      alphanumeric: {
+        name: 'Letters & Numbers',
+        icon: 'fas fa-font',
+        keys: new Set(),
+        priority: 2,
+      },
+      numberpad: {
+        name: 'Numberpad',
+        icon: 'fas fa-calculator',
+        keys: new Set(),
+        priority: 3,
+      },
+      modifiers: {
+        name: 'Modifier Keys',
+        icon: 'fas fa-hand-paper',
+        keys: new Set(),
+        priority: 4,
+      },
+      navigation: {
+        name: 'Navigation',
+        icon: 'fas fa-arrows-alt',
+        keys: new Set(),
+        priority: 5,
+      },
+      system: {
+        name: 'System Keys',
+        icon: 'fas fa-cogs',
+        keys: new Set(),
+        priority: 6,
+      },
+      mouse: {
+        name: 'Mouse & Wheel',
+        icon: 'fas fa-mouse',
+        keys: new Set(),
+        priority: 7,
+      },
+      symbols: {
+        name: 'Symbols & Punctuation',
+        icon: 'fas fa-at',
+        keys: new Set(),
+        priority: 8,
+      },
+      other: {
+        name: 'Other Keys',
+        icon: 'fas fa-question-circle',
+        keys: new Set(),
+        priority: 9,
+      },
+    }
+    return (
+      t.forEach((e) => {
+        this.detectKeyTypes(e).forEach((t) => {
+          a[t] ? a[t].keys.add(e) : a.other.keys.add(e)
+        })
+      }),
+      Object.values(a).forEach((e) => {
+        e.keys = Array.from(e.keys).sort(this.compareKeys.bind(this))
+      }),
+      a
+    )
+  }
+  renderKeyTypeView(e, t, a) {
+    e.classList.add('categorized')
+    const n = this.categorizeKeysByType(t.keys, a)
+    Object.entries(n)
+      .sort(([e, t], [a, n]) => t.priority - n.priority)
+      .forEach(([t, a]) => {
+        const n = this.createKeyCategoryElement(t, a, 'key-type')
+        e.appendChild(n)
+      })
+  }
+  compareKeys(e, t) {
+    const a = (e) =>
+        'Space' === e
+          ? 0
+          : e.match(/^[0-9]$/)
+            ? 1
+            : e.match(/^F[0-9]+$/)
+              ? 2
+              : e.includes('Ctrl+')
+                ? 3
+                : e.includes('Alt+')
+                  ? 4
+                  : e.includes('Shift+')
+                    ? 5
+                    : 6,
+      n = a(e),
+      o = a(t)
+    return n !== o ? n - o : e.localeCompare(t)
+  }
+  createKeyElement(e) {
+    const t = this.getCurrentProfile().keys[e] || [],
+      a = e === this.selectedKey,
+      n = document.createElement('div')
+    ;(n.className = 'key-item ' + (a ? 'active' : '')),
+      (n.dataset.key = e),
+      (n.title = `${e}: ${t.length} command${1 !== t.length ? 's' : ''}`)
+    const o = this.formatKeyName(e)
+    let i
+    if (o.includes('<br>')) {
+      const t = e.split('+'),
+        a = Math.max(...t.map((e) => e.length))
+      i = a <= 4 ? 'short' : a <= 8 ? 'medium' : 'long'
+    } else {
+      const t = e.length
+      i = t <= 3 ? 'short' : t <= 5 ? 'medium' : t <= 8 ? 'long' : 'extra-long'
+    }
+    return (
+      (n.dataset.length = i),
+      (n.innerHTML = `\n            <div class="key-label">${o}</div>\n            ${t.length > 0 ? `\n                <div class="activity-bar" style="width: ${Math.min(15 * t.length, 100)}%"></div>\n                <div class="command-count-badge">${t.length}</div>\n            ` : ''}\n        `),
+      n.addEventListener('click', () => {
+        this.selectKey(e)
+      }),
+      n
+    )
+  }
+  updateViewToggleButton(e) {
+    const t = document.getElementById('toggleKeyViewBtn')
+    if (t) {
+      const a = t.querySelector('i')
+      'categorized' === e
+        ? ((a.className = 'fas fa-sitemap'),
+          (t.title = 'Switch to key type view'))
+        : 'key-types' === e
+          ? ((a.className = 'fas fa-th'), (t.title = 'Switch to grid view'))
+          : ((a.className = 'fas fa-list'),
+            (t.title = 'Switch to command categories'))
+    }
+  }
+  toggleKeyView() {
+    const e = localStorage.getItem('keyViewMode') || 'key-types'
+    let t
+    ;(t =
+      'key-types' === e ? 'grid' : 'grid' === e ? 'categorized' : 'key-types'),
+      localStorage.setItem('keyViewMode', t),
+      this.renderKeyGrid()
+  }
+  renderCommandChain() {
+    const e = document.getElementById('commandList'),
+      t = document.getElementById('chainTitle'),
+      a = document.getElementById('commandPreview'),
+      n = document.getElementById('commandCount'),
+      o = document.getElementById('emptyState')
+    if (!e || !t || !a) return
+    if (!this.selectedKey)
+      return (
+        (t.textContent = 'Select a key to edit'),
+        (a.textContent = 'Select a key to see the generated command'),
+        n && (n.textContent = '0 commands'),
+        o && (o.style.display = 'block'),
+        void (e.innerHTML =
+          '<div class="empty-state" id="emptyState"><i class="fas fa-keyboard"></i><h4>No Key Selected</h4><p>Select a key from the left panel to view and edit its command chain.</p></div>')
+      )
+    const i = this.getCurrentProfile().keys[this.selectedKey] || []
+    if (
+      ((t.textContent = `Command Chain for ${this.selectedKey}`),
+      n && (n.textContent = `${i.length} command${1 !== i.length ? 's' : ''}`),
+      0 === i.length)
+    )
+      (e.innerHTML = `\n                <div class="empty-state">\n                    <i class="fas fa-plus-circle"></i>\n                    <h4>No Commands</h4>\n                    <p>Click "Add Command" to start building your command chain for ${this.selectedKey}.</p>\n                </div>\n            `),
+        (a.textContent = `${this.selectedKey} ""`)
+    else {
+      ;(e.innerHTML = ''),
+        i.forEach((t, a) => {
+          const n = this.createCommandElement(t, a)
+          e.appendChild(n)
+        })
+      const t = document.getElementById('stabilizeExecutionOrder')
+      let n
+      ;(n =
+        t && t.checked && i.length > 1
+          ? stoKeybinds.generateMirroredCommandString(i)
+          : i.map((e) => e.command).join(' $$ ')),
+        (a.textContent = `${this.selectedKey} "${n}"`)
+    }
+  }
+  createCommandElement(e, t) {
+    const a = document.createElement('div')
+    ;(a.className = 'command-item-row'),
+      (a.dataset.index = t),
+      (a.draggable = !0)
+    const n = this.findCommandDefinition(e),
+      o = n && n.customizable
+    let i = e.text,
+      r = e.icon
+    if (n)
+      if (((i = n.name), (r = n.icon), o && e.parameters)) {
+        if ('tray_with_backup' === n.commandId) {
+          const t = e.parameters
+          i = `${n.name} (${t.active} ${t.tray} ${t.slot} ${t.backup_tray} ${t.backup_slot})`
+        } else if ('custom_tray' === n.commandId) {
+          const t = e.parameters
+          i = `${n.name} (${t.tray} ${t.slot})`
+        } else if ('target' === n.commandId) {
+          const t = e.parameters
+          i = `${n.name}: ${t.entityName}`
+        }
+      } else if (o)
+        if (e.command.includes('TrayExecByTrayWithBackup')) {
+          const t = e.command.split(' ')
+          t.length >= 6 &&
+            (i = `${n.name} (${t[1]} ${t[2]} ${t[3]} ${t[4]} ${t[5]})`)
+        } else if (e.command.includes('TrayExec')) {
+          const t = e.command.replace('+', '').split(' ')
+          t.length >= 3 && (i = `${n.name} (${t[1]} ${t[2]})`)
+        } else if (e.command.includes('Target ')) {
+          const t = e.command.match(/Target "([^"]+)"/)
+          t && (i = `${n.name}: ${t[1]}`)
+        }
+    o && ((a.dataset.parameters = 'true'), a.classList.add('customizable'))
+    const s = this.getCommandWarning(e),
+      c = s
+        ? `<span class="command-warning-icon" title="${s}"><i class="fas fa-exclamation-triangle"></i></span>`
+        : '',
+      l = o
+        ? ' <span class="param-indicator" title="Editable parameters">⚙️</span>'
+        : ''
+    return (
+      (a.innerHTML = `\n            <div class="command-number">${t + 1}</div>\n            <div class="command-content">\n                <span class="command-icon">${r}</span>\n                <span class="command-text">${i}${l}</span>\n                ${c}\n            </div>\n            <span class="command-type ${e.type}">${e.type}</span>\n            <div class="command-actions">\n                <button class="btn btn-small-icon" onclick="app.editCommand(${t})" title="Edit Command">\n                    <i class="fas fa-edit"></i>\n                </button>\n                <button class="btn btn-small-icon btn-danger" onclick="app.deleteCommand('${this.selectedKey}', ${t})" title="Delete Command">\n                    <i class="fas fa-times"></i>\n                </button>\n                <button class="btn btn-small-icon" onclick="app.moveCommand('${this.selectedKey}', ${t}, ${t - 1})" \n                        title="Move Up" ${0 === t ? 'disabled' : ''}>\n                    <i class="fas fa-chevron-up"></i>\n                </button>\n                <button class="btn btn-small-icon" onclick="app.moveCommand('${this.selectedKey}', ${t}, ${t + 1})" \n                        title="Move Down" ${t === this.getCurrentProfile().keys[this.selectedKey].length - 1 ? 'disabled' : ''}>\n                    <i class="fas fa-chevron-down"></i>\n                </button>\n            </div>\n        `),
+      a
+    )
+  }
+  getCommandWarning(e) {
+    const t = STO_DATA.commands
+    for (const [a, n] of Object.entries(t))
+      for (const [t, a] of Object.entries(n.commands))
+        if (
+          a.command === e.command ||
+          a.name === e.text ||
+          e.command.includes(a.command)
+        )
+          return a.warning || null
+    return null
+  }
+  setupCommandLibrary() {
+    const e = document.getElementById('commandCategories')
+    e &&
+      ((e.innerHTML = ''),
+      Object.entries(STO_DATA.commands).forEach(([t, a]) => {
+        const n = this.createCategoryElement(t, a)
+        e.appendChild(n)
+      }),
+      this.filterCommandLibrary())
+  }
+  createCategoryElement(e, t) {
+    const a = document.createElement('div')
+    ;(a.className = 'category'), (a.dataset.category = e)
+    const n = `commandCategory_${e}_collapsed`,
+      o = 'true' === localStorage.getItem(n)
+    return (
+      (a.innerHTML = `\n            <h4 class="${o ? 'collapsed' : ''}" data-category="${e}">\n                <i class="fas fa-chevron-right category-chevron"></i>\n                <i class="${t.icon}"></i> \n                ${t.name}\n                <span class="command-count">(${Object.keys(t.commands).length})</span>\n            </h4>\n            <div class="category-commands ${o ? 'collapsed' : ''}">\n                ${Object.entries(
+        t.commands
+      )
+        .map(
+          ([e, t]) =>
+            `\n                    <div class="command-item ${t.customizable ? 'customizable' : ''}" data-command="${e}" title="${t.description}${t.customizable ? ' (Customizable)' : ''}">\n                        ${t.icon} ${t.name}${t.customizable ? ' <span class="param-indicator">⚙️</span>' : ''}\n                    </div>\n                `
+        )
+        .join('')}\n            </div>\n        `),
+      a.querySelector('h4').addEventListener('click', () => {
+        this.toggleCommandCategory(e, a)
+      }),
+      a.addEventListener('click', (t) => {
+        if (t.target.classList.contains('command-item')) {
+          const a = t.target.dataset.command
+          this.addCommandFromLibrary(e, a)
+        }
+      }),
+      a
+    )
+  }
+  toggleCommandCategory(e, t) {
+    const a = t.querySelector('h4'),
+      n = t.querySelector('.category-commands'),
+      o = a.querySelector('.category-chevron'),
+      i = `commandCategory_${e}_collapsed`
+    n.classList.contains('collapsed')
+      ? (n.classList.remove('collapsed'),
+        a.classList.remove('collapsed'),
+        (o.style.transform = 'rotate(90deg)'),
+        localStorage.setItem(i, 'false'))
+      : (n.classList.add('collapsed'),
+        a.classList.add('collapsed'),
+        (o.style.transform = 'rotate(0deg)'),
+        localStorage.setItem(i, 'true'))
+  }
+  addCommandFromLibrary(e, t) {
+    if (!this.selectedKey)
+      return void stoUI.showToast('Please select a key first', 'warning')
+    const a = STO_DATA.commands[e].commands[t]
+    if (!a) return
+    if (a.customizable && a.parameters)
+      return void this.showParameterModal(e, t, a)
+    const n = {
+      command: a.command,
+      type: e,
+      icon: a.icon,
+      text: a.name,
+      id: this.generateCommandId(),
+    }
+    this.addCommand(this.selectedKey, n)
+  }
+  setupDragAndDrop() {
+    const e = document.getElementById('commandList')
+    e &&
+      stoUI.initDragAndDrop(e, {
+        dragSelector: '.command-item-row',
+        dropZoneSelector: '.command-item-row',
+        onDrop: (e, t, a) => {
+          if (!this.selectedKey) return
+          const n = parseInt(t.dragElement.dataset.index),
+            o = parseInt(a.dataset.index)
+          n !== o && this.moveCommand(this.selectedKey, n, o)
+        },
+      })
+  }
+  updateChainActions() {
+    const e = !!this.selectedKey
+    ;[
+      'addCommandBtn',
+      'addFromTemplateBtn',
+      'importFromKeyBtn',
+      'deleteKeyBtn',
+      'duplicateKeyBtn',
+    ].forEach((t) => {
+      const a = document.getElementById(t)
+      a && (a.disabled = !e)
+    })
+  }
+  setupEventListeners() {
+    const e = document.getElementById('profileSelect')
+    e?.addEventListener('change', (e) => {
+      this.switchProfile(e.target.value)
+    }),
+      document.querySelectorAll('.mode-btn').forEach((e) => {
+        e.addEventListener('click', (e) => {
+          const t = e.target.dataset.mode
+          this.switchMode(t)
+        })
+      }),
+      i.onDom('openProjectBtn', 'click', 'project-open', () => {
+        this.openProject()
+      }),
+      i.onDom('saveProjectBtn', 'click', 'project-save', () => {
+        this.saveProject()
+      }),
+      i.onDom('exportKeybindsBtn', 'click', 'keybinds-export', () => {
+        this.exportKeybinds()
+      }),
+      i.onDom('vertigoBtn', 'click', 'vertigo-open', () => {
+        this.showVertigoModal()
+      }),
+      i.onDom('addKeyBtn', 'click', 'key-add', () => {
+        this.showKeySelectionModal()
+      }),
+      i.onDom('deleteKeyBtn', 'click', 'key-delete', () => {
+        this.selectedKey && this.confirmDeleteKey(this.selectedKey)
+      }),
+      i.onDom('duplicateKeyBtn', 'click', 'key-duplicate', () => {
+        this.selectedKey && this.duplicateKey(this.selectedKey)
+      }),
+      i.onDom('addCommandBtn', 'click', 'command-add', () => {
+        modalManager.show('addCommandModal')
+      }),
+      i.onDom('addFromTemplateBtn', 'click', 'command-add-template', () => {
+        this.showTemplateModal()
+      }),
+      i.onDom('clearChainBtn', 'click', 'command-chain-clear', () => {
+        this.selectedKey && this.confirmClearChain(this.selectedKey)
+      }),
+      i.onDom('validateChainBtn', 'click', 'command-chain-validate', () => {
+        this.validateCurrentChain()
+      }),
+      i.onDom('stabilizeExecutionOrder', 'change', 'stabilize-change', (e) => {
+        if (this.selectedKey) {
+          const t = this.currentEnvironment,
+            a = stoStorage.getProfile(this.currentProfile)
+          a &&
+            (a.keybindMetadata || (a.keybindMetadata = {}),
+            a.keybindMetadata[t] || (a.keybindMetadata[t] = {}),
+            a.keybindMetadata[t][this.selectedKey] ||
+              (a.keybindMetadata[t][this.selectedKey] = {}),
+            (a.keybindMetadata[t][this.selectedKey].stabilizeExecutionOrder =
+              e.target.checked),
+            stoStorage.saveProfile(this.currentProfile, a),
+            this.setModified(!0))
+        }
+        this.renderCommandChain()
+      }),
+      i.onDom('keyFilter', 'input', 'key-filter', (e) => {
+        this.filterKeys(e.target.value)
+      }),
+      i.onDom('commandSearch', 'input', 'command-search', (e) => {
+        this.filterCommands(e.target.value)
+      }),
+      i.onDom('showAllKeysBtn', 'click', 'show-all-keys', () => {
+        this.showAllKeys()
+      }),
+      i.onDom('toggleKeyViewBtn', 'click', 'toggle-key-view', () => {
+        this.toggleKeyView()
+      }),
+      i.onDom('toggleLibraryBtn', 'click', 'toggle-library', () => {
+        this.toggleLibrary()
+      }),
+      this.setupModalHandlers(),
+      setInterval(() => {
+        this.isModified && this.saveData()
+      }, 3e4)
+  }
+  setupModalHandlers() {
+    i.onDom('confirmAddKeyBtn', 'click', 'key-add-confirm', () => {
+      const e = document.getElementById('newKeyName')?.value.trim()
+      e && (this.addKey(e), modalManager.hide('addKeyModal'))
+    }),
+      document.querySelectorAll('.key-suggestion').forEach((e) => {
+        e.addEventListener('click', (e) => {
+          const t = e.target.dataset.key,
+            a = document.getElementById('newKeyName')
+          a && (a.value = t)
+        })
+      }),
+      i.onDom('saveCommandBtn', 'click', 'command-save', () => {
+        this.saveCommandFromModal()
+      }),
+      document.querySelectorAll('.modal-close, [data-modal]').forEach((e) => {
+        e.addEventListener('click', (e) => {
+          const t =
+            e.target.dataset.modal || e.target.closest('button').dataset.modal
+          t &&
+            (modalManager.hide(t),
+            'vertigoModal' === t &&
+              (this.vertigoInitialState &&
+                !this.vertigoSaving &&
+                ((vertigoManager.selectedEffects.space = new Set(
+                  this.vertigoInitialState.selectedEffects.space
+                )),
+                (vertigoManager.selectedEffects.ground = new Set(
+                  this.vertigoInitialState.selectedEffects.ground
+                )),
+                (vertigoManager.showPlayerSay =
+                  this.vertigoInitialState.showPlayerSay)),
+              delete this.vertigoInitialState,
+              (this.vertigoSaving = !1)))
+        })
+      })
+  }
+  saveProfile() {
+    const e = this.getCurrentProfile()
+    if (!e) return
+    this.saveCurrentBuild()
+    const t = stoStorage.getProfile(this.currentProfile)
+    if (!t) return
+    const a = {
+      ...t,
+      name: e.name,
+      description: e.description || t.description,
+      aliases: e.aliases || {},
+      keybindMetadata: e.keybindMetadata || t.keybindMetadata,
+      created: t.created,
+      lastModified: new Date().toISOString(),
+      currentEnvironment: this.currentEnvironment,
+    }
+    stoStorage.saveProfile(this.currentProfile, a)
+  }
+  switchMode(e) {
+    if (this.currentEnvironment !== e) {
+      this.saveCurrentBuild(), (this.currentEnvironment = e)
+      const t = stoStorage.getProfile(this.currentProfile)
+      t &&
+        ((t.currentEnvironment = e),
+        stoStorage.saveProfile(this.currentProfile, t)),
+        this.updateModeButtons(),
+        this.updateProfileInfo(),
+        this.renderKeyGrid(),
+        this.renderCommandChain(),
+        this.filterCommandLibrary(),
+        this.setModified(!0),
+        stoUI.showToast(`Switched to ${e} mode`, 'success')
+    }
+  }
+  updateModeButtons() {
+    const e = document.querySelector('[data-mode="space"]'),
+      t = document.querySelector('[data-mode="ground"]')
+    e &&
+      t &&
+      (e.classList.toggle('active', 'space' === this.currentEnvironment),
+      t.classList.toggle('active', 'ground' === this.currentEnvironment))
+  }
+  saveCurrentBuild() {
+    const e = stoStorage.getProfile(this.currentProfile),
+      t = this.getCurrentProfile()
+    e &&
+      t &&
+      (e.builds || (e.builds = { space: { keys: {} }, ground: { keys: {} } }),
+      (e.builds[this.currentEnvironment] = { keys: t.keys || {} }),
+      stoStorage.saveProfile(this.currentProfile, e))
+  }
+  async confirmDeleteKey(e) {
+    ;(await stoUI.confirm(
+      `Are you sure you want to delete the key "${e}" and all its commands?`,
+      'Delete Key',
+      'danger'
+    )) && this.deleteKey(e)
+  }
+  async confirmClearChain(e) {
+    ;(await stoUI.confirm(
+      `Are you sure you want to clear all commands for "${e}"?`,
+      'Clear Commands',
+      'warning'
+    )) &&
+      ((this.getCurrentProfile().keys[e] = []),
+      this.saveCurrentBuild(),
+      this.renderCommandChain(),
+      this.renderKeyGrid(),
+      this.setModified(!0),
+      stoUI.showToast(`Commands cleared for ${e}`, 'success'))
+  }
+  openProject() {
+    const e = document.getElementById('fileInput')
+    ;(e.accept = '.json'),
+      (e.onchange = (e) => {
+        const t = e.target.files[0]
+        if (t) {
+          const e = new FileReader()
+          ;(e.onload = (e) => {
+            try {
+              stoStorage.importData(e.target.result)
+                ? (this.loadData(),
+                  this.renderProfiles(),
+                  this.renderKeyGrid(),
+                  this.renderCommandChain(),
+                  stoUI.showToast('Project loaded successfully', 'success'))
+                : stoUI.showToast('Failed to load project file', 'error')
+            } catch (e) {
+              stoUI.showToast('Invalid project file', 'error')
+            }
+          }),
+            e.readAsText(t)
+        }
+      }),
+      e.click()
+  }
+  saveProject() {
+    const e = stoStorage.exportData(),
+      t = new Blob([e], { type: 'application/json' }),
+      a = URL.createObjectURL(t),
+      n = document.createElement('a')
+    ;(n.href = a),
+      (n.download = 'sto_keybinds.json'),
+      n.click(),
+      URL.revokeObjectURL(a),
+      stoUI.showToast('Project exported successfully', 'success')
+  }
+  exportKeybinds() {
+    const e = this.getCurrentProfile()
+    if (!e) return
+    const t = stoExport.generateSTOKeybindFile(e, {
+        environment: this.currentEnvironment,
+      }),
+      a = new Blob([t], { type: 'text/plain' }),
+      n = URL.createObjectURL(a),
+      o = document.createElement('a')
+    o.href = n
+    const i = e.name.replace(/[^a-zA-Z0-9]/g, '_')
+    ;(o.download = `${i}_${this.currentEnvironment}_keybinds.txt`),
+      o.click(),
+      URL.revokeObjectURL(n),
+      stoUI.showToast(
+        `${this.currentEnvironment} keybinds exported successfully`,
+        'success'
+      )
+  }
+  isFirstTime() {
+    return !localStorage.getItem('sto_keybind_manager_visited')
+  }
+  showWelcomeMessage() {
+    localStorage.setItem('sto_keybind_manager_visited', 'true'),
+      modalManager.show('aboutModal')
+  }
+  duplicateKey(e) {
+    const t = this.getCurrentProfile(),
+      a = t.keys[e]
+    if (!a || 0 === a.length)
+      return void stoUI.showToast('No commands to duplicate', 'warning')
+    let n = e + '_copy',
+      o = 1
+    for (; t.keys[n]; ) (n = `${e}_copy_${o}`), o++
+    const i = a.map((e) => ({ ...e, id: this.generateCommandId() }))
+    ;(t.keys[n] = i),
+      stoStorage.saveProfile(this.currentProfile, t),
+      this.renderKeyGrid(),
+      this.setModified(!0),
+      stoUI.showToast(`Key "${e}" duplicated as "${n}"`, 'success')
+  }
+  showTemplateModal() {
+    stoUI.showToast('Template system coming soon', 'info')
+  }
+  validateCurrentChain() {
+    if (!this.selectedKey)
+      return void stoUI.showToast('No key selected', 'warning')
+    const e = this.getCurrentProfile().keys[this.selectedKey] || []
+    if (0 === e.length)
+      return void stoUI.showToast('No commands to validate', 'warning')
+    const t = stoKeybinds.validateKeybind(this.selectedKey, e)
+    if (t.valid) stoUI.showToast('Command chain is valid', 'success')
+    else {
+      const e = 'Validation errors:\n' + t.errors.join('\n')
+      stoUI.showToast(e, 'error', 5e3)
+    }
+  }
+  filterKeys(e) {
+    const t = e.toLowerCase()
+    document.querySelectorAll('.key-item').forEach((a) => {
+      const n = a.dataset.key.toLowerCase(),
+        o = !e || n.includes(t)
+      a.style.display = o ? 'flex' : 'none'
+    }),
+      document.querySelectorAll('.command-item[data-key]').forEach((a) => {
+        const n = a.dataset.key.toLowerCase(),
+          o = !e || n.includes(t)
+        a.style.display = o ? 'flex' : 'none'
+      }),
+      document.querySelectorAll('.category').forEach((t) => {
+        const a = t.querySelectorAll(
+            '.command-item[data-key]:not([style*="display: none"])'
+          ),
+          n = !e || a.length > 0
+        t.style.display = n ? 'block' : 'none'
+      })
+  }
+  filterCommands(e) {
+    const t = document.querySelectorAll('.command-item'),
+      a = e.toLowerCase()
+    t.forEach((t) => {
+      const n = t.textContent.toLowerCase(),
+        o = !e || n.includes(a)
+      t.style.display = o ? 'flex' : 'none'
+    }),
+      document.querySelectorAll('.category').forEach((t) => {
+        const a = t.querySelectorAll(
+            '.command-item:not([style*="display: none"])'
+          ),
+          n = !e || a.length > 0
+        t.style.display = n ? 'block' : 'none'
+      })
+  }
+  showAllKeys() {
+    document.querySelectorAll('.key-item').forEach((e) => {
+      e.style.display = 'flex'
+    }),
+      document.querySelectorAll('.command-item[data-key]').forEach((e) => {
+        e.style.display = 'flex'
+      }),
+      document.querySelectorAll('.category').forEach((e) => {
+        e.style.display = 'block'
+      })
+    const e = document.getElementById('keyFilter')
+    e && (e.value = '')
+  }
+  toggleLibrary() {
+    const e = document.getElementById('libraryContent'),
+      t = document.getElementById('toggleLibraryBtn')
+    if (e && t) {
+      const a = 'none' === e.style.display
+      e.style.display = a ? 'block' : 'none'
+      const n = t.querySelector('i')
+      n && (n.className = a ? 'fas fa-chevron-up' : 'fas fa-chevron-down')
+    }
+  }
+  saveCommandFromModal() {
+    if (!this.selectedKey)
+      return void stoUI.showToast('Please select a key first', 'warning')
+    const e = stoCommands.getCurrentCommand()
+    if (!e) return void stoUI.showToast('Please configure a command', 'warning')
+    const t = stoCommands.validateCommand(e)
+    t.valid
+      ? (this.addCommand(this.selectedKey, e),
+        modalManager.hide('addCommandModal'))
+      : stoUI.showToast(t.error, 'error')
+  }
+  showParameterModal(e, t, a) {
+    ;(this.currentParameterCommand = {
+      categoryId: e,
+      commandId: t,
+      commandDef: a,
+    }),
+      document.getElementById('parameterModal') || this.createParameterModal(),
+      this.populateParameterModal(a),
+      modalManager.show('parameterModal')
+  }
+  createParameterModal() {
+    const e = document.createElement('div')
+    ;(e.className = 'modal'),
+      (e.id = 'parameterModal'),
+      (e.innerHTML =
+        '\n            <div class="modal-content">\n                <div class="modal-header">\n                    <h3 id="parameterModalTitle">Configure Command Parameters</h3>\n                    <button class="modal-close" data-modal="parameterModal">\n                        <i class="fas fa-times"></i>\n                    </button>\n                </div>\n                <div class="modal-body">\n                    <div id="parameterInputs">\n                        \x3c!-- Parameter inputs will be populated here --\x3e\n                    </div>\n                    <div class="command-preview-modal">\n                        <label>Generated Command:</label>\n                        <div class="command-preview" id="parameterCommandPreview">\n                            \x3c!-- Command preview will be shown here --\x3e\n                        </div>\n                    </div>\n                </div>\n                <div class="modal-footer">\n                    <button class="btn btn-primary" id="saveParameterCommandBtn">Add Command</button>\n                    <button class="btn btn-secondary" data-modal="parameterModal">Cancel</button>\n                </div>\n            </div>\n        '),
+      document.body.appendChild(e),
+      i.onDom(
+        'saveParameterCommandBtn',
+        'click',
+        'parameter-command-save',
+        () => {
+          this.saveParameterCommand()
+        }
+      ),
+      e
+        .querySelectorAll('.modal-close, [data-modal="parameterModal"]')
+        .forEach((e) => {
+          e.addEventListener('click', () => {
+            this.cancelParameterCommand()
+          })
+        })
+  }
+  cancelParameterCommand() {
+    this.currentParameterCommand = null
+    const e = document.getElementById('saveParameterCommandBtn')
+    e && (e.textContent = 'Add Command'), modalManager.hide('parameterModal')
+  }
+  populateParameterModal(e) {
+    const t = document.getElementById('parameterInputs')
+    ;(document.getElementById('parameterModalTitle').textContent =
+      `Configure: ${e.name}`),
+      (t.innerHTML = ''),
+      Object.entries(e.parameters).forEach(([e, a]) => {
+        const n = document.createElement('div')
+        n.className = 'form-group'
+        const o = document.createElement('label')
+        let i
+        if (
+          ((o.textContent = this.formatParameterName(e)),
+          o.setAttribute('for', `param_${e}`),
+          'message' === e)
+        ) {
+          const t = document.createElement('div')
+          ;(t.className = 'input-with-button'),
+            (i = document.createElement('input')),
+            (i.type = 'text'),
+            (i.id = `param_${e}`),
+            (i.name = e),
+            (i.value = a.default || ''),
+            a.placeholder && (i.placeholder = a.placeholder)
+          const r = document.createElement('button')
+          ;(r.type = 'button'),
+            (r.className = 'btn btn-small insert-target-btn'),
+            (r.title = 'Insert $Target variable'),
+            (r.innerHTML = '<i class="fas fa-crosshairs"></i> $Target'),
+            t.appendChild(i),
+            t.appendChild(r)
+          const s = document.createElement('small')
+          s.textContent = this.getParameterHelp(e, a)
+          const c = document.createElement('div')
+          ;(c.className = 'variable-help'),
+            (c.innerHTML =
+              "<strong>$Target</strong> - Use to include your current target's name in the message"),
+            n.appendChild(o),
+            n.appendChild(t),
+            n.appendChild(s),
+            n.appendChild(c)
+        } else {
+          'select' === a.type
+            ? ((i = document.createElement('select')),
+              (i.id = `param_${e}`),
+              (i.name = e),
+              a.options.forEach((e) => {
+                const t = document.createElement('option')
+                ;(t.value = e),
+                  (t.textContent =
+                    'STOTrayExecByTray' === e
+                      ? 'STOTrayExecByTray (shows key binding on UI)'
+                      : 'TrayExecByTray (no UI indication)'),
+                  e === a.default && (t.selected = !0),
+                  i.appendChild(t)
+              }))
+            : ((i = document.createElement('input')),
+              (i.type = 'number' === a.type ? 'number' : 'text'),
+              (i.id = `param_${e}`),
+              (i.name = e),
+              (i.value = a.default || ''),
+              a.placeholder && (i.placeholder = a.placeholder),
+              'number' === a.type &&
+                (void 0 !== a.min && (i.min = a.min),
+                void 0 !== a.max && (i.max = a.max),
+                void 0 !== a.step && (i.step = a.step)))
+          const t = document.createElement('small')
+          ;(t.textContent = this.getParameterHelp(e, a)),
+            n.appendChild(o),
+            n.appendChild(i),
+            n.appendChild(t)
+        }
+        t.appendChild(n),
+          i.addEventListener('input', () => {
+            this.updateParameterPreview()
+          }),
+          'SELECT' === i.tagName &&
+            i.addEventListener('change', () => {
+              this.updateParameterPreview()
+            })
+      }),
+      this.updateParameterPreview()
+  }
+  formatParameterName(e) {
+    return e.replace(/_/g, ' ').replace(/\b\w/g, (e) => e.toUpperCase())
+  }
+  getParameterHelp(e, t) {
+    return (
+      {
+        entityName:
+          'Name of the entity to target (e.g., ship name, player name)',
+        active: 'Whether the command is active (1 = active, 0 = inactive)',
+        tray: 'Primary tray number (0-9, where 0 is the first tray)',
+        slot: 'Primary slot number (0-9, where 0 is the first slot)',
+        backup_tray: 'Backup tray number (0-9, where 0 is the first tray)',
+        backup_slot: 'Backup slot number (0-9, where 0 is the first slot)',
+        amount: 'Throttle adjustment amount (-1 to 1)',
+        position:
+          'Throttle position (-1 = full reverse, 0 = stop, 1 = full forward)',
+        distance: 'Camera distance from target',
+        filename: 'Name of the keybind file (without extension)',
+        message: 'Text message to send',
+        state: 'Enable (1) or disable (0) combat log',
+        command_type:
+          'STOTrayExecByTray shows key binding on UI, TrayExecByTray does not',
+      }[e] ||
+      `${t.type} value ${void 0 !== t.min ? `(${t.min} to ${t.max})` : ''}`
+    )
+  }
+  updateParameterPreview() {
+    if (!this.currentParameterCommand) return
+    const {
+        categoryId: e,
+        commandId: t,
+        commandDef: a,
+      } = this.currentParameterCommand,
+      n = this.getParameterValues(),
+      o = this.buildParameterizedCommand(e, t, a, n),
+      i = document.getElementById('parameterCommandPreview')
+    if (i && o)
+      if (Array.isArray(o)) {
+        const e = o.map((e) => e.command)
+        i.textContent = e.join(' $$ ')
+      } else i.textContent = o.command
+  }
+  getParameterValues() {
+    const e = {}
+    return (
+      document
+        .querySelectorAll('#parameterInputs input, #parameterInputs select')
+        .forEach((t) => {
+          const a = t.name
+          let n = t.value
+          'number' === t.type && (n = parseFloat(n) || 0), (e[a] = n)
+        }),
+      e
+    )
+  }
+  buildParameterizedCommand(e, t, a, n) {
+    const o = {
+        targeting: (e) =>
+          'target' === t && e.entityName
+            ? {
+                command: `${a.command} "${e.entityName}"`,
+                text: `Target: ${e.entityName}`,
+              }
+            : { command: a.command, text: a.name },
+        tray: (n) => {
+          const o = n.tray || 0,
+            i = n.slot || 0
+          if ('tray_with_backup' === t) {
+            const e = void 0 !== n.active ? n.active : 1,
+              t = n.backup_tray || 0,
+              a = n.backup_slot || 0
+            return {
+              command: `TrayExecByTrayWithBackup ${e} ${o} ${i} ${t} ${a}`,
+              text: `Execute Tray ${o + 1} Slot ${i + 1} (backup: Tray ${t + 1} Slot ${a + 1})`,
+            }
+          }
+          if ('tray_range' === t) {
+            const t = n.start_tray || 0,
+              o = n.start_slot || 0,
+              i = n.end_tray || 0,
+              r = n.end_slot || 0,
+              s = n.command_type || 'STOTrayExecByTray'
+            return stoCommands
+              .generateTrayRangeCommands(t, o, i, r, s)
+              .map((n, s) => {
+                let c, l
+                try {
+                  const e = n.replace('+', '').trim().split(/\s+/)
+                  ;(c = parseInt(e[1])), (l = parseInt(e[2]))
+                } catch (e) {
+                  ;(c = void 0), (l = void 0)
+                }
+                return {
+                  command: n,
+                  type: e,
+                  icon: a.icon,
+                  text:
+                    0 === s
+                      ? `Execute Range: Tray ${t + 1} Slot ${o + 1} to Tray ${i + 1} Slot ${r + 1}`
+                      : n,
+                  id: this.generateCommandId(),
+                  parameters: { tray: c, slot: l },
+                }
+              })
+          }
+          if ('tray_range_with_backup' === t) {
+            const t = n.active || 1,
+              o = n.start_tray || 0,
+              i = n.start_slot || 0,
+              r = n.end_tray || 0,
+              s = n.end_slot || 0,
+              c = n.backup_start_tray || 0,
+              l = n.backup_start_slot || 0,
+              d = n.backup_end_tray || 0,
+              m = n.backup_end_slot || 0
+            return stoCommands
+              .generateTrayRangeWithBackupCommands(t, o, i, r, s, c, l, d, m)
+              .map((t, n) => {
+                let i, s, c, l, d
+                try {
+                  const e = t.trim().split(/\s+/)
+                  ;(i = parseInt(e[1])),
+                    (s = parseInt(e[2])),
+                    (c = parseInt(e[3])),
+                    (l = parseInt(e[4])),
+                    (d = parseInt(e[5]))
+                } catch (e) {}
+                return {
+                  command: t,
+                  type: e,
+                  icon: a.icon,
+                  text:
+                    0 === n
+                      ? `Execute Range with Backup: Tray ${o + 1}-${r + 1}`
+                      : t,
+                  id: this.generateCommandId(),
+                  parameters: {
+                    active: i,
+                    tray: s,
+                    slot: c,
+                    backup_tray: l,
+                    backup_slot: d,
+                  },
+                }
+              })
+          }
+          if ('whole_tray' === t) {
+            const t = n.command_type || 'STOTrayExecByTray'
+            return stoCommands.generateWholeTrayCommands(o, t).map((t, n) => {
+              let i
+              try {
+                const e = t.replace('+', '').trim().split(/\s+/)
+                i = parseInt(e[2])
+              } catch (e) {
+                i = void 0
+              }
+              return {
+                command: t,
+                type: e,
+                icon: a.icon,
+                text: 0 === n ? `Execute Whole Tray ${o + 1}` : t,
+                id: this.generateCommandId(),
+                parameters: { tray: o, slot: i },
+              }
+            })
+          }
+          if ('whole_tray_with_backup' === t) {
+            const t = n.active || 1,
+              i = n.backup_tray || 0
+            return stoCommands
+              .generateWholeTrayWithBackupCommands(t, o, i)
+              .map((t, n) => {
+                let r, s, c, l, d
+                try {
+                  const e = t.trim().split(/\s+/)
+                  ;(r = parseInt(e[1])),
+                    (s = parseInt(e[2])),
+                    (c = parseInt(e[3])),
+                    (l = parseInt(e[4])),
+                    (d = parseInt(e[5]))
+                } catch (e) {}
+                return {
+                  command: t,
+                  type: e,
+                  icon: a.icon,
+                  text:
+                    0 === n
+                      ? `Execute Whole Tray ${o + 1} (with backup Tray ${i + 1})`
+                      : t,
+                  id: this.generateCommandId(),
+                  parameters: {
+                    active: r,
+                    tray: s,
+                    slot: c,
+                    backup_tray: l,
+                    backup_slot: d,
+                  },
+                }
+              })
+          }
+          {
+            const e =
+                this.currentParameterCommand &&
+                this.currentParameterCommand.isEditing,
+              t = n.command_type || 'STOTrayExecByTray',
+              a = '+'
+            if (e) {
+              const e =
+                this.getCurrentProfile().keys[this.selectedKey][
+                  this.currentParameterCommand.editIndex
+                ]
+              if (
+                e &&
+                (e.command.startsWith('TrayExecByTray') ||
+                  e.command.startsWith('+TrayExecByTray'))
+              )
+                return {
+                  command: `+TrayExecByTray ${o} ${i}`,
+                  text: `Execute Tray ${o + 1} Slot ${i + 1}`,
+                }
+            }
+            return {
+              command: `${a}${t} ${o} ${i}`,
+              text: `Execute Tray ${o + 1} Slot ${i + 1}`,
+            }
+          }
+        },
+        movement: (e) => {
+          let n = a.command
+          return (
+            'throttle_adjust' === t && void 0 !== e.amount
+              ? (n = `${a.command} ${e.amount}`)
+              : 'throttle_set' === t &&
+                void 0 !== e.position &&
+                (n = `${a.command} ${e.position}`),
+            { command: n, text: a.name }
+          )
+        },
+        camera: (e) => {
+          let n = a.command
+          return (
+            'cam_distance' === t &&
+              void 0 !== e.distance &&
+              (n = `${a.command} ${e.distance}`),
+            { command: n, text: a.name }
+          )
+        },
+        communication: (e) => ({
+          command: `${a.command} ${e.message || 'Message text here'}`,
+          text: `${a.name}: ${e.message || 'Message text here'}`,
+        }),
+        system: (e) => {
+          let n = a.command
+          return (
+            ('bind_save_file' !== t && 'bind_load_file' !== t) || !e.filename
+              ? 'combat_log' === t &&
+                void 0 !== e.state &&
+                (n = `${a.command} ${e.state}`)
+              : (n = `${a.command} ${e.filename}`),
+            { command: n, text: a.name }
+          )
+        },
+      },
+      i = o[e]
+    if (i) {
+      const t = i(n)
+      return Array.isArray(t)
+        ? t
+        : {
+            command: t.command,
+            type: e,
+            icon: a.icon,
+            text: t.text,
+            id: this.generateCommandId(),
+            parameters: n,
+          }
+    }
+    return null
+  }
+  saveParameterCommand() {
+    if (!this.selectedKey || !this.currentParameterCommand) return
+    const {
+        categoryId: e,
+        commandId: t,
+        commandDef: a,
+        editIndex: n,
+        isEditing: o,
+      } = this.currentParameterCommand,
+      i = this.getParameterValues(),
+      r = this.buildParameterizedCommand(e, t, a, i)
+    if (r) {
+      if (o && void 0 !== n)
+        if (Array.isArray(r)) {
+          const e = this.getCurrentProfile()
+          e.keys[this.selectedKey].splice(n, 1, ...r),
+            stoStorage.saveProfile(this.currentProfile, e),
+            this.renderCommandChain(),
+            this.setModified(!0),
+            stoUI.showToast(
+              `${r.length} commands updated successfully`,
+              'success'
+            )
+        } else {
+          const e = this.getCurrentProfile()
+          ;(e.keys[this.selectedKey][n] = r),
+            stoStorage.saveProfile(this.currentProfile, e),
+            this.renderCommandChain(),
+            this.setModified(!0),
+            stoUI.showToast('Command updated successfully', 'success')
+        }
+      else this.addCommand(this.selectedKey, r)
+      modalManager.hide('parameterModal'),
+        (this.currentParameterCommand = null),
+        (document.getElementById('saveParameterCommandBtn').textContent =
+          'Add Command')
+    }
+  }
+  editCommand(e) {
+    if (!this.selectedKey) return
+    const t = this.getCurrentProfile().keys[this.selectedKey]
+    if (!t || !t[e]) return
+    const a = t[e]
+    if (a.parameters && a.type) {
+      const t = this.findCommandDefinition(a)
+      if (t && t.customizable)
+        return void this.editParameterizedCommand(e, a, t)
+    }
+    const n = this.findCommandDefinition(a)
+    n && n.customizable
+      ? this.editParameterizedCommand(e, a, n)
+      : stoUI.showToast(`Command: ${a.command}\nType: ${a.type}`, 'info', 3e3)
+  }
+  findCommandDefinition(e) {
+    if (e.command.includes('TrayExec')) {
+      const t = STO_DATA.commands.tray
+      if (t)
+        if (
+          e.command.includes('TrayExecByTrayWithBackup') &&
+          e.command.includes('$$')
+        ) {
+          if (e.command.split('$$').map((e) => e.trim()).length > 1) {
+            const e = t.commands.tray_range_with_backup
+            if (e) return { commandId: 'tray_range_with_backup', ...e }
+          }
+        } else if (
+          (e.command.includes('STOTrayExecByTray') ||
+            e.command.includes('TrayExecByTray')) &&
+          e.command.includes('$$') &&
+          !e.command.includes('WithBackup')
+        ) {
+          if (e.command.split('$$').map((e) => e.trim()).length > 1) {
+            const e = t.commands.tray_range
+            if (e) return { commandId: 'tray_range', ...e }
+          }
+        } else if (e.command.includes('TrayExecByTrayWithBackup')) {
+          const e = t.commands.tray_with_backup
+          if (e) return { commandId: 'tray_with_backup', ...e }
+        } else if (
+          e.command.includes('STOTrayExecByTray') ||
+          (e.command.includes('TrayExecByTray') &&
+            !e.command.includes('WithBackup'))
+        ) {
+          const e = t.commands.custom_tray
+          if (e) return { commandId: 'custom_tray', ...e }
+        }
+    }
+    const t = STO_DATA.commands[e.type]
+    if (!t) return null
+    for (const [a, n] of Object.entries(t.commands))
+      if (n.command === e.command) return { commandId: a, ...n }
+    for (const [a, n] of Object.entries(t.commands))
+      if (n.customizable && e.command.startsWith(n.command.split(' ')[0]))
+        return { commandId: a, ...n }
+    return null
+  }
+  editParameterizedCommand(e, t, a) {
+    ;(this.currentParameterCommand = {
+      categoryId: t.type,
+      commandId: a.commandId,
+      commandDef: a,
+      editIndex: e,
+      isEditing: !0,
+    }),
+      document.getElementById('parameterModal') || this.createParameterModal(),
+      this.populateParameterModalForEdit(a, t.parameters),
+      (document.getElementById('parameterModalTitle').textContent =
+        `Edit: ${a.name}`),
+      (document.getElementById('saveParameterCommandBtn').textContent =
+        'Update Command'),
+      modalManager.show('parameterModal')
+  }
+  populateParameterModalForEdit(e, t) {
+    const a = document.getElementById('parameterInputs')
+    ;(a.innerHTML = ''),
+      Object.entries(e.parameters).forEach(([e, n]) => {
+        const o = document.createElement('div')
+        o.className = 'form-group'
+        const i = document.createElement('label')
+        let r
+        if (
+          ((i.textContent = this.formatParameterName(e)),
+          i.setAttribute('for', `param_${e}`),
+          'select' === n.type)
+        ) {
+          ;(r = document.createElement('select')),
+            (r.id = `param_${e}`),
+            (r.name = e),
+            n.options.forEach((e) => {
+              const t = document.createElement('option')
+              ;(t.value = e),
+                (t.textContent =
+                  'STOTrayExecByTray' === e
+                    ? 'STOTrayExecByTray (shows key binding on UI)'
+                    : 'TrayExecByTray (no UI indication)'),
+                r.appendChild(t)
+            })
+          const a = t && void 0 !== t[e] ? t[e] : n.default
+          r.value = null != a ? a : n.default
+        } else {
+          ;(r = document.createElement('input')),
+            (r.type = 'number' === n.type ? 'number' : 'text'),
+            (r.id = `param_${e}`),
+            (r.name = e)
+          const a = t && void 0 !== t[e] ? t[e] : n.default
+          ;(r.value = null != a ? a : ''),
+            n.placeholder && (r.placeholder = n.placeholder),
+            'number' === n.type &&
+              (void 0 !== n.min && (r.min = n.min),
+              void 0 !== n.max && (r.max = n.max),
+              void 0 !== n.step && (r.step = n.step))
+        }
+        const s = document.createElement('small')
+        ;(s.textContent = this.getParameterHelp(e, n)),
+          o.appendChild(i),
+          o.appendChild(r),
+          o.appendChild(s),
+          a.appendChild(o),
+          r.addEventListener('input', () => {
+            this.updateParameterPreview()
+          }),
+          'SELECT' === r.tagName &&
+            r.addEventListener('change', () => {
+              this.updateParameterPreview()
+            })
+      }),
+      this.updateParameterPreview()
+  }
+  filterCommandLibrary() {
+    document.querySelectorAll('.command-item').forEach((e) => {
+      const t = e.dataset.command
+      if (!t) return
+      let a = null
+      for (const [e, n] of Object.entries(STO_DATA.commands))
+        if (n.commands[t]) {
+          a = n.commands[t]
+          break
+        }
+      if (a) {
+        let t = !0
+        ;(t = !a.environment || a.environment === this.currentEnvironment),
+          (e.style.display = t ? 'flex' : 'none')
+      }
+    }),
+      document.querySelectorAll('.category').forEach((e) => {
+        const t =
+          e.querySelectorAll('.command-item:not([style*="display: none"])')
+            .length > 0
+        e.style.display = t ? 'block' : 'none'
+      })
+  }
+  showKeySelectionModal() {
+    this.setupKeySelectionModal(), modalManager.show('keySelectionModal')
+  }
+  setupKeySelectionModal() {
+    this.populateCommonKeys()
+    const e = document.getElementById('findOtherKeysBtn')
+    e && (e.onclick = () => this.showFullKeyList())
+    const t = document.getElementById('keySearchInput')
+    t && (t.oninput = (e) => this.filterKeyList(e.target.value))
+  }
+  populateCommonKeys() {
+    const e = document.getElementById('commonKeysGrid')
+    if (!e) return
+    const t = STO_DATA.keys.common.keys
+    ;(e.innerHTML = ''),
+      t.forEach((t) => {
+        const a = document.createElement('div')
+        ;(a.className = 'key-button'),
+          (a.onclick = () => this.selectKeyFromModal(t.key)),
+          (a.innerHTML = `\n                <div class="key-name">${t.key}</div>\n                <div class="key-desc">${t.description}</div>\n            `),
+          e.appendChild(a)
+      })
+  }
+  showFullKeyList() {
+    const e = document.getElementById('fullKeysSection'),
+      t = document.getElementById('findOtherKeysBtn')
+    e &&
+      t &&
+      ((e.style.display = 'block'),
+      (t.style.display = 'none'),
+      this.populateKeyCategories())
+  }
+  populateKeyCategories() {
+    const e = document.getElementById('keyCategories')
+    e &&
+      ((e.innerHTML = ''),
+      Object.entries(STO_DATA.keys).forEach(([t, a]) => {
+        if ('common' === t) return
+        if (
+          (console.log('Processing category:', t, a), !a || !a.name || !a.keys)
+        )
+          return void console.warn(
+            `Invalid category data for categoryId: ${t}`,
+            a
+          )
+        const n = document.createElement('div')
+        n.className = 'key-category'
+        const o = document.createElement('div')
+        ;(o.className = 'key-category-header'),
+          (o.onclick = () => this.toggleKeySelectionCategory(t)),
+          (o.innerHTML = `\n                <div>\n                    <h5>${a.name}</h5>\n                    <div class="category-desc">${a.description || ''}</div>\n                </div>\n                <i class="fas fa-chevron-right category-chevron"></i>\n            `)
+        const i = document.createElement('div')
+        ;(i.className = 'key-category-content collapsed'),
+          (i.id = `key-category-${t}`),
+          Array.isArray(a.keys) &&
+            a.keys.forEach((e) => {
+              if (e && e.key) {
+                const t = document.createElement('div')
+                ;(t.className = 'key-button'),
+                  (t.onclick = () => this.selectKeyFromModal(e.key)),
+                  (t.innerHTML = `\n                            <div class="key-name">${e.key}</div>\n                            <div class="key-desc">${e.description || ''}</div>\n                        `),
+                  i.appendChild(t)
+              }
+            }),
+          n.appendChild(o),
+          n.appendChild(i),
+          e.appendChild(n)
+      }))
+  }
+  toggleKeySelectionCategory(e) {
+    const t = document.getElementById(`key-category-${e}`)
+    if (!t)
+      return void console.warn(
+        `Key selection category content not found for categoryId: ${e}`
+      )
+    const a = t.previousElementSibling
+    if (t && a)
+      if (t.classList.contains('collapsed')) {
+        t.classList.remove('collapsed'), a.classList.remove('collapsed')
+        const e = a.querySelector('.category-chevron')
+        e && (e.style.transform = 'rotate(90deg)')
+      } else {
+        t.classList.add('collapsed'), a.classList.add('collapsed')
+        const e = a.querySelector('.category-chevron')
+        e && (e.style.transform = 'rotate(0deg)')
+      }
+  }
+  filterKeyList(e) {
+    const t = e.toLowerCase().trim()
+    document.querySelectorAll('#keyCategories .key-button').forEach((e) => {
+      const a = e.querySelector('.key-name').textContent.toLowerCase(),
+        n = e.querySelector('.key-desc').textContent.toLowerCase(),
+        o = a.includes(t) || n.includes(t)
+      e.style.display = o ? 'flex' : 'none'
+    }),
+      document.querySelectorAll('.key-category').forEach((e) => {
+        const a =
+          e.querySelectorAll('.key-button:not([style*="display: none"])')
+            .length > 0
+        if ('' === t) e.style.display = 'block'
+        else if (((e.style.display = a ? 'block' : 'none'), a)) {
+          const t = e.querySelector('.key-category-content'),
+            a = e.querySelector('.key-category-header')
+          t &&
+            a &&
+            (t.classList.remove('collapsed'), a.classList.remove('collapsed'))
+        }
+      })
+  }
+  selectKeyFromModal(e) {
+    modalManager.hide('keySelectionModal'), this.selectKey(e)
+  }
+  insertTargetVariable(e) {
+    const t = e.selectionStart,
+      a = e.value,
+      n = a.slice(0, t) + '$Target' + a.slice(t)
+    ;(e.value = n),
+      e.setSelectionRange(t + 7, t + 7),
+      e.focus(),
+      e.dispatchEvent(new Event('input', { bubbles: !0 }))
+  }
+  showVertigoModal() {
+    const e = stoStorage.getProfile(this.currentProfile)
+    e && vertigoManager.loadState(e),
+      (this.vertigoInitialState = {
+        selectedEffects: {
+          space: new Set(vertigoManager.selectedEffects.space),
+          ground: new Set(vertigoManager.selectedEffects.ground),
+        },
+        showPlayerSay: vertigoManager.showPlayerSay,
+      }),
+      this.populateVertigoModal(),
+      this.setupVertigoEventListeners(),
+      modalManager.show('vertigoModal')
+  }
+  populateVertigoModal() {
+    const e = document.getElementById('spaceEffectsList')
+    e &&
+      ((e.innerHTML = ''),
+      VFX_EFFECTS.space.forEach((t) => {
+        const a = this.createEffectItem('space', t)
+        e.appendChild(a)
+      }))
+    const t = document.getElementById('groundEffectsList')
+    t &&
+      ((t.innerHTML = ''),
+      VFX_EFFECTS.ground.forEach((e) => {
+        const a = this.createEffectItem('ground', e)
+        t.appendChild(a)
+      })),
+      this.updateVertigoCheckboxes('space'),
+      this.updateVertigoCheckboxes('ground')
+    const a = document.getElementById('vertigoShowPlayerSay')
+    a && (a.checked = vertigoManager.showPlayerSay),
+      this.updateVertigoEffectCounts(),
+      this.updateVertigoPreview()
+  }
+  createEffectItem(e, t) {
+    const a = document.createElement('div')
+    ;(a.className = 'effect-item'),
+      (a.innerHTML = `\n            <input type="checkbox" id="effect_${e}_${t.effect.replace(/[^a-zA-Z0-9]/g, '_')}" \n                   data-environment="${e}" \n                   data-effect="${t.effect}">\n            <label for="effect_${e}_${t.effect.replace(/[^a-zA-Z0-9]/g, '_')}" \n                   class="effect-label">${t.label}</label>\n        `)
+    const n = a.querySelector('input[type="checkbox"]')
+    return (
+      n.addEventListener('change', () => {
+        vertigoManager.toggleEffect(e, t.effect),
+          this.updateVertigoEffectCounts(),
+          this.updateVertigoPreview(),
+          a.classList.toggle('selected', n.checked)
+      }),
+      a.querySelector('.effect-label').addEventListener('click', () => {
+        ;(n.checked = !n.checked), n.dispatchEvent(new Event('change'))
+      }),
+      a
+    )
+  }
+  setupVertigoEventListeners() {
+    ;[
+      'spaceSelectAll',
+      'spaceClearAll',
+      'groundSelectAll',
+      'groundClearAll',
+      'vertigoShowPlayerSay',
+      'saveVertigoBtn',
+    ].forEach((e) => {
+      const t = document.getElementById(e)
+      t && t.replaceWith(t.cloneNode(!0))
+    }),
+      i.onDom('spaceSelectAll', 'click', 'vertigo-space-select-all', () => {
+        try {
+          vertigoManager.selectAllEffects('space'),
+            this.updateVertigoCheckboxes('space'),
+            this.updateVertigoEffectCounts(),
+            this.updateVertigoPreview()
+        } catch (e) {
+          e instanceof InvalidEnvironmentError
+            ? stoUI.showToast(`Error: ${e.message}`, 'error')
+            : (stoUI.showToast('Failed to select all space effects', 'error'),
+              console.error('Error selecting all space effects:', e))
+        }
+      }),
+      i.onDom('spaceClearAll', 'click', 'vertigo-space-clear-all', () => {
+        vertigoManager.selectedEffects.space.clear(),
+          this.updateVertigoCheckboxes('space'),
+          this.updateVertigoEffectCounts(),
+          this.updateVertigoPreview()
+      }),
+      i.onDom('groundSelectAll', 'click', 'vertigo-ground-select-all', () => {
+        try {
+          vertigoManager.selectAllEffects('ground'),
+            this.updateVertigoCheckboxes('ground'),
+            this.updateVertigoEffectCounts(),
+            this.updateVertigoPreview()
+        } catch (e) {
+          e instanceof InvalidEnvironmentError
+            ? stoUI.showToast(`Error: ${e.message}`, 'error')
+            : (stoUI.showToast('Failed to select all ground effects', 'error'),
+              console.error('Error selecting all ground effects:', e))
+        }
+      }),
+      i.onDom('groundClearAll', 'click', 'vertigo-ground-clear-all', () => {
+        vertigoManager.selectedEffects.ground.clear(),
+          this.updateVertigoCheckboxes('ground'),
+          this.updateVertigoEffectCounts(),
+          this.updateVertigoPreview()
+      }),
+      i.onDom(
+        'vertigoShowPlayerSay',
+        'change',
+        'vertigo-show-playersay',
+        (e) => {
+          ;(vertigoManager.showPlayerSay = e.target.checked),
+            this.updateVertigoPreview()
+        }
+      ),
+      i.onDom('saveVertigoBtn', 'click', 'vertigo-save', () => {
+        this.generateVertigoAliases()
+      })
+  }
+  updateVertigoCheckboxes(e) {
+    document.querySelectorAll(`input[data-environment="${e}"]`).forEach((t) => {
+      const a = t.dataset.effect,
+        n = vertigoManager.isEffectSelected(e, a)
+      ;(t.checked = n),
+        t.closest('.effect-item').classList.toggle('selected', n)
+    })
+  }
+  updateVertigoEffectCounts() {
+    const e = vertigoManager.getEffectCount('space'),
+      t = vertigoManager.getEffectCount('ground'),
+      a = document.getElementById('spaceEffectCount'),
+      n = document.getElementById('groundEffectCount')
+    a && (a.textContent = `${e} selected`),
+      n && (n.textContent = `${t} selected`)
+  }
+  updateVertigoPreview() {
+    const e = document.getElementById('spaceAliasCommand'),
+      t = document.getElementById('groundAliasCommand')
+    if (e)
+      try {
+        const t = vertigoManager.generateAlias('space')
+        e.textContent = t || 'No space effects selected'
+      } catch (t) {
+        t instanceof InvalidEnvironmentError
+          ? ((e.textContent = 'Error: Invalid environment'),
+            stoUI.showToast(`Space preview error: ${t.message}`, 'error'))
+          : ((e.textContent = 'Error generating preview'),
+            console.error('Error generating space alias preview:', t))
+      }
+    if (t)
+      try {
+        const e = vertigoManager.generateAlias('ground')
+        t.textContent = e || 'No ground effects selected'
+      } catch (e) {
+        e instanceof InvalidEnvironmentError
+          ? ((t.textContent = 'Error: Invalid environment'),
+            stoUI.showToast(`Ground preview error: ${e.message}`, 'error'))
+          : ((t.textContent = 'Error generating preview'),
+            console.error('Error generating ground alias preview:', e))
+      }
+  }
+  generateVertigoAliases() {
+    let e = '',
+      t = ''
+    try {
+      e = vertigoManager.generateAlias('space')
+    } catch (e) {
+      return e instanceof InvalidEnvironmentError
+        ? void stoUI.showToast(`Space alias error: ${e.message}`, 'error')
+        : (stoUI.showToast('Failed to generate space alias', 'error'),
+          void console.error('Error generating space alias:', e))
+    }
+    try {
+      t = vertigoManager.generateAlias('ground')
+    } catch (e) {
+      return e instanceof InvalidEnvironmentError
+        ? void stoUI.showToast(`Ground alias error: ${e.message}`, 'error')
+        : (stoUI.showToast('Failed to generate ground alias', 'error'),
+          void console.error('Error generating ground alias:', e))
+    }
+    if (!e && !t)
+      return void stoUI.showToast(
+        'No effects selected. Please select at least one effect to generate aliases.',
+        'warning'
+      )
+    if (!this.getCurrentProfile())
+      return void stoUI.showToast('No profile selected', 'error')
+    const a = stoStorage.getProfile(this.currentProfile)
+    if (!a) return void stoUI.showToast('No profile found', 'error')
+    let n = 0
+    if ((a.aliases || (a.aliases = {}), e)) {
+      const t = 'dynFxSetFXExlusionList_Space',
+        o = e.match(/alias\s+\w+\s+<&\s+(.+?)&>/),
+        i = o ? o[1] : ''
+      ;(a.aliases[t] = {
+        name: t,
+        description: 'VFX - Disable Space Visual Effects',
+        commands: i,
+        created: new Date().toISOString(),
+        lastModified: new Date().toISOString(),
+      }),
+        n++
+    }
+    if (t) {
+      const e = 'dynFxSetFXExlusionList_Ground',
+        o = t.match(/alias\s+\w+\s+<&\s+(.+?)&>/),
+        i = o ? o[1] : ''
+      ;(a.aliases[e] = {
+        name: e,
+        description: 'VFX - Disable Ground Visual Effects',
+        commands: i,
+        created: new Date().toISOString(),
+        lastModified: new Date().toISOString(),
+      }),
+        n++
+    }
+    vertigoManager.saveState(a),
+      stoStorage.saveProfile(this.currentProfile, a),
+      this.saveProfile(),
+      this.setModified(!0),
+      'undefined' != typeof stoAliases &&
+        stoAliases.updateCommandLibrary &&
+        stoAliases.updateCommandLibrary(),
+      (this.vertigoInitialState = {
+        selectedEffects: {
+          space: new Set(vertigoManager.selectedEffects.space),
+          ground: new Set(vertigoManager.selectedEffects.ground),
+        },
+        showPlayerSay: vertigoManager.showPlayerSay,
+      }),
+      (this.vertigoSaving = !0),
+      modalManager.hide('vertigoModal'),
+      stoUI.showToast(
+        `Generated ${n} Vertigo alias${n > 1 ? 'es' : ''}! Check the Alias Manager to bind them to keys.`,
+        'success'
+      )
+  }
+  applyTheme() {
+    const e = stoStorage.getSettings().theme || 'default'
+    'dark' === e
+      ? document.documentElement.setAttribute('data-theme', 'dark')
+      : document.documentElement.removeAttribute('data-theme'),
+      this.updateThemeToggleButton(e)
+  }
+  toggleTheme() {
+    const e = stoStorage.getSettings(),
+      t = 'dark' === (e.theme || 'default') ? 'default' : 'dark'
+    ;(e.theme = t), stoStorage.saveSettings(e), this.applyTheme()
+    const a = 'dark' === t ? 'Dark Mode' : 'Light Mode'
+    stoUI.showToast(`Switched to ${a}`, 'success')
+  }
+  updateThemeToggleButton(e) {
+    const t = document.getElementById('themeToggleBtn'),
+      a = document.getElementById('themeToggleText'),
+      n = t?.querySelector('i')
+    t &&
+      a &&
+      n &&
+      ('dark' === e
+        ? ((n.className = 'fas fa-sun'), (a.textContent = 'Light Mode'))
+        : ((n.className = 'fas fa-moon'), (a.textContent = 'Dark Mode')))
+  }
+})()
+;(window.app = T),
+  i.on('sto-app-ready', () => {
+    p.init(), u.init(), y.init(), f.init(), b.init()
+  })

--- a/src/index.html
+++ b/src/index.html
@@ -1,642 +1,865 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>STO Tools Keybind Manager</title>
-    <meta name="description" content="Star Trek Online Keybind Manager - Create, edit, and export keybind configurations">
-    <link rel="stylesheet" href="styles.css">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-</head>
-<body>
+    <meta
+      name="description"
+      content="Star Trek Online Keybind Manager - Create, edit, and export keybind configurations"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <link
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
     <div class="app-container">
-        <!-- Header -->
-        <header class="app-header">
-            <div class="header-left">
-                <h1><a href="https://sto-tools.org/" target="_blank" rel="noopener noreferrer"><img src="img/delta_64x64.png" alt="STO Tools Logo" class="app-logo"></a> STO Tools Keybind Manager</h1>
-                <span class="version" id="appVersion"></span>
+      <!-- Header -->
+      <header class="app-header">
+        <div class="header-left">
+          <h1>
+            <a
+              href="https://sto-tools.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              ><img
+                src="img/delta_64x64.png"
+                alt="STO Tools Logo"
+                class="app-logo"
+            /></a>
+            STO Tools Keybind Manager
+          </h1>
+          <span class="version" id="appVersion"></span>
+        </div>
+        <div class="header-right">
+          <button
+            class="btn btn-secondary"
+            id="openProjectBtn"
+            title="Open Project JSON"
+          >
+            <i class="fas fa-folder-open"></i> Open
+          </button>
+          <button
+            class="btn btn-secondary"
+            id="saveProjectBtn"
+            title="Save Project JSON"
+          >
+            <i class="fas fa-save"></i> Save
+          </button>
+          <button
+            class="btn btn-secondary"
+            id="fileExplorerBtn"
+            title="File Explorer"
+          >
+            <i class="fas fa-sitemap"></i> Explorer
+          </button>
+          <div class="dropdown">
+            <button
+              class="btn btn-secondary dropdown-toggle"
+              id="keybindsBtn"
+              title="Keybind Operations"
+            >
+              <i class="fas fa-keyboard"></i> Keybinds
+            </button>
+            <div class="dropdown-menu" id="keybindsMenu">
+              <button class="dropdown-item" id="importKeybindsBtn">
+                <i class="fas fa-file-import"></i> Import Keybinds
+              </button>
+              <button class="dropdown-item" id="exportKeybindsBtn">
+                <i class="fas fa-download"></i> Export Keybinds
+              </button>
             </div>
-            <div class="header-right">
-                <button class="btn btn-secondary" id="openProjectBtn" title="Open Project JSON">
-                    <i class="fas fa-folder-open"></i> Open
-                </button>
-                <button class="btn btn-secondary" id="saveProjectBtn" title="Save Project JSON">
-                    <i class="fas fa-save"></i> Save
-                </button>
-                <button class="btn btn-secondary" id="fileExplorerBtn" title="File Explorer">
-                    <i class="fas fa-sitemap"></i> Explorer
-                </button>
-                <div class="dropdown">
-                    <button class="btn btn-secondary dropdown-toggle" id="keybindsBtn" title="Keybind Operations">
-                        <i class="fas fa-keyboard"></i> Keybinds
-                    </button>
-                    <div class="dropdown-menu" id="keybindsMenu">
-                        <button class="dropdown-item" id="importKeybindsBtn">
-                            <i class="fas fa-file-import"></i> Import Keybinds
-                        </button>
-                        <button class="dropdown-item" id="exportKeybindsBtn">
-                            <i class="fas fa-download"></i> Export Keybinds
-                        </button>
-                    </div>
-                </div>
-                <div class="dropdown">
-                    <button class="btn btn-secondary dropdown-toggle" id="aliasesBtn" title="Alias Operations">
-                        <i class="fas fa-mask"></i> Aliases
-                    </button>
-                    <div class="dropdown-menu" id="aliasesMenu">
-                        <button class="dropdown-item" id="importAliasesBtn">
-                            <i class="fas fa-mask"></i> Import Aliases
-                        </button>
-                        <button class="dropdown-item" id="exportAliasesBtn">
-                            <i class="fas fa-mask"></i> Export Aliases
-                        </button>
-                    </div>
-                </div>
-                <button class="btn btn-secondary" id="vertigoBtn" title="VFX Manager">
-                    <i class="fas fa-eye-slash"></i> VFX
-                </button>
-                <div class="dropdown">
-                    <button class="btn btn-icon dropdown-toggle" id="settingsBtn" title="Settings">
-                        <i class="fas fa-cog"></i>
-                    </button>
-                    <div class="dropdown-menu" id="settingsMenu">
-                        <button class="dropdown-item" id="themeToggleBtn">
-                            <i class="fas fa-moon"></i> <span id="themeToggleText">Dark Mode</span>
-                        </button>
-                        <button class="dropdown-item" id="loadDefaultDataBtn">
-                            <i class="fas fa-download"></i> Load Default Data
-                        </button>
-                        <button class="dropdown-item" id="resetAppBtn">
-                            <i class="fas fa-refresh"></i> Reset Application
-                        </button>
-                        <button class="dropdown-item" id="aboutBtn">
-                            <i class="fas fa-info-circle"></i> About
-                        </button>
-                    </div>
-                </div>
+          </div>
+          <div class="dropdown">
+            <button
+              class="btn btn-secondary dropdown-toggle"
+              id="aliasesBtn"
+              title="Alias Operations"
+            >
+              <i class="fas fa-mask"></i> Aliases
+            </button>
+            <div class="dropdown-menu" id="aliasesMenu">
+              <button class="dropdown-item" id="importAliasesBtn">
+                <i class="fas fa-mask"></i> Import Aliases
+              </button>
+              <button class="dropdown-item" id="exportAliasesBtn">
+                <i class="fas fa-mask"></i> Export Aliases
+              </button>
             </div>
-        </header>
+          </div>
+          <button class="btn btn-secondary" id="vertigoBtn" title="VFX Manager">
+            <i class="fas fa-eye-slash"></i> VFX
+          </button>
+          <div class="dropdown">
+            <button
+              class="btn btn-icon dropdown-toggle"
+              id="settingsBtn"
+              title="Settings"
+            >
+              <i class="fas fa-cog"></i>
+            </button>
+            <div class="dropdown-menu" id="settingsMenu">
+              <button class="dropdown-item" id="themeToggleBtn">
+                <i class="fas fa-moon"></i>
+                <span id="themeToggleText">Dark Mode</span>
+              </button>
+              <button class="dropdown-item" id="loadDefaultDataBtn">
+                <i class="fas fa-download"></i> Load Default Data
+              </button>
+              <button class="dropdown-item" id="resetAppBtn">
+                <i class="fas fa-refresh"></i> Reset Application
+              </button>
+              <button class="dropdown-item" id="aboutBtn">
+                <i class="fas fa-info-circle"></i> About
+              </button>
+            </div>
+          </div>
+        </div>
+      </header>
 
-        <!-- Profile Bar -->
-        <div class="profile-bar">
-            <div class="profile-selector">
-                <i class="fas fa-clipboard-list"></i>
-                <select id="profileSelect" title="Select Profile">
-                    <!-- Profiles populated by JavaScript -->
-                </select>
-                <div class="profile-actions">
-                    <button class="btn-small" id="newProfileBtn" title="New Profile">
-                        <i class="fas fa-plus"></i> New
-                    </button>
-                    <button class="btn-small" id="cloneProfileBtn" title="Clone Profile">
-                        <i class="fas fa-copy"></i> Clone
-                    </button>
-                    <button class="btn-small" id="renameProfileBtn" title="Rename Profile">
-                        <i class="fas fa-edit"></i> Rename
-                    </button>
-                    <button class="btn-small btn-danger" id="deleteProfileBtn" title="Delete Profile">
-                        <i class="fas fa-trash"></i> Delete
-                    </button>
-                </div>
+      <!-- Profile Bar -->
+      <div class="profile-bar">
+        <div class="profile-selector">
+          <i class="fas fa-clipboard-list"></i>
+          <select id="profileSelect" title="Select Profile">
+            <!-- Profiles populated by JavaScript -->
+          </select>
+          <div class="profile-actions">
+            <button class="btn-small" id="newProfileBtn" title="New Profile">
+              <i class="fas fa-plus"></i> New
+            </button>
+            <button
+              class="btn-small"
+              id="cloneProfileBtn"
+              title="Clone Profile"
+            >
+              <i class="fas fa-copy"></i> Clone
+            </button>
+            <button
+              class="btn-small"
+              id="renameProfileBtn"
+              title="Rename Profile"
+            >
+              <i class="fas fa-edit"></i> Rename
+            </button>
+            <button
+              class="btn-small btn-danger"
+              id="deleteProfileBtn"
+              title="Delete Profile"
+            >
+              <i class="fas fa-trash"></i> Delete
+            </button>
+          </div>
+        </div>
+        <div class="profile-info">
+          <div class="mode-toggle">
+            <button
+              class="mode-btn active"
+              data-mode="space"
+              title="Space Mode"
+            >
+              <i class="fas fa-rocket"></i> Space
+            </button>
+            <button class="mode-btn" data-mode="ground" title="Ground Mode">
+              <i class="fas fa-user"></i> Ground
+            </button>
+          </div>
+          <div class="status-indicators">
+            <span
+              class="modified-indicator"
+              id="modifiedIndicator"
+              style="display: none"
+              title="Unsaved Changes"
+            >
+              <i class="fas fa-circle"></i> Modified
+            </span>
+            <span
+              class="status-indicator"
+              id="statusIndicator"
+              title="Validation Status"
+            >
+              <i class="fas fa-check-circle"></i> Valid
+            </span>
+            <span class="key-count" id="keyCount" title="Bound Keys">
+              0 keys
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Main Content -->
+      <div class="main-content">
+        <!-- Key Selector -->
+        <div class="key-selector-container">
+          <div class="key-selector-header">
+            <h3>Keys</h3>
+            <div class="key-controls">
+              <div class="key-filter">
+                <input
+                  type="text"
+                  placeholder="Filter keys..."
+                  id="keyFilter"
+                />
+                <button class="btn btn-small" id="showAllKeysBtn">
+                  <i class="fas fa-eye"></i> All
+                </button>
+              </div>
+              <div class="view-toggle">
+                <button
+                  class="btn btn-small"
+                  id="toggleKeyViewBtn"
+                  title="Toggle between grid and categorized view"
+                >
+                  <i class="fas fa-list"></i>
+                </button>
+              </div>
             </div>
-            <div class="profile-info">
-                <div class="mode-toggle">
-                    <button class="mode-btn active" data-mode="space" title="Space Mode">
-                        <i class="fas fa-rocket"></i> Space
-                    </button>
-                    <button class="mode-btn" data-mode="ground" title="Ground Mode">
-                        <i class="fas fa-user"></i> Ground
-                    </button>
-                </div>
-                <div class="status-indicators">
-                    <span class="modified-indicator" id="modifiedIndicator" style="display: none;" title="Unsaved Changes">
-                        <i class="fas fa-circle"></i> Modified
-                    </span>
-                    <span class="status-indicator" id="statusIndicator" title="Validation Status">
-                        <i class="fas fa-check-circle"></i> Valid
-                    </span>
-                    <span class="key-count" id="keyCount" title="Bound Keys">
-                        0 keys
-                    </span>
-                </div>
+          </div>
+          <div class="key-selector">
+            <div class="key-grid" id="keyGrid">
+              <!-- Keys populated by JavaScript -->
             </div>
+            <div class="key-actions">
+              <button class="btn btn-small btn-primary" id="addKeyBtn">
+                <i class="fas fa-plus"></i> Add Key
+              </button>
+              <button
+                class="btn btn-small btn-danger"
+                id="deleteKeyBtn"
+                disabled
+              >
+                <i class="fas fa-trash"></i> Delete
+              </button>
+              <button class="btn btn-small" id="duplicateKeyBtn" disabled>
+                <i class="fas fa-copy"></i> Copy
+              </button>
+            </div>
+          </div>
         </div>
 
-        <!-- Main Content -->
-        <div class="main-content">
-            <!-- Key Selector -->
-            <div class="key-selector-container">
-                <div class="key-selector-header">
-                    <h3>Keys</h3>
-                    <div class="key-controls">
-                        <div class="key-filter">
-                            <input type="text" placeholder="Filter keys..." id="keyFilter">
-                            <button class="btn btn-small" id="showAllKeysBtn">
-                                <i class="fas fa-eye"></i> All
-                            </button>
-                        </div>
-                        <div class="view-toggle">
-                            <button class="btn btn-small" id="toggleKeyViewBtn" title="Toggle between grid and categorized view">
-                                <i class="fas fa-list"></i>
-                            </button>
-                        </div>
-                    </div>
-                </div>
-                <div class="key-selector">
-                    <div class="key-grid" id="keyGrid">
-                        <!-- Keys populated by JavaScript -->
-                    </div>
-                    <div class="key-actions">
-                        <button class="btn btn-small btn-primary" id="addKeyBtn">
-                            <i class="fas fa-plus"></i> Add Key
-                        </button>
-                        <button class="btn btn-small btn-danger" id="deleteKeyBtn" disabled>
-                            <i class="fas fa-trash"></i> Delete
-                        </button>
-                        <button class="btn btn-small" id="duplicateKeyBtn" disabled>
-                            <i class="fas fa-copy"></i> Copy
-                        </button>
-                    </div>
-                </div>
+        <!-- Command Chain Editor -->
+        <div class="command-chain-container">
+          <div class="chain-header">
+            <h3 id="chainTitle">Select a key to edit</h3>
+            <div class="chain-info">
+              <span class="command-count" id="commandCount">0 commands</span>
+              <div class="chain-options">
+                <label
+                  class="checkbox-label"
+                  title="Ensures consistent execution order by mirroring commands (Phase 1: left-to-right, Phase 2: right-to-left)"
+                >
+                  <input type="checkbox" id="stabilizeExecutionOrder" />
+                  <span class="checkmark"></span>
+                  Stabilize Execution Order
+                </label>
+              </div>
             </div>
-
-            <!-- Command Chain Editor -->
-            <div class="command-chain-container">
-                <div class="chain-header">
-                    <h3 id="chainTitle">Select a key to edit</h3>
-                    <div class="chain-info">
-                        <span class="command-count" id="commandCount">0 commands</span>
-                        <div class="chain-options">
-                            <label class="checkbox-label" title="Ensures consistent execution order by mirroring commands (Phase 1: left-to-right, Phase 2: right-to-left)">
-                                <input type="checkbox" id="stabilizeExecutionOrder" />
-                                <span class="checkmark"></span>
-                                Stabilize Execution Order
-                            </label>
-                        </div>
-                    </div>
-                    <div class="chain-actions">
-                        <button class="btn btn-small" id="validateChainBtn" title="Validate Command Chain">
-                            <i class="fas fa-check"></i> Validate
-                        </button>
-                        <button class="btn btn-small btn-danger" id="clearChainBtn" title="Clear All Commands">
-                            <i class="fas fa-trash"></i> Clear
-                        </button>
-                    </div>
-                </div>
-                
-                <div class="command-list-container">
-                    <div class="command-list" id="commandList">
-                        <div class="empty-state" id="emptyState">
-                            <i class="fas fa-keyboard"></i>
-                            <h4>No Key Selected</h4>
-                            <p>Select a key from the left panel to view and edit its command chain.</p>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="generated-command">
-                    <div class="command-preview-header">
-                        <label>Generated Command:</label>
-                        <button class="btn btn-small" id="copyPreviewBtn" title="Copy to Clipboard">
-                            <i class="fas fa-copy"></i>
-                        </button>
-                    </div>
-                    <div class="command-preview" id="commandPreview">
-                        Select a key to see the generated command
-                    </div>
-                </div>
-
-                <div class="chain-bottom-actions">
-                    <button class="btn btn-primary" id="addCommandBtn" disabled>
-                        <i class="fas fa-plus"></i> Add Command
-                    </button>
-                    <button class="btn btn-secondary" id="addFromTemplateBtn" disabled>
-                        <i class="fas fa-list"></i> From Template
-                    </button>
-                    <button class="btn btn-secondary" id="addAliasBtn">
-                        <i class="fas fa-mask"></i> Add Alias
-                    </button>
-                    <button class="btn btn-secondary" id="importFromKeyBtn" disabled>
-                        <i class="fas fa-copy"></i> Copy from Key
-                    </button>
-                </div>
+            <div class="chain-actions">
+              <button
+                class="btn btn-small"
+                id="validateChainBtn"
+                title="Validate Command Chain"
+              >
+                <i class="fas fa-check"></i> Validate
+              </button>
+              <button
+                class="btn btn-small btn-danger"
+                id="clearChainBtn"
+                title="Clear All Commands"
+              >
+                <i class="fas fa-trash"></i> Clear
+              </button>
             </div>
+          </div>
 
-            <!-- Command Library -->
-            <div class="command-library">
-                <div class="library-header">
-                    <h3>Command Library</h3>
-                    <div class="library-controls">
-                        <div class="library-search">
-                            <input type="text" placeholder="Search commands..." id="commandSearch">
-                            <button class="btn btn-icon">
-                                <i class="fas fa-search"></i>
-                            </button>
-                        </div>
-                        <button class="btn btn-small" id="toggleLibraryBtn" title="Collapse/Expand">
-                            <i class="fas fa-chevron-up"></i>
-                        </button>
-                    </div>
-                </div>
-
-                <div class="library-content" id="libraryContent">
-                    <div class="command-categories" id="commandCategories">
-                        <!-- Categories populated by JavaScript -->
-                    </div>
-                </div>
+          <div class="command-list-container">
+            <div class="command-list" id="commandList">
+              <div class="empty-state" id="emptyState">
+                <i class="fas fa-keyboard"></i>
+                <h4>No Key Selected</h4>
+                <p>
+                  Select a key from the left panel to view and edit its command
+                  chain.
+                </p>
+              </div>
             </div>
+          </div>
+
+          <div class="generated-command">
+            <div class="command-preview-header">
+              <label>Generated Command:</label>
+              <button
+                class="btn btn-small"
+                id="copyPreviewBtn"
+                title="Copy to Clipboard"
+              >
+                <i class="fas fa-copy"></i>
+              </button>
+            </div>
+            <div class="command-preview" id="commandPreview">
+              Select a key to see the generated command
+            </div>
+          </div>
+
+          <div class="chain-bottom-actions">
+            <button class="btn btn-primary" id="addCommandBtn" disabled>
+              <i class="fas fa-plus"></i> Add Command
+            </button>
+            <button class="btn btn-secondary" id="addFromTemplateBtn" disabled>
+              <i class="fas fa-list"></i> From Template
+            </button>
+            <button class="btn btn-secondary" id="addAliasBtn">
+              <i class="fas fa-mask"></i> Add Alias
+            </button>
+            <button class="btn btn-secondary" id="importFromKeyBtn" disabled>
+              <i class="fas fa-copy"></i> Copy from Key
+            </button>
+          </div>
         </div>
 
-        <!-- Toast Notifications -->
-        <div class="toast-container" id="toastContainer"></div>
+        <!-- Command Library -->
+        <div class="command-library">
+          <div class="library-header">
+            <h3>Command Library</h3>
+            <div class="library-controls">
+              <div class="library-search">
+                <input
+                  type="text"
+                  placeholder="Search commands..."
+                  id="commandSearch"
+                />
+                <button class="btn btn-icon">
+                  <i class="fas fa-search"></i>
+                </button>
+              </div>
+              <button
+                class="btn btn-small"
+                id="toggleLibraryBtn"
+                title="Collapse/Expand"
+              >
+                <i class="fas fa-chevron-up"></i>
+              </button>
+            </div>
+          </div>
+
+          <div class="library-content" id="libraryContent">
+            <div class="command-categories" id="commandCategories">
+              <!-- Categories populated by JavaScript -->
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Toast Notifications -->
+      <div class="toast-container" id="toastContainer"></div>
     </div>
 
     <!-- Modals -->
     <div class="modal-overlay" id="modalOverlay"></div>
-    
+
     <!-- Add Key Modal -->
     <div class="modal" id="addKeyModal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3>Add New Key</h3>
-                <button class="modal-close" data-modal="addKeyModal">
-                    <i class="fas fa-times"></i>
-                </button>
-            </div>
-            <div class="modal-body">
-                <div class="form-group">
-                    <label for="newKeyName">Key Name:</label>
-                    <input type="text" id="newKeyName" placeholder="e.g., F5, Ctrl+A, Shift+1" autocomplete="off">
-                    <small>Use standard key names like F1, Ctrl+A, Shift+Space, etc.</small>
-                </div>
-                <div class="common-keys">
-                    <h4>Common Keys:</h4>
-                    <div class="key-suggestions">
-                        <button class="key-suggestion" data-key="F5">F5</button>
-                        <button class="key-suggestion" data-key="F6">F6</button>
-                        <button class="key-suggestion" data-key="F7">F7</button>
-                        <button class="key-suggestion" data-key="F8">F8</button>
-                        <button class="key-suggestion" data-key="Ctrl+1">Ctrl+1</button>
-                        <button class="key-suggestion" data-key="Ctrl+2">Ctrl+2</button>
-                        <button class="key-suggestion" data-key="Alt+1">Alt+1</button>
-                        <button class="key-suggestion" data-key="Shift+Space">Shift+Space</button>
-                    </div>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button class="btn btn-primary" id="confirmAddKeyBtn">Add Key</button>
-                <button class="btn btn-secondary" data-modal="addKeyModal">Cancel</button>
-            </div>
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3>Add New Key</h3>
+          <button class="modal-close" data-modal="addKeyModal">
+            <i class="fas fa-times"></i>
+          </button>
         </div>
+        <div class="modal-body">
+          <div class="form-group">
+            <label for="newKeyName">Key Name:</label>
+            <input
+              type="text"
+              id="newKeyName"
+              placeholder="e.g., F5, Ctrl+A, Shift+1"
+              autocomplete="off"
+            />
+            <small
+              >Use standard key names like F1, Ctrl+A, Shift+Space, etc.</small
+            >
+          </div>
+          <div class="common-keys">
+            <h4>Common Keys:</h4>
+            <div class="key-suggestions">
+              <button class="key-suggestion" data-key="F5">F5</button>
+              <button class="key-suggestion" data-key="F6">F6</button>
+              <button class="key-suggestion" data-key="F7">F7</button>
+              <button class="key-suggestion" data-key="F8">F8</button>
+              <button class="key-suggestion" data-key="Ctrl+1">Ctrl+1</button>
+              <button class="key-suggestion" data-key="Ctrl+2">Ctrl+2</button>
+              <button class="key-suggestion" data-key="Alt+1">Alt+1</button>
+              <button class="key-suggestion" data-key="Shift+Space">
+                Shift+Space
+              </button>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-primary" id="confirmAddKeyBtn">Add Key</button>
+          <button class="btn btn-secondary" data-modal="addKeyModal">
+            Cancel
+          </button>
+        </div>
+      </div>
     </div>
 
     <!-- Add Command Modal -->
     <div class="modal" id="addCommandModal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3>Add Command</h3>
-                <button class="modal-close" data-modal="addCommandModal">
-                    <i class="fas fa-times"></i>
-                </button>
-            </div>
-            <div class="modal-body">
-                <div class="form-group">
-                    <label for="commandType">Command Type:</label>
-                    <select id="commandType">
-                        <option value="">Select command type...</option>
-                        <option value="targeting">Targeting</option>
-                        <option value="combat">Combat</option>
-                        <option value="tray">Tray Execution</option>
-                        <option value="power">Shield Management</option>
-                        <option value="movement">Movement</option>
-                        <option value="camera">Camera</option>
-                        <option value="communication">Communication</option>
-                        <option value="system">System</option>
-                        <option value="alias">Alias</option>
-                        <option value="custom">Custom Command</option>
-                    </select>
-                </div>
-
-                <div class="command-builder" id="commandBuilder">
-                    <!-- Command builder content populated by JavaScript -->
-                </div>
-
-                <div class="command-preview-modal">
-                    <label>Generated Command:</label>
-                    <div class="command-preview" id="modalCommandPreview">
-                        Select a command type to see preview
-                    </div>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button class="btn btn-primary" id="saveCommandBtn" disabled>Add Command</button>
-                <button class="btn btn-secondary" data-modal="addCommandModal">Cancel</button>
-            </div>
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3>Add Command</h3>
+          <button class="modal-close" data-modal="addCommandModal">
+            <i class="fas fa-times"></i>
+          </button>
         </div>
+        <div class="modal-body">
+          <div class="form-group">
+            <label for="commandType">Command Type:</label>
+            <select id="commandType">
+              <option value="">Select command type...</option>
+              <option value="targeting">Targeting</option>
+              <option value="combat">Combat</option>
+              <option value="tray">Tray Execution</option>
+              <option value="power">Shield Management</option>
+              <option value="movement">Movement</option>
+              <option value="camera">Camera</option>
+              <option value="communication">Communication</option>
+              <option value="system">System</option>
+              <option value="alias">Alias</option>
+              <option value="custom">Custom Command</option>
+            </select>
+          </div>
+
+          <div class="command-builder" id="commandBuilder">
+            <!-- Command builder content populated by JavaScript -->
+          </div>
+
+          <div class="command-preview-modal">
+            <label>Generated Command:</label>
+            <div class="command-preview" id="modalCommandPreview">
+              Select a command type to see preview
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-primary" id="saveCommandBtn" disabled>
+            Add Command
+          </button>
+          <button class="btn btn-secondary" data-modal="addCommandModal">
+            Cancel
+          </button>
+        </div>
+      </div>
     </div>
 
     <!-- Profile Modal -->
     <div class="modal" id="profileModal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 id="profileModalTitle">Profile</h3>
-                <button class="modal-close" data-modal="profileModal">
-                    <i class="fas fa-times"></i>
-                </button>
-            </div>
-            <div class="modal-body">
-                <div class="form-group">
-                    <label for="profileName">Profile Name:</label>
-                    <input type="text" id="profileName" placeholder="Enter profile name" autocomplete="off">
-                </div>
-                <div class="form-group">
-                    <label for="profileDescription">Description (optional):</label>
-                    <textarea id="profileDescription" placeholder="Describe this keybind profile" rows="3"></textarea>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button class="btn btn-primary" id="saveProfileBtn">Save</button>
-                <button class="btn btn-secondary" data-modal="profileModal">Cancel</button>
-            </div>
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 id="profileModalTitle">Profile</h3>
+          <button class="modal-close" data-modal="profileModal">
+            <i class="fas fa-times"></i>
+          </button>
         </div>
+        <div class="modal-body">
+          <div class="form-group">
+            <label for="profileName">Profile Name:</label>
+            <input
+              type="text"
+              id="profileName"
+              placeholder="Enter profile name"
+              autocomplete="off"
+            />
+          </div>
+          <div class="form-group">
+            <label for="profileDescription">Description (optional):</label>
+            <textarea
+              id="profileDescription"
+              placeholder="Describe this keybind profile"
+              rows="3"
+            ></textarea>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-primary" id="saveProfileBtn">Save</button>
+          <button class="btn btn-secondary" data-modal="profileModal">
+            Cancel
+          </button>
+        </div>
+      </div>
     </div>
 
     <!-- Alias Manager Modal -->
     <div class="modal large-modal" id="aliasManagerModal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3>Command Alias Manager</h3>
-                <button class="modal-close" data-modal="aliasManagerModal">
-                    <i class="fas fa-times"></i>
-                </button>
-            </div>
-            <div class="modal-body">
-                <div class="alias-manager-content">
-                    <div class="alias-list" id="aliasList">
-                        <!-- Aliases populated by JavaScript -->
-                    </div>
-                    <div class="alias-actions">
-                        <button class="btn btn-primary" id="newAliasBtn">
-                            <i class="fas fa-plus"></i> New Alias
-                        </button>
-                    </div>
-                </div>
-            </div>
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3>Command Alias Manager</h3>
+          <button class="modal-close" data-modal="aliasManagerModal">
+            <i class="fas fa-times"></i>
+          </button>
         </div>
+        <div class="modal-body">
+          <div class="alias-manager-content">
+            <div class="alias-list" id="aliasList">
+              <!-- Aliases populated by JavaScript -->
+            </div>
+            <div class="alias-actions">
+              <button class="btn btn-primary" id="newAliasBtn">
+                <i class="fas fa-plus"></i> New Alias
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- Edit Alias Modal -->
     <div class="modal" id="editAliasModal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 id="editAliasTitle">Edit Alias</h3>
-                <button class="modal-close" data-modal="editAliasModal">
-                    <i class="fas fa-times"></i>
-                </button>
-            </div>
-            <div class="modal-body">
-                <div class="form-group">
-                    <label for="aliasName">Alias Name:</label>
-                    <input type="text" id="aliasName" placeholder="MyAlias" autocomplete="off">
-                    <small>Use alphanumeric characters only, no spaces</small>
-                </div>
-                <div class="form-group">
-                    <label for="aliasDescription">Description:</label>
-                    <input type="text" id="aliasDescription" placeholder="Brief description of what this alias does" autocomplete="off">
-                </div>
-                <div class="form-group">
-                    <label for="aliasCommands">Commands:</label>
-                    <div class="textarea-with-button">
-                        <textarea id="aliasCommands" placeholder="Enter command sequence (use $$ to separate commands)" rows="4"></textarea>
-                        <button type="button" class="btn btn-small insert-target-btn" title="Insert $Target variable">
-                            <i class="fas fa-crosshairs"></i> $Target
-                        </button>
-                    </div>
-                    <small>Example: target_self $$ +power_exec Science_Team $$ team Healing [$Target]</small>
-                    <div class="variable-help">
-                        <strong>$Target</strong> - Use in communication commands to include target name
-                    </div>
-                </div>
-                <div class="alias-preview">
-                    <label>Preview:</label>
-                    <div class="command-preview" id="aliasPreview">
-                        alias MyAlias "command sequence"
-                    </div>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button class="btn btn-primary" id="saveAliasBtn">Save Alias</button>
-                <button class="btn btn-secondary" data-modal="editAliasModal">Cancel</button>
-            </div>
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 id="editAliasTitle">Edit Alias</h3>
+          <button class="modal-close" data-modal="editAliasModal">
+            <i class="fas fa-times"></i>
+          </button>
         </div>
+        <div class="modal-body">
+          <div class="form-group">
+            <label for="aliasName">Alias Name:</label>
+            <input
+              type="text"
+              id="aliasName"
+              placeholder="MyAlias"
+              autocomplete="off"
+            />
+            <small>Use alphanumeric characters only, no spaces</small>
+          </div>
+          <div class="form-group">
+            <label for="aliasDescription">Description:</label>
+            <input
+              type="text"
+              id="aliasDescription"
+              placeholder="Brief description of what this alias does"
+              autocomplete="off"
+            />
+          </div>
+          <div class="form-group">
+            <label for="aliasCommands">Commands:</label>
+            <div class="textarea-with-button">
+              <textarea
+                id="aliasCommands"
+                placeholder="Enter command sequence (use $$ to separate commands)"
+                rows="4"
+              ></textarea>
+              <button
+                type="button"
+                class="btn btn-small insert-target-btn"
+                title="Insert $Target variable"
+              >
+                <i class="fas fa-crosshairs"></i> $Target
+              </button>
+            </div>
+            <small
+              >Example: target_self $$ +power_exec Science_Team $$ team Healing
+              [$Target]</small
+            >
+            <div class="variable-help">
+              <strong>$Target</strong> - Use in communication commands to
+              include target name
+            </div>
+          </div>
+          <div class="alias-preview">
+            <label>Preview:</label>
+            <div class="command-preview" id="aliasPreview">
+              alias MyAlias "command sequence"
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-primary" id="saveAliasBtn">Save Alias</button>
+          <button class="btn btn-secondary" data-modal="editAliasModal">
+            Cancel
+          </button>
+        </div>
+      </div>
     </div>
 
     <!-- Key Selection Modal -->
     <div class="modal large-modal" id="keySelectionModal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3>Select Key</h3>
-                <button class="modal-close" data-modal="keySelectionModal">
-                    <i class="fas fa-times"></i>
-                </button>
-            </div>
-            <div class="modal-body">
-                <div class="key-selection-content">
-                    <!-- Common Keys Section -->
-                    <div class="common-keys-section">
-                        <h4>Common Keys</h4>
-                        <div class="common-keys-grid" id="commonKeysGrid">
-                            <!-- Populated by JavaScript -->
-                        </div>
-                    </div>
-                    
-                    <!-- Find Other Keys Button -->
-                    <div class="find-keys-section">
-                        <button class="btn btn-outline" id="findOtherKeysBtn">
-                            <i class="fas fa-search"></i> Find other keys...
-                        </button>
-                    </div>
-                    
-                    <!-- Full Key List (initially hidden) -->
-                    <div class="full-keys-section" id="fullKeysSection" style="display: none;">
-                        <div class="key-search">
-                            <input type="text" id="keySearchInput" placeholder="Search keys..." autocomplete="off">
-                        </div>
-                        <div class="key-categories" id="keyCategories">
-                            <!-- Populated by JavaScript -->
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button class="btn btn-secondary" data-modal="keySelectionModal">Cancel</button>
-            </div>
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3>Select Key</h3>
+          <button class="modal-close" data-modal="keySelectionModal">
+            <i class="fas fa-times"></i>
+          </button>
         </div>
+        <div class="modal-body">
+          <div class="key-selection-content">
+            <!-- Common Keys Section -->
+            <div class="common-keys-section">
+              <h4>Common Keys</h4>
+              <div class="common-keys-grid" id="commonKeysGrid">
+                <!-- Populated by JavaScript -->
+              </div>
+            </div>
+
+            <!-- Find Other Keys Button -->
+            <div class="find-keys-section">
+              <button class="btn btn-outline" id="findOtherKeysBtn">
+                <i class="fas fa-search"></i> Find other keys...
+              </button>
+            </div>
+
+            <!-- Full Key List (initially hidden) -->
+            <div
+              class="full-keys-section"
+              id="fullKeysSection"
+              style="display: none"
+            >
+              <div class="key-search">
+                <input
+                  type="text"
+                  id="keySearchInput"
+                  placeholder="Search keys..."
+                  autocomplete="off"
+                />
+              </div>
+              <div class="key-categories" id="keyCategories">
+                <!-- Populated by JavaScript -->
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-secondary" data-modal="keySelectionModal">
+            Cancel
+          </button>
+        </div>
+      </div>
     </div>
 
     <!-- Modal -->
     <div class="modal large-modal" id="vertigoModal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3>VFX Manager</h3>
-                <button class="modal-close" data-modal="vertigoModal">
-                    <i class="fas fa-times"></i>
-                </button>
-            </div>
-            <div class="modal-body">
-                <div class="vertigo-content">
-                    <div class="vertigo-header">
-                        <p>Select visual effects to disable using dynFxSetFXExlusionList aliases. Effects are organized by environment.</p>
-                    </div>
-                    <div class="vertigo-environments">
-                        <div class="vertigo-environment">
-                            <div class="environment-header">
-                                <h4><i class="fas fa-rocket"></i> Space Effects</h4>
-                                <div class="environment-controls">
-                                    <button class="btn btn-small" id="spaceSelectAll">Select All</button>
-                                    <button class="btn btn-small" id="spaceClearAll">Clear All</button>
-                                    <span class="effect-count" id="spaceEffectCount">0 selected</span>
-                                </div>
-                            </div>
-                            <div class="effects-list" id="spaceEffectsList">
-                                <!-- Space effects populated by JavaScript -->
-                            </div>
-                        </div>
-                        <div class="vertigo-environment">
-                            <div class="environment-header">
-                                <h4><i class="fas fa-user"></i> Ground Effects</h4>
-                                <div class="environment-controls">
-                                    <button class="btn btn-small" id="groundSelectAll">Select All</button>
-                                    <button class="btn btn-small" id="groundClearAll">Clear All</button>
-                                    <span class="effect-count" id="groundEffectCount">0 selected</span>
-                                </div>
-                            </div>
-                            <div class="effects-list" id="groundEffectsList">
-                                <!-- Ground effects populated by JavaScript -->
-                            </div>
-                        </div>
-                    </div>
-                    <div class="vertigo-preview">
-                        <div class="alias-preview-section">
-                            <h4>Generated Aliases:</h4>
-                            <div class="alias-preview" id="spaceAliasPreview">
-                                <label>Space Alias:</label>
-                                <div class="command-preview" id="spaceAliasCommand">
-                                    No space effects selected
-                                </div>
-                            </div>
-                            <div class="alias-preview" id="groundAliasPreview">
-                                <label>Ground Alias:</label>
-                                <div class="command-preview" id="groundAliasCommand">
-                                    No ground effects selected
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <div class="vertigo-controls">
-                    <label class="checkbox-label">
-                        <input type="checkbox" id="vertigoShowPlayerSay" />
-                        <span class="checkmark"></span>
-                        Show Player Say
-                    </label>
-                </div>
-
-                <button class="btn btn-primary" id="saveVertigoBtn">Generate Aliases</button>
-                <button class="btn btn-secondary" data-modal="vertigoModal">Cancel</button>
-            </div>
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3>VFX Manager</h3>
+          <button class="modal-close" data-modal="vertigoModal">
+            <i class="fas fa-times"></i>
+          </button>
         </div>
+        <div class="modal-body">
+          <div class="vertigo-content">
+            <div class="vertigo-header">
+              <p>
+                Select visual effects to disable using dynFxSetFXExlusionList
+                aliases. Effects are organized by environment.
+              </p>
+            </div>
+            <div class="vertigo-environments">
+              <div class="vertigo-environment">
+                <div class="environment-header">
+                  <h4><i class="fas fa-rocket"></i> Space Effects</h4>
+                  <div class="environment-controls">
+                    <button class="btn btn-small" id="spaceSelectAll">
+                      Select All
+                    </button>
+                    <button class="btn btn-small" id="spaceClearAll">
+                      Clear All
+                    </button>
+                    <span class="effect-count" id="spaceEffectCount"
+                      >0 selected</span
+                    >
+                  </div>
+                </div>
+                <div class="effects-list" id="spaceEffectsList">
+                  <!-- Space effects populated by JavaScript -->
+                </div>
+              </div>
+              <div class="vertigo-environment">
+                <div class="environment-header">
+                  <h4><i class="fas fa-user"></i> Ground Effects</h4>
+                  <div class="environment-controls">
+                    <button class="btn btn-small" id="groundSelectAll">
+                      Select All
+                    </button>
+                    <button class="btn btn-small" id="groundClearAll">
+                      Clear All
+                    </button>
+                    <span class="effect-count" id="groundEffectCount"
+                      >0 selected</span
+                    >
+                  </div>
+                </div>
+                <div class="effects-list" id="groundEffectsList">
+                  <!-- Ground effects populated by JavaScript -->
+                </div>
+              </div>
+            </div>
+            <div class="vertigo-preview">
+              <div class="alias-preview-section">
+                <h4>Generated Aliases:</h4>
+                <div class="alias-preview" id="spaceAliasPreview">
+                  <label>Space Alias:</label>
+                  <div class="command-preview" id="spaceAliasCommand">
+                    No space effects selected
+                  </div>
+                </div>
+                <div class="alias-preview" id="groundAliasPreview">
+                  <label>Ground Alias:</label>
+                  <div class="command-preview" id="groundAliasCommand">
+                    No ground effects selected
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <div class="vertigo-controls">
+            <label class="checkbox-label">
+              <input type="checkbox" id="vertigoShowPlayerSay" />
+              <span class="checkmark"></span>
+              Show Player Say
+            </label>
+          </div>
+
+          <button class="btn btn-primary" id="saveVertigoBtn">
+            Generate Aliases
+          </button>
+          <button class="btn btn-secondary" data-modal="vertigoModal">
+            Cancel
+          </button>
+        </div>
+      </div>
     </div>
 
     <!-- About Modal -->
     <div class="modal" id="aboutModal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3>About STO Tools Keybind Manager</h3>
-                <button class="modal-close" data-modal="aboutModal">
-                    <i class="fas fa-times"></i>
-                </button>
-            </div>
-            <div class="modal-body">
-                <div class="about-content">
-                    <div class="app-info">
-                        <h4><i class="fas fa-bolt"></i> STO Tools Keybind Manager <span id="aboutVersion"></span></h4>
-                        <p>A comprehensive web-based tool for creating, editing, and managing Star Trek Online keybind configurations with visual editing and advanced features.</p>
-                    </div>
-                    <div class="features">
-                        <h4>Features:</h4>
-                        <ul>
-                            <li>Visual keybind editor</li>
-                            <li>STO command library with search and categorization</li>
-                            <li>Multiple profile management (create, clone, rename, delete)</li>
-                            <li>Custom alias system for complex command sequences</li>
-                            <li>VERTIGO-inspired VFX Manager for visual effects control</li>
-                            <li>Import/export keybind and alias files, and project backups</li>
-                            <li>Real-time validation and command preview</li>
-                        </ul>
-                    </div>
-                    <div class="usage">
-                        <h4>Quick Start:</h4>
-                        <ol>
-                            <li>Create a new profile or use the default profile</li>
-                            <li>Select keys from the grid and add commands from the library</li>
-                            <li>Use the command chain editor to build complex sequences</li>
-                            <li>Export your keybinds as .txt files for use in STO</li>
-                        </ol>
-                    </div>
-                    <div class="contact-info">
-                        <h4>Resources:</h4>
-                        <p>
-                            <i class="fas fa-globe"></i> <a href="https://sto-tools.org/" target="_blank" rel="noopener noreferrer">https://sto-tools.org/</a> | <i class="fas fa-envelope"></i> <a href="mailto:keybinds@sto-tools.org">keybinds@sto-tools.org</a>
-                        </p>
-                    </div>
-                    <div class="copyright">
-                        <p><small>© 2025 STO Tools. All rights reserved.</small></p>
-                    </div>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button class="btn btn-primary" data-modal="aboutModal">Got it!</button>
-            </div>
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3>About STO Tools Keybind Manager</h3>
+          <button class="modal-close" data-modal="aboutModal">
+            <i class="fas fa-times"></i>
+          </button>
         </div>
+        <div class="modal-body">
+          <div class="about-content">
+            <div class="app-info">
+              <h4>
+                <i class="fas fa-bolt"></i> STO Tools Keybind Manager
+                <span id="aboutVersion"></span>
+              </h4>
+              <p>
+                A comprehensive web-based tool for creating, editing, and
+                managing Star Trek Online keybind configurations with visual
+                editing and advanced features.
+              </p>
+            </div>
+            <div class="features">
+              <h4>Features:</h4>
+              <ul>
+                <li>Visual keybind editor</li>
+                <li>STO command library with search and categorization</li>
+                <li>
+                  Multiple profile management (create, clone, rename, delete)
+                </li>
+                <li>Custom alias system for complex command sequences</li>
+                <li>VERTIGO-inspired VFX Manager for visual effects control</li>
+                <li>
+                  Import/export keybind and alias files, and project backups
+                </li>
+                <li>Real-time validation and command preview</li>
+              </ul>
+            </div>
+            <div class="usage">
+              <h4>Quick Start:</h4>
+              <ol>
+                <li>Create a new profile or use the default profile</li>
+                <li>
+                  Select keys from the grid and add commands from the library
+                </li>
+                <li>Use the command chain editor to build complex sequences</li>
+                <li>Export your keybinds as .txt files for use in STO</li>
+              </ol>
+            </div>
+            <div class="contact-info">
+              <h4>Resources:</h4>
+              <p>
+                <i class="fas fa-globe"></i>
+                <a
+                  href="https://sto-tools.org/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >https://sto-tools.org/</a
+                >
+                | <i class="fas fa-envelope"></i>
+                <a href="mailto:keybinds@sto-tools.org"
+                  >keybinds@sto-tools.org</a
+                >
+              </p>
+            </div>
+            <div class="copyright">
+              <p><small>© 2025 STO Tools. All rights reserved.</small></p>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-primary" data-modal="aboutModal">
+            Got it!
+          </button>
+        </div>
+      </div>
     </div>
 
     <!-- File Explorer Modal -->
     <div class="modal large-modal" id="fileExplorerModal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3>File Explorer</h3>
-                <button class="modal-close" data-modal="fileExplorerModal">
-                    <i class="fas fa-times"></i>
-                </button>
-            </div>
-            <div class="modal-body">
-                <div class="file-explorer-content">
-                    <div class="file-tree" id="fileTree">
-                        <!-- Tree populated by JavaScript -->
-                    </div>
-                    <div class="file-details">
-                        <div class="file-actions">
-                            <button class="btn btn-small" id="copyFileContentBtn" title="Copy to Clipboard">
-                                <i class="fas fa-copy"></i> Copy
-                            </button>
-                        </div>
-                        <pre class="file-content" id="fileContent">Select an item on the left to preview export</pre>
-                    </div>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button class="btn btn-secondary" data-modal="fileExplorerModal">Close</button>
-            </div>
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3>File Explorer</h3>
+          <button class="modal-close" data-modal="fileExplorerModal">
+            <i class="fas fa-times"></i>
+          </button>
         </div>
+        <div class="modal-body">
+          <div class="file-explorer-content">
+            <div class="file-tree" id="fileTree">
+              <!-- Tree populated by JavaScript -->
+            </div>
+            <div class="file-details">
+              <div class="file-actions">
+                <button
+                  class="btn btn-small"
+                  id="copyFileContentBtn"
+                  title="Copy to Clipboard"
+                >
+                  <i class="fas fa-copy"></i> Copy
+                </button>
+              </div>
+              <pre class="file-content" id="fileContent">
+Select an item on the left to preview export</pre
+              >
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-secondary" data-modal="fileExplorerModal">
+            Close
+          </button>
+        </div>
+      </div>
     </div>
 
     <!-- File input for imports (hidden) -->
-    <input type="file" id="fileInput" accept=".json,.txt" style="display: none;">
+    <input
+      type="file"
+      id="fileInput"
+      accept=".json,.txt"
+      style="display: none"
+    />
 
     <!-- Scripts -->
     <script src="dist/bundle.js"></script>
-</body>
-</html> 
+  </body>
+</html>

--- a/src/js/aliases.js
+++ b/src/js/aliases.js
@@ -4,120 +4,130 @@ import store from './store.js'
 import eventBus from './eventBus.js'
 
 export default class STOAliasManager {
-    constructor() {
-        this.currentAlias = null;
-        // Don't initialize immediately - wait for app to be ready
-    }
+  constructor() {
+    this.currentAlias = null
+    // Don't initialize immediately - wait for app to be ready
+  }
 
-    init() {
-        this.setupEventListeners();
-        // Update command library to show existing aliases on initialization
-        this.updateCommandLibrary();
-    }
+  init() {
+    this.setupEventListeners()
+    // Update command library to show existing aliases on initialization
+    this.updateCommandLibrary()
+  }
 
-    setupEventListeners() {
-        // Alias manager button
-        eventBus.onDom('addAliasBtn', 'click', 'alias-manager-open', () => {
-            this.showAliasManager();
-        });
+  setupEventListeners() {
+    // Alias manager button
+    eventBus.onDom('addAliasBtn', 'click', 'alias-manager-open', () => {
+      this.showAliasManager()
+    })
 
-        // New alias button
-        eventBus.onDom('newAliasBtn', 'click', 'alias-new', () => {
-            this.showEditAliasModal();
-        });
+    // New alias button
+    eventBus.onDom('newAliasBtn', 'click', 'alias-new', () => {
+      this.showEditAliasModal()
+    })
 
-        // Save alias button
-        eventBus.onDom('saveAliasBtn', 'click', 'alias-save', () => {
-            this.saveAlias();
-        });
+    // Save alias button
+    eventBus.onDom('saveAliasBtn', 'click', 'alias-save', () => {
+      this.saveAlias()
+    })
 
-        // Alias input changes for live preview
-        document.addEventListener('input', (e) => {
-            if (['aliasName', 'aliasCommands', 'aliasDescription'].includes(e.target.id)) {
-                this.updateAliasPreview();
-            }
-        });
+    // Alias input changes for live preview
+    document.addEventListener('input', (e) => {
+      if (
+        ['aliasName', 'aliasCommands', 'aliasDescription'].includes(e.target.id)
+      ) {
+        this.updateAliasPreview()
+      }
+    })
 
-        // Insert $Target variable button in alias editor
-        document.addEventListener('click', (e) => {
-            if (e.target.classList.contains('insert-target-btn') || e.target.closest('.insert-target-btn')) {
-                e.preventDefault();
-                const button = e.target.classList.contains('insert-target-btn') ? e.target : e.target.closest('.insert-target-btn');
-                const textareaContainer = button.closest('.textarea-with-button');
-                const textarea = textareaContainer ? textareaContainer.querySelector('textarea') : null;
-                
-                if (textarea) {
-                    this.insertTargetVariable(textarea);
-                }
-            }
-        });
-    }
+    // Insert $Target variable button in alias editor
+    document.addEventListener('click', (e) => {
+      if (
+        e.target.classList.contains('insert-target-btn') ||
+        e.target.closest('.insert-target-btn')
+      ) {
+        e.preventDefault()
+        const button = e.target.classList.contains('insert-target-btn')
+          ? e.target
+          : e.target.closest('.insert-target-btn')
+        const textareaContainer = button.closest('.textarea-with-button')
+        const textarea = textareaContainer
+          ? textareaContainer.querySelector('textarea')
+          : null
 
-    // Alias Manager Modal
-    showAliasManager() {
-        this.renderAliasList();
-        modalManager.show('aliasManagerModal');
-    }
+        if (textarea) {
+          this.insertTargetVariable(textarea)
+        }
+      }
+    })
+  }
 
-    renderAliasList() {
-        const container = document.getElementById('aliasList');
-        if (!container) return;
+  // Alias Manager Modal
+  showAliasManager() {
+    this.renderAliasList()
+    modalManager.show('aliasManagerModal')
+  }
 
-        const profile = app.getCurrentProfile();
-        if (!profile || !profile.aliases) {
-            container.innerHTML = `
+  renderAliasList() {
+    const container = document.getElementById('aliasList')
+    if (!container) return
+
+    const profile = app.getCurrentProfile()
+    if (!profile || !profile.aliases) {
+      container.innerHTML = `
                 <div class="empty-state">
                     <i class="fas fa-mask"></i>
                     <h4>No Aliases</h4>
                     <p>Create command aliases to simplify complex command sequences.</p>
                 </div>
-            `;
-            return;
-        }
+            `
+      return
+    }
 
-        const aliases = Object.entries(profile.aliases);
-        
-        if (aliases.length === 0) {
-            container.innerHTML = `
+    const aliases = Object.entries(profile.aliases)
+
+    if (aliases.length === 0) {
+      container.innerHTML = `
                 <div class="empty-state">
                     <i class="fas fa-mask"></i>
                     <h4>No Aliases</h4>
                     <p>Create command aliases to simplify complex command sequences.</p>
                 </div>
-            `;
-            return;
-        }
+            `
+      return
+    }
 
-        container.innerHTML = `
+    container.innerHTML = `
             <div class="alias-grid">
                 ${aliases.map(([name, alias]) => this.createAliasCard(name, alias)).join('')}
             </div>
-        `;
+        `
 
-        // Add event listeners to alias cards
-        container.querySelectorAll('.alias-card').forEach(card => {
-            const aliasName = card.dataset.alias;
-            
-            card.querySelector('.edit-alias-btn')?.addEventListener('click', () => {
-                this.editAlias(aliasName);
-            });
-            
-            card.querySelector('.delete-alias-btn')?.addEventListener('click', () => {
-                this.confirmDeleteAlias(aliasName);
-            });
-            
-            card.querySelector('.use-alias-btn')?.addEventListener('click', () => {
-                this.useAlias(aliasName);
-            });
-        });
-    }
+    // Add event listeners to alias cards
+    container.querySelectorAll('.alias-card').forEach((card) => {
+      const aliasName = card.dataset.alias
 
-    createAliasCard(name, alias) {
-        const commandPreview = alias.commands.length > 60 
-            ? alias.commands.substring(0, 60) + '...' 
-            : alias.commands;
+      card.querySelector('.edit-alias-btn')?.addEventListener('click', () => {
+        this.editAlias(aliasName)
+      })
 
-        return `
+      card.querySelector('.delete-alias-btn')?.addEventListener('click', () => {
+        this.confirmDeleteAlias(aliasName)
+      })
+
+      card.querySelector('.use-alias-btn')?.addEventListener('click', () => {
+        this.useAlias(aliasName)
+      })
+    })
+  }
+
+  createAliasCard(name, alias) {
+    const commandPreview =
+      alias.commands.length > 60
+        ? alias.commands.substring(0, 60) + '...'
+        : alias.commands
+
+    return `
             <div class="alias-card" data-alias="${name}">
                 <div class="alias-header">
                     <h4>${name}</h4>
@@ -143,269 +153,318 @@ export default class STOAliasManager {
                     Usage: <code>${name}</code>
                 </div>
             </div>
-        `;
+        `
+  }
+
+  // Edit Alias Modal
+  showEditAliasModal(aliasName = null) {
+    const title = document.getElementById('editAliasTitle')
+    const nameInput = document.getElementById('aliasName')
+    const descInput = document.getElementById('aliasDescription')
+    const commandsInput = document.getElementById('aliasCommands')
+
+    if (aliasName) {
+      // Editing existing alias
+      const profile = app.getCurrentProfile()
+      const alias = profile.aliases[aliasName]
+
+      if (title) title.textContent = 'Edit Alias'
+      if (nameInput) {
+        nameInput.value = aliasName
+        nameInput.disabled = true // Can't change alias name
+      }
+      if (descInput) descInput.value = alias.description || ''
+      if (commandsInput) commandsInput.value = alias.commands
+
+      this.currentAlias = aliasName
+    } else {
+      // Creating new alias
+      if (title) title.textContent = 'New Alias'
+      if (nameInput) {
+        nameInput.value = ''
+        nameInput.disabled = false
+      }
+      if (descInput) descInput.value = ''
+      if (commandsInput) commandsInput.value = ''
+
+      this.currentAlias = null
     }
 
-    // Edit Alias Modal
-    showEditAliasModal(aliasName = null) {
-        const title = document.getElementById('editAliasTitle');
-        const nameInput = document.getElementById('aliasName');
-        const descInput = document.getElementById('aliasDescription');
-        const commandsInput = document.getElementById('aliasCommands');
+    this.updateAliasPreview()
+    modalManager.hide('aliasManagerModal')
+    modalManager.show('editAliasModal')
+  }
 
-        if (aliasName) {
-            // Editing existing alias
-            const profile = app.getCurrentProfile();
-            const alias = profile.aliases[aliasName];
-            
-            if (title) title.textContent = 'Edit Alias';
-            if (nameInput) {
-                nameInput.value = aliasName;
-                nameInput.disabled = true; // Can't change alias name
-            }
-            if (descInput) descInput.value = alias.description || '';
-            if (commandsInput) commandsInput.value = alias.commands;
-            
-            this.currentAlias = aliasName;
-        } else {
-            // Creating new alias
-            if (title) title.textContent = 'New Alias';
-            if (nameInput) {
-                nameInput.value = '';
-                nameInput.disabled = false;
-            }
-            if (descInput) descInput.value = '';
-            if (commandsInput) commandsInput.value = '';
-            
-            this.currentAlias = null;
-        }
+  editAlias(aliasName) {
+    this.showEditAliasModal(aliasName)
+  }
 
-        this.updateAliasPreview();
-        modalManager.hide('aliasManagerModal');
-        modalManager.show('editAliasModal');
+  async confirmDeleteAlias(aliasName) {
+    const confirmed = await stoUI.confirm(
+      `Are you sure you want to delete the alias "${aliasName}"?`,
+      'Delete Alias',
+      'danger'
+    )
+
+    if (confirmed) {
+      this.deleteAlias(aliasName)
+    }
+  }
+
+  deleteAlias(aliasName) {
+    const profile = app.getCurrentProfile()
+    if (profile && profile.aliases && profile.aliases[aliasName]) {
+      delete profile.aliases[aliasName]
+      app.saveProfile()
+      app.setModified(true)
+
+      this.renderAliasList()
+      this.updateCommandLibrary()
+
+      stoUI.showToast(`Alias "${aliasName}" deleted`, 'success')
+    }
+  }
+
+  useAlias(aliasName) {
+    if (!store.selectedKey) {
+      stoUI.showToast('Please select a key first', 'warning')
+      return
     }
 
-    editAlias(aliasName) {
-        this.showEditAliasModal(aliasName);
+    const command = {
+      command: aliasName,
+      type: 'alias',
+      icon: '🎭',
+      text: `Alias: ${aliasName}`,
+      id: app.generateCommandId(),
     }
 
-    async confirmDeleteAlias(aliasName) {
-        const confirmed = await stoUI.confirm(
-            `Are you sure you want to delete the alias "${aliasName}"?`,
-            'Delete Alias',
-            'danger'
-        );
+    app.addCommand(store.selectedKey, command)
+    modalManager.hide('aliasManagerModal')
+    stoUI.showToast(
+      `Alias "${aliasName}" added to ${store.selectedKey}`,
+      'success'
+    )
+  }
 
-        if (confirmed) {
-            this.deleteAlias(aliasName);
-        }
+  // Save Alias
+  saveAlias() {
+    const nameInput = document.getElementById('aliasName')
+    const descInput = document.getElementById('aliasDescription')
+    const commandsInput = document.getElementById('aliasCommands')
+
+    if (!nameInput || !commandsInput) return
+
+    const name = nameInput.value.trim()
+    const description = descInput?.value.trim() || ''
+    const commands = commandsInput.value.trim()
+
+    // Validation
+    const validation = this.validateAlias(name, commands)
+    if (!validation.valid) {
+      stoUI.showToast(validation.error, 'error')
+      return
     }
 
-    deleteAlias(aliasName) {
-        const profile = app.getCurrentProfile();
-        if (profile && profile.aliases && profile.aliases[aliasName]) {
-            delete profile.aliases[aliasName];
-            app.saveProfile();
-            app.setModified(true);
-            
-            this.renderAliasList();
-            this.updateCommandLibrary();
-            
-            stoUI.showToast(`Alias "${aliasName}" deleted`, 'success');
-        }
+    const profile = app.getCurrentProfile()
+    if (!profile) {
+      stoUI.showToast('No active profile', 'error')
+      return
     }
 
-    useAlias(aliasName) {
-        if (!store.selectedKey) {
-            stoUI.showToast('Please select a key first', 'warning');
-            return;
-        }
-
-        const command = {
-            command: aliasName,
-            type: 'alias',
-            icon: '🎭',
-            text: `Alias: ${aliasName}`,
-            id: app.generateCommandId()
-        };
-
-        app.addCommand(store.selectedKey, command);
-        modalManager.hide('aliasManagerModal');
-        stoUI.showToast(`Alias "${aliasName}" added to ${store.selectedKey}`, 'success');
+    // Initialize aliases object if it doesn't exist
+    if (!profile.aliases) {
+      profile.aliases = {}
     }
 
-    // Save Alias
-    saveAlias() {
-        const nameInput = document.getElementById('aliasName');
-        const descInput = document.getElementById('aliasDescription');
-        const commandsInput = document.getElementById('aliasCommands');
-
-        if (!nameInput || !commandsInput) return;
-
-        const name = nameInput.value.trim();
-        const description = descInput?.value.trim() || '';
-        const commands = commandsInput.value.trim();
-
-        // Validation
-        const validation = this.validateAlias(name, commands);
-        if (!validation.valid) {
-            stoUI.showToast(validation.error, 'error');
-            return;
-        }
-
-        const profile = app.getCurrentProfile();
-        if (!profile) {
-            stoUI.showToast('No active profile', 'error');
-            return;
-        }
-
-        // Initialize aliases object if it doesn't exist
-        if (!profile.aliases) {
-            profile.aliases = {};
-        }
-
-        // Check for duplicate names (only when creating new alias)
-        if (!this.currentAlias && profile.aliases[name]) {
-            stoUI.showToast('An alias with this name already exists', 'error');
-            nameInput.focus();
-            return;
-        }
-
-        // Save alias
-        profile.aliases[name] = {
-            name: name,
-            description: description,
-            commands: commands,
-            created: this.currentAlias ? profile.aliases[name]?.created : new Date().toISOString(),
-            lastModified: new Date().toISOString()
-        };
-
-        app.saveProfile();
-        app.setModified(true);
-
-        // Update UI
-        this.updateCommandLibrary();
-        
-        const action = this.currentAlias ? 'updated' : 'created';
-        stoUI.showToast(`Alias "${name}" ${action}`, 'success');
-        
-        modalManager.hide('editAliasModal');
-        this.showAliasManager();
+    // Check for duplicate names (only when creating new alias)
+    if (!this.currentAlias && profile.aliases[name]) {
+      stoUI.showToast('An alias with this name already exists', 'error')
+      nameInput.focus()
+      return
     }
 
-    validateAlias(name, commands) {
-        // Validate name
-        if (!name) {
-            return { valid: false, error: 'Alias name is required' };
-        }
-
-        if (!STO_DATA.validation.aliasNamePattern.test(name)) {
-            return { valid: false, error: 'Invalid alias name. Use only letters, numbers, and underscores. Must start with a letter.' };
-        }
-
-        if (name.length > 30) {
-            return { valid: false, error: 'Alias name is too long (max 30 characters)' };
-        }
-
-        // Check for reserved names
-        const reservedNames = ['alias', 'bind', 'unbind', 'bind_load_file', 'bind_save_file'];
-        if (reservedNames.includes(name.toLowerCase())) {
-            return { valid: false, error: 'This is a reserved command name' };
-        }
-
-        // Validate commands
-        if (!commands) {
-            return { valid: false, error: 'Commands are required' };
-        }
-
-        if (commands.length > 500) {
-            return { valid: false, error: 'Command sequence is too long (max 500 characters)' };
-        }
-
-        // Check for circular references (only if app is available)
-        if (typeof app !== 'undefined' && app.getCurrentProfile) {
-            const profile = app.getCurrentProfile();
-            if (profile && profile.aliases) {
-                const aliasNames = Object.keys(profile.aliases);
-                if (aliasNames.some(aliasName => commands.includes(aliasName) && aliasName !== name)) {
-                    // This is a simplified check - a more thorough check would trace the full dependency graph
-                    return { valid: false, error: 'Potential circular reference detected' };
-                }
-            }
-        }
-
-        return { valid: true };
+    // Save alias
+    profile.aliases[name] = {
+      name: name,
+      description: description,
+      commands: commands,
+      created: this.currentAlias
+        ? profile.aliases[name]?.created
+        : new Date().toISOString(),
+      lastModified: new Date().toISOString(),
     }
 
-    updateAliasPreview() {
-        const preview = document.getElementById('aliasPreview');
-        const nameInput = document.getElementById('aliasName');
-        const commandsInput = document.getElementById('aliasCommands');
+    app.saveProfile()
+    app.setModified(true)
 
-        if (!preview || !nameInput || !commandsInput) return;
+    // Update UI
+    this.updateCommandLibrary()
 
-        const name = nameInput.value.trim() || 'AliasName';
-        const commands = commandsInput.value.trim() || 'command sequence';
+    const action = this.currentAlias ? 'updated' : 'created'
+    stoUI.showToast(`Alias "${name}" ${action}`, 'success')
 
-        preview.textContent = `alias ${name} <& ${commands} &>`;
+    modalManager.hide('editAliasModal')
+    this.showAliasManager()
+  }
+
+  validateAlias(name, commands) {
+    // Validate name
+    if (!name) {
+      return { valid: false, error: 'Alias name is required' }
     }
 
-    // Command Library Integration
-    updateCommandLibrary() {
-        const profile = app.getCurrentProfile();
-        if (!profile || !profile.aliases) return;
-
-        // Find or create aliases category in command library
-        const categories = document.getElementById('commandCategories');
-        if (!categories) return;
-
-        // Remove existing alias categories
-        const existingAliasCategory = categories.querySelector('[data-category="aliases"]');
-        if (existingAliasCategory) {
-            existingAliasCategory.remove();
-        }
-        const existingVertigoCategory = categories.querySelector('[data-category="vertigo-aliases"]');
-        if (existingVertigoCategory) {
-            existingVertigoCategory.remove();
-        }
-
-        // Separate regular aliases from VFX aliases
-        const allAliases = Object.entries(profile.aliases);
-        const regularAliases = allAliases.filter(([name, alias]) => 
-            !name.startsWith('dynFxSetFXExlusionList_')
-        );
-        const vertigoAliases = allAliases.filter(([name, alias]) => 
-            name.startsWith('dynFxSetFXExlusionList_')
-        );
-
-        // Add regular aliases category if there are regular aliases
-        if (regularAliases.length > 0) {
-            const aliasCategory = this.createAliasCategoryElement(regularAliases, 'aliases', 'Command Aliases', 'fas fa-mask');
-            categories.appendChild(aliasCategory);
-        }
-
-        // Add VFX aliases category if there are VERTIGO aliases
-        if (vertigoAliases.length > 0) {
-            const vertigoCategory = this.createAliasCategoryElement(vertigoAliases, 'vertigo-aliases', 'VFX Aliases', 'fas fa-eye-slash');
-            categories.appendChild(vertigoCategory);
-        }
+    if (!STO_DATA.validation.aliasNamePattern.test(name)) {
+      return {
+        valid: false,
+        error:
+          'Invalid alias name. Use only letters, numbers, and underscores. Must start with a letter.',
+      }
     }
 
-    createAliasCategoryElement(aliases, categoryType = 'aliases', title = 'Command Aliases', iconClass = 'fas fa-mask') {
-        const element = document.createElement('div');
-        element.className = 'category';
-        element.dataset.category = categoryType;
-        
-        // Check if category should be collapsed (similar to main command library)
-        const storageKey = `commandCategory_${categoryType}_collapsed`;
-        const isCollapsed = localStorage.getItem(storageKey) === 'true';
-        
-        // Choose appropriate icon and styling for different alias types
-        const isVertigo = categoryType === 'vertigo-aliases';
-        const itemIcon = isVertigo ? '👁️' : '🎭';
-        const itemClass = isVertigo ? 'command-item vertigo-alias-item' : 'command-item alias-item';
-        
-        element.innerHTML = `
+    if (name.length > 30) {
+      return {
+        valid: false,
+        error: 'Alias name is too long (max 30 characters)',
+      }
+    }
+
+    // Check for reserved names
+    const reservedNames = [
+      'alias',
+      'bind',
+      'unbind',
+      'bind_load_file',
+      'bind_save_file',
+    ]
+    if (reservedNames.includes(name.toLowerCase())) {
+      return { valid: false, error: 'This is a reserved command name' }
+    }
+
+    // Validate commands
+    if (!commands) {
+      return { valid: false, error: 'Commands are required' }
+    }
+
+    if (commands.length > 500) {
+      return {
+        valid: false,
+        error: 'Command sequence is too long (max 500 characters)',
+      }
+    }
+
+    // Check for circular references (only if app is available)
+    if (typeof app !== 'undefined' && app.getCurrentProfile) {
+      const profile = app.getCurrentProfile()
+      if (profile && profile.aliases) {
+        const aliasNames = Object.keys(profile.aliases)
+        if (
+          aliasNames.some(
+            (aliasName) => commands.includes(aliasName) && aliasName !== name
+          )
+        ) {
+          // This is a simplified check - a more thorough check would trace the full dependency graph
+          return {
+            valid: false,
+            error: 'Potential circular reference detected',
+          }
+        }
+      }
+    }
+
+    return { valid: true }
+  }
+
+  updateAliasPreview() {
+    const preview = document.getElementById('aliasPreview')
+    const nameInput = document.getElementById('aliasName')
+    const commandsInput = document.getElementById('aliasCommands')
+
+    if (!preview || !nameInput || !commandsInput) return
+
+    const name = nameInput.value.trim() || 'AliasName'
+    const commands = commandsInput.value.trim() || 'command sequence'
+
+    preview.textContent = `alias ${name} <& ${commands} &>`
+  }
+
+  // Command Library Integration
+  updateCommandLibrary() {
+    const profile = app.getCurrentProfile()
+    if (!profile || !profile.aliases) return
+
+    // Find or create aliases category in command library
+    const categories = document.getElementById('commandCategories')
+    if (!categories) return
+
+    // Remove existing alias categories
+    const existingAliasCategory = categories.querySelector(
+      '[data-category="aliases"]'
+    )
+    if (existingAliasCategory) {
+      existingAliasCategory.remove()
+    }
+    const existingVertigoCategory = categories.querySelector(
+      '[data-category="vertigo-aliases"]'
+    )
+    if (existingVertigoCategory) {
+      existingVertigoCategory.remove()
+    }
+
+    // Separate regular aliases from VFX aliases
+    const allAliases = Object.entries(profile.aliases)
+    const regularAliases = allAliases.filter(
+      ([name, alias]) => !name.startsWith('dynFxSetFXExlusionList_')
+    )
+    const vertigoAliases = allAliases.filter(([name, alias]) =>
+      name.startsWith('dynFxSetFXExlusionList_')
+    )
+
+    // Add regular aliases category if there are regular aliases
+    if (regularAliases.length > 0) {
+      const aliasCategory = this.createAliasCategoryElement(
+        regularAliases,
+        'aliases',
+        'Command Aliases',
+        'fas fa-mask'
+      )
+      categories.appendChild(aliasCategory)
+    }
+
+    // Add VFX aliases category if there are VERTIGO aliases
+    if (vertigoAliases.length > 0) {
+      const vertigoCategory = this.createAliasCategoryElement(
+        vertigoAliases,
+        'vertigo-aliases',
+        'VFX Aliases',
+        'fas fa-eye-slash'
+      )
+      categories.appendChild(vertigoCategory)
+    }
+  }
+
+  createAliasCategoryElement(
+    aliases,
+    categoryType = 'aliases',
+    title = 'Command Aliases',
+    iconClass = 'fas fa-mask'
+  ) {
+    const element = document.createElement('div')
+    element.className = 'category'
+    element.dataset.category = categoryType
+
+    // Check if category should be collapsed (similar to main command library)
+    const storageKey = `commandCategory_${categoryType}_collapsed`
+    const isCollapsed = localStorage.getItem(storageKey) === 'true'
+
+    // Choose appropriate icon and styling for different alias types
+    const isVertigo = categoryType === 'vertigo-aliases'
+    const itemIcon = isVertigo ? '👁️' : '🎭'
+    const itemClass = isVertigo
+      ? 'command-item vertigo-alias-item'
+      : 'command-item alias-item'
+
+    element.innerHTML = `
             <h4 class="${isCollapsed ? 'collapsed' : ''}" data-category="${categoryType}">
                 <i class="fas fa-chevron-right category-chevron"></i>
                 <i class="${iconClass}"></i> 
@@ -413,226 +472,245 @@ export default class STOAliasManager {
                 <span class="command-count">(${aliases.length})</span>
             </h4>
             <div class="category-commands ${isCollapsed ? 'collapsed' : ''}">
-                ${aliases.map(([name, alias]) => `
+                ${aliases
+                  .map(
+                    ([name, alias]) => `
                     <div class="${itemClass}" data-alias="${name}" title="${alias.description || alias.commands}">
                         ${itemIcon} ${name}
                     </div>
-                `).join('')}
+                `
+                  )
+                  .join('')}
             </div>
-        `;
-        
-        // Add click handler for category header
-        const header = element.querySelector('h4');
-        header.addEventListener('click', () => {
-            this.toggleAliasCategory(categoryType, element);
-        });
-        
-        // Add click handlers for aliases
-        element.addEventListener('click', (e) => {
-            if (e.target.classList.contains('alias-item') || e.target.classList.contains('vertigo-alias-item')) {
-                const aliasName = e.target.dataset.alias;
-                this.addAliasToKey(aliasName);
-            }
-        });
-        
-        return element;
+        `
+
+    // Add click handler for category header
+    const header = element.querySelector('h4')
+    header.addEventListener('click', () => {
+      this.toggleAliasCategory(categoryType, element)
+    })
+
+    // Add click handlers for aliases
+    element.addEventListener('click', (e) => {
+      if (
+        e.target.classList.contains('alias-item') ||
+        e.target.classList.contains('vertigo-alias-item')
+      ) {
+        const aliasName = e.target.dataset.alias
+        this.addAliasToKey(aliasName)
+      }
+    })
+
+    return element
+  }
+
+  toggleAliasCategory(categoryType, element) {
+    const header = element.querySelector('h4')
+    const commands = element.querySelector('.category-commands')
+    const chevron = header.querySelector('.category-chevron')
+
+    const isCollapsed = commands.classList.contains('collapsed')
+    const storageKey = `commandCategory_${categoryType}_collapsed`
+
+    if (isCollapsed) {
+      commands.classList.remove('collapsed')
+      header.classList.remove('collapsed')
+      chevron.style.transform = 'rotate(90deg)'
+      localStorage.setItem(storageKey, 'false')
+    } else {
+      commands.classList.add('collapsed')
+      header.classList.add('collapsed')
+      chevron.style.transform = 'rotate(0deg)'
+      localStorage.setItem(storageKey, 'true')
+    }
+  }
+
+  addAliasToKey(aliasName) {
+    if (!store.selectedKey) {
+      stoUI.showToast('Please select a key first', 'warning')
+      return
     }
 
-    toggleAliasCategory(categoryType, element) {
-        const header = element.querySelector('h4');
-        const commands = element.querySelector('.category-commands');
-        const chevron = header.querySelector('.category-chevron');
-        
-        const isCollapsed = commands.classList.contains('collapsed');
-        const storageKey = `commandCategory_${categoryType}_collapsed`;
-        
-        if (isCollapsed) {
-            commands.classList.remove('collapsed');
-            header.classList.remove('collapsed');
-            chevron.style.transform = 'rotate(90deg)';
-            localStorage.setItem(storageKey, 'false');
-        } else {
-            commands.classList.add('collapsed');
-            header.classList.add('collapsed');
-            chevron.style.transform = 'rotate(0deg)';
-            localStorage.setItem(storageKey, 'true');
+    const profile = app.getCurrentProfile()
+    const alias = profile.aliases[aliasName]
+
+    if (!alias) {
+      stoUI.showToast('Alias not found', 'error')
+      return
+    }
+
+    const command = {
+      command: aliasName,
+      type: 'alias',
+      icon: '🎭',
+      text: `Alias: ${aliasName}`,
+      description: alias.description,
+      id: app.generateCommandId(),
+    }
+
+    app.addCommand(store.selectedKey, command)
+  }
+
+  // Alias Templates
+  getAliasTemplates() {
+    return {
+      space_combat: {
+        name: 'Space Combat',
+        description: 'Aliases for space combat scenarios',
+        templates: {
+          AttackRun: {
+            name: 'AttackRun',
+            description: 'Full attack sequence with targeting',
+            commands:
+              'target_nearest_enemy $$ +STOTrayExecByTray 0 0 $$ +STOTrayExecByTray 0 1',
+          },
+          DefensiveMode: {
+            name: 'DefensiveMode',
+            description: 'Defensive abilities and shield management',
+            commands:
+              'target_self $$ +power_exec Distribute_Shields $$ +STOTrayExecByTray 2 0 $$ +STOTrayExecByTray 2 1',
+          },
+          HealSelf: {
+            name: 'HealSelf',
+            description: 'Self-healing sequence',
+            commands:
+              'target_self $$ +STOTrayExecByTray 3 0 $$ +STOTrayExecByTray 3 1',
+          },
+        },
+      },
+      ground_combat: {
+        name: 'Ground Combat',
+        description: 'Aliases for ground combat scenarios',
+        templates: {
+          GroundAttack: {
+            name: 'GroundAttack',
+            description: 'Basic ground combat sequence',
+            commands:
+              'target_nearest_enemy $$ +STOTrayExecByTray 0 0 $$ +STOTrayExecByTray 0 1',
+          },
+          GroundHeal: {
+            name: 'GroundHeal',
+            description: 'Ground healing sequence',
+            commands:
+              'target_self $$ +STOTrayExecByTray 1 0 $$ +STOTrayExecByTray 1 1',
+          },
+        },
+      },
+      communication: {
+        name: 'Communication',
+        description: 'Aliases for team communication',
+        templates: {
+          TeamReady: {
+            name: 'TeamReady',
+            description: 'Announce ready status to team',
+            commands: 'team Ready!',
+          },
+          NeedHealing: {
+            name: 'NeedHealing',
+            description: 'Request healing from team',
+            commands: 'team Need healing!',
+          },
+          Incoming: {
+            name: 'Incoming',
+            description: 'Warn team of incoming enemies',
+            commands: 'team Incoming enemies!',
+          },
+        },
+      },
+    }
+  }
+
+  createAliasFromTemplate(category, templateId) {
+    const templates = this.getAliasTemplates()
+    const template = templates[category]?.templates?.[templateId]
+
+    if (!template) {
+      stoUI.showToast('Template not found', 'error')
+      return
+    }
+
+    // Check if alias already exists
+    const profile = app.getCurrentProfile()
+    if (profile.aliases && profile.aliases[template.name]) {
+      stoUI.showToast(`Alias "${template.name}" already exists`, 'warning')
+      return
+    }
+
+    // Create alias
+    if (!profile.aliases) {
+      profile.aliases = {}
+    }
+
+    profile.aliases[template.name] = {
+      ...template,
+      created: new Date().toISOString(),
+      lastModified: new Date().toISOString(),
+    }
+
+    app.saveProfile()
+    app.setModified(true)
+
+    this.updateCommandLibrary()
+    this.renderAliasList()
+
+    stoUI.showToast(`Alias "${template.name}" created from template`, 'success')
+  }
+
+  // Utility Methods
+
+  getAliasUsage(aliasName) {
+    const profile = app.getCurrentProfile()
+    if (!profile) return []
+
+    const usage = []
+
+    // Check in keybinds
+    Object.entries(profile.keys).forEach(([key, commands]) => {
+      commands.forEach((command, index) => {
+        if (
+          command.command === aliasName ||
+          command.command.includes(aliasName)
+        ) {
+          usage.push({
+            type: 'keybind',
+            key: key,
+            position: index + 1,
+            context: `Key "${key}", command ${index + 1}`,
+          })
         }
-    }
+      })
+    })
 
-    addAliasToKey(aliasName) {
-        if (!store.selectedKey) {
-            stoUI.showToast('Please select a key first', 'warning');
-            return;
-        }
+    // Check in other aliases
+    Object.entries(profile.aliases || {}).forEach(([name, alias]) => {
+      if (name !== aliasName && alias.commands.includes(aliasName)) {
+        usage.push({
+          type: 'alias',
+          alias: name,
+          context: `Alias "${name}"`,
+        })
+      }
+    })
 
-        const profile = app.getCurrentProfile();
-        const alias = profile.aliases[aliasName];
-        
-        if (!alias) {
-            stoUI.showToast('Alias not found', 'error');
-            return;
-        }
+    return usage
+  }
 
-        const command = {
-            command: aliasName,
-            type: 'alias',
-            icon: '🎭',
-            text: `Alias: ${aliasName}`,
-            description: alias.description,
-            id: app.generateCommandId()
-        };
+  insertTargetVariable(textarea) {
+    const targetVar = '$Target'
+    const cursorPosition = textarea.selectionStart
+    const value = textarea.value
+    const newValue =
+      value.slice(0, cursorPosition) + targetVar + value.slice(cursorPosition)
+    textarea.value = newValue
+    textarea.setSelectionRange(
+      cursorPosition + targetVar.length,
+      cursorPosition + targetVar.length
+    )
+    textarea.focus()
 
-        app.addCommand(store.selectedKey, command);
-    }
-
-    // Alias Templates
-    getAliasTemplates() {
-        return {
-            space_combat: {
-                name: 'Space Combat',
-                description: 'Aliases for space combat scenarios',
-                templates: {
-                    'AttackRun': {
-                        name: 'AttackRun',
-                        description: 'Full attack sequence with targeting',
-                        commands: 'target_nearest_enemy $$ +STOTrayExecByTray 0 0 $$ +STOTrayExecByTray 0 1'
-                    },
-                    'DefensiveMode': {
-                        name: 'DefensiveMode',
-                        description: 'Defensive abilities and shield management',
-                        commands: 'target_self $$ +power_exec Distribute_Shields $$ +STOTrayExecByTray 2 0 $$ +STOTrayExecByTray 2 1'
-                    },
-                    'HealSelf': {
-                        name: 'HealSelf',
-                        description: 'Self-healing sequence',
-                        commands: 'target_self $$ +STOTrayExecByTray 3 0 $$ +STOTrayExecByTray 3 1'
-                    }
-                }
-            },
-            ground_combat: {
-                name: 'Ground Combat',
-                description: 'Aliases for ground combat scenarios',
-                templates: {
-                    'GroundAttack': {
-                        name: 'GroundAttack',
-                        description: 'Basic ground combat sequence',
-                        commands: 'target_nearest_enemy $$ +STOTrayExecByTray 0 0 $$ +STOTrayExecByTray 0 1'
-                    },
-                    'GroundHeal': {
-                        name: 'GroundHeal',
-                        description: 'Ground healing sequence',
-                        commands: 'target_self $$ +STOTrayExecByTray 1 0 $$ +STOTrayExecByTray 1 1'
-                    }
-                }
-            },
-            communication: {
-                name: 'Communication',
-                description: 'Aliases for team communication',
-                templates: {
-                    'TeamReady': {
-                        name: 'TeamReady',
-                        description: 'Announce ready status to team',
-                        commands: 'team Ready!'
-                    },
-                    'NeedHealing': {
-                        name: 'NeedHealing',
-                        description: 'Request healing from team',
-                        commands: 'team Need healing!'
-                    },
-                    'Incoming': {
-                        name: 'Incoming',
-                        description: 'Warn team of incoming enemies',
-                        commands: 'team Incoming enemies!'
-                    }
-                }
-            }
-        };
-    }
-
-    createAliasFromTemplate(category, templateId) {
-        const templates = this.getAliasTemplates();
-        const template = templates[category]?.templates?.[templateId];
-        
-        if (!template) {
-            stoUI.showToast('Template not found', 'error');
-            return;
-        }
-
-        // Check if alias already exists
-        const profile = app.getCurrentProfile();
-        if (profile.aliases && profile.aliases[template.name]) {
-            stoUI.showToast(`Alias "${template.name}" already exists`, 'warning');
-            return;
-        }
-
-        // Create alias
-        if (!profile.aliases) {
-            profile.aliases = {};
-        }
-
-        profile.aliases[template.name] = {
-            ...template,
-            created: new Date().toISOString(),
-            lastModified: new Date().toISOString()
-        };
-
-        app.saveProfile();
-        app.setModified(true);
-        
-        this.updateCommandLibrary();
-        this.renderAliasList();
-        
-        stoUI.showToast(`Alias "${template.name}" created from template`, 'success');
-    }
-
-    // Utility Methods
-
-    getAliasUsage(aliasName) {
-        const profile = app.getCurrentProfile();
-        if (!profile) return [];
-
-        const usage = [];
-        
-        // Check in keybinds
-        Object.entries(profile.keys).forEach(([key, commands]) => {
-            commands.forEach((command, index) => {
-                if (command.command === aliasName || command.command.includes(aliasName)) {
-                    usage.push({
-                        type: 'keybind',
-                        key: key,
-                        position: index + 1,
-                        context: `Key "${key}", command ${index + 1}`
-                    });
-                }
-            });
-        });
-
-        // Check in other aliases
-        Object.entries(profile.aliases || {}).forEach(([name, alias]) => {
-            if (name !== aliasName && alias.commands.includes(aliasName)) {
-                usage.push({
-                    type: 'alias',
-                    alias: name,
-                    context: `Alias "${name}"`
-                });
-            }
-        });
-
-        return usage;
-    }
-
-    insertTargetVariable(textarea) {
-        const targetVar = '$Target';
-        const cursorPosition = textarea.selectionStart;
-        const value = textarea.value;
-        const newValue = value.slice(0, cursorPosition) + targetVar + value.slice(cursorPosition);
-        textarea.value = newValue;
-        textarea.setSelectionRange(cursorPosition + targetVar.length, cursorPosition + targetVar.length);
-        textarea.focus();
-        
-        // Trigger input event to update preview
-        textarea.dispatchEvent(new Event('input', { bubbles: true }));
-    }
+    // Trigger input event to update preview
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  }
 }
 
 // Global alias manager instance

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -4,663 +4,739 @@ import store from './store.js'
 import eventBus from './eventBus.js'
 
 export default class STOToolsKeybindManager {
-    constructor() {
-        this.store = store;
-        this.eventListeners = new Map();
-        
-        // Initialize when DOM is ready
-        if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', () => this.init());
-        } else {
-            this.init();
-        }
+  constructor() {
+    this.store = store
+    this.eventListeners = new Map()
+
+    // Initialize when DOM is ready
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', () => this.init())
+    } else {
+      this.init()
+    }
+  }
+
+  get currentProfile() {
+    return this.store.currentProfile
+  }
+  set currentProfile(val) {
+    this.store.currentProfile = val
+  }
+
+  get currentMode() {
+    return this.store.currentMode
+  }
+  set currentMode(val) {
+    this.store.currentMode = val
+  }
+
+  get currentEnvironment() {
+    return this.store.currentEnvironment
+  }
+  set currentEnvironment(val) {
+    this.store.currentEnvironment = val
+  }
+
+  get selectedKey() {
+    return this.store.selectedKey
+  }
+  set selectedKey(val) {
+    this.store.selectedKey = val
+  }
+
+  get isModified() {
+    return this.store.isModified
+  }
+  set isModified(val) {
+    this.store.isModified = val
+  }
+
+  get undoStack() {
+    return this.store.undoStack
+  }
+  set undoStack(val) {
+    this.store.undoStack = val
+  }
+
+  get redoStack() {
+    return this.store.redoStack
+  }
+  set redoStack(val) {
+    this.store.redoStack = val
+  }
+
+  get maxUndoSteps() {
+    return this.store.maxUndoSteps
+  }
+  set maxUndoSteps(val) {
+    this.store.maxUndoSteps = val
+  }
+
+  get commandIdCounter() {
+    return this.store.commandIdCounter
+  }
+  set commandIdCounter(val) {
+    this.store.commandIdCounter = val
+  }
+
+  async init() {
+    try {
+      // Check if required dependencies are available
+      if (typeof stoStorage === 'undefined' || typeof stoUI === 'undefined') {
+        throw new Error('Required dependencies not loaded')
+      }
+
+      // Load data from storage
+      await this.loadData()
+
+      // Apply saved theme
+      this.applyTheme()
+
+      // Setup UI components
+      this.setupEventListeners()
+      this.setupCommandLibrary()
+      this.setupDragAndDrop()
+
+      // Render initial state
+      this.renderProfiles()
+      this.renderKeyGrid()
+      this.renderCommandChain()
+
+      // Update theme toggle button to reflect current theme
+      const settings = stoStorage.getSettings()
+      this.updateThemeToggleButton(settings.theme || 'default')
+
+      // Show welcome message for new users
+      if (this.isFirstTime()) {
+        this.showWelcomeMessage()
+      }
+
+      stoUI.showToast(
+        'STO Tools Keybind Manager loaded successfully',
+        'success'
+      )
+
+      // Dispatch app ready event through eventBus
+      eventBus.emit('sto-app-ready', { app: this })
+    } catch (error) {
+      console.error('Failed to initialize application:', error)
+      if (typeof stoUI !== 'undefined' && stoUI.showToast) {
+        stoUI.showToast('Failed to load application', 'error')
+      }
+
+      // Dispatch error event through eventBus
+      eventBus.emit('sto-app-error', { error })
+    }
+  }
+
+  // Data Management
+  async loadData() {
+    const data = stoStorage.getAllData()
+    this.currentProfile = data.currentProfile
+
+    // Load current environment from profile or default to space
+    const profileData = data.profiles[this.currentProfile]
+    if (profileData) {
+      this.currentEnvironment = profileData.currentEnvironment || 'space'
+    } else {
+      this.currentEnvironment = 'space'
     }
 
-    get currentProfile() { return this.store.currentProfile }
-    set currentProfile(val) { this.store.currentProfile = val }
+    // Validate current profile exists
+    if (!data.profiles[this.currentProfile]) {
+      this.currentProfile = Object.keys(data.profiles)[0]
+      this.saveCurrentProfile()
+    }
+  }
 
-    get currentMode() { return this.store.currentMode }
-    set currentMode(val) { this.store.currentMode = val }
+  saveData() {
+    const data = stoStorage.getAllData()
+    data.currentProfile = this.currentProfile
+    data.lastModified = new Date().toISOString()
 
-    get currentEnvironment() { return this.store.currentEnvironment }
-    set currentEnvironment(val) { this.store.currentEnvironment = val }
+    if (stoStorage.saveAllData(data)) {
+      this.setModified(false)
+      return true
+    }
+    return false
+  }
 
-    get selectedKey() { return this.store.selectedKey }
-    set selectedKey(val) { this.store.selectedKey = val }
+  saveCurrentProfile() {
+    const data = stoStorage.getAllData()
+    data.currentProfile = this.currentProfile
+    return stoStorage.saveAllData(data)
+  }
 
-    get isModified() { return this.store.isModified }
-    set isModified(val) { this.store.isModified = val }
+  setModified(modified = true) {
+    this.isModified = modified
+    const indicator = document.getElementById('modifiedIndicator')
+    if (indicator) {
+      indicator.style.display = modified ? 'inline' : 'none'
+    }
+  }
 
-    get undoStack() { return this.store.undoStack }
-    set undoStack(val) { this.store.undoStack = val }
+  // Profile Management
+  getCurrentProfile() {
+    const profile = stoStorage.getProfile(this.currentProfile)
+    if (!profile) return null
 
-    get redoStack() { return this.store.redoStack }
-    set redoStack(val) { this.store.redoStack = val }
+    // Return current environment build data
+    return this.getCurrentBuild(profile)
+  }
 
-    get maxUndoSteps() { return this.store.maxUndoSteps }
-    set maxUndoSteps(val) { this.store.maxUndoSteps = val }
+  getCurrentBuild(profile) {
+    if (!profile) return null
 
-    get commandIdCounter() { return this.store.commandIdCounter }
-    set commandIdCounter(val) { this.store.commandIdCounter = val }
+    // Convert old profile format to new format if needed
+    if (!profile.builds) {
+      profile.builds = {
+        space: {
+          keys: profile.keys || {},
+        },
+        ground: {
+          keys: {},
+        },
+      }
+      profile.currentEnvironment = profile.mode || 'space'
+      delete profile.mode // Remove old mode property
+      delete profile.keys // Move to builds
+      // Keep profile.aliases at profile level - don't move to builds
 
-    async init() {
-        try {
-            // Check if required dependencies are available
-            if (typeof stoStorage === 'undefined' || typeof stoUI === 'undefined') {
-                throw new Error('Required dependencies not loaded');
-            }
-            
-            // Load data from storage
-            await this.loadData();
-            
-            // Apply saved theme
-            this.applyTheme();
-            
-            // Setup UI components
-            this.setupEventListeners();
-            this.setupCommandLibrary();
-            this.setupDragAndDrop();
-            
-            // Render initial state
-            this.renderProfiles();
-            this.renderKeyGrid();
-            this.renderCommandChain();
-            
-            // Update theme toggle button to reflect current theme
-            const settings = stoStorage.getSettings();
-            this.updateThemeToggleButton(settings.theme || 'default');
-            
-            // Show welcome message for new users
-            if (this.isFirstTime()) {
-                this.showWelcomeMessage();
-            }
-            
-            stoUI.showToast('STO Tools Keybind Manager loaded successfully', 'success');
-            
-            // Dispatch app ready event through eventBus
-            eventBus.emit('sto-app-ready', { app: this });
-            
-        } catch (error) {
-            console.error('Failed to initialize application:', error);
-            if (typeof stoUI !== 'undefined' && stoUI.showToast) {
-                stoUI.showToast('Failed to load application', 'error');
-            }
-            
-            // Dispatch error event through eventBus
-            eventBus.emit('sto-app-error', { error });
-        }
+      // Save the converted profile
+      stoStorage.saveProfile(this.currentProfile, profile)
     }
 
-    // Data Management
-    async loadData() {
-        const data = stoStorage.getAllData();
-        this.currentProfile = data.currentProfile;
-        
-        // Load current environment from profile or default to space
-        const profileData = data.profiles[this.currentProfile];
-        if (profileData) {
-            this.currentEnvironment = profileData.currentEnvironment || 'space';
-        } else {
-            this.currentEnvironment = 'space';
-        }
-        
-        // Validate current profile exists
-        if (!data.profiles[this.currentProfile]) {
-            this.currentProfile = Object.keys(data.profiles)[0];
-            this.saveCurrentProfile();
-        }
+    // Ensure builds exist
+    if (!profile.builds) {
+      profile.builds = {
+        space: { keys: {} },
+        ground: { keys: {} },
+      }
     }
 
-    saveData() {
-        const data = stoStorage.getAllData();
-        data.currentProfile = this.currentProfile;
-        data.lastModified = new Date().toISOString();
-        
-        if (stoStorage.saveAllData(data)) {
-            this.setModified(false);
-            return true;
-        }
-        return false;
+    if (!profile.builds[this.currentEnvironment]) {
+      profile.builds[this.currentEnvironment] = { keys: {} }
     }
 
-    saveCurrentProfile() {
-        const data = stoStorage.getAllData();
-        data.currentProfile = this.currentProfile;
-        return stoStorage.saveAllData(data);
+    // Ensure the build keys object exists
+    if (!profile.builds[this.currentEnvironment].keys) {
+      profile.builds[this.currentEnvironment].keys = {}
     }
 
-    setModified(modified = true) {
-        this.isModified = modified;
-        const indicator = document.getElementById('modifiedIndicator');
-        if (indicator) {
-            indicator.style.display = modified ? 'inline' : 'none';
-        }
+    // Return a profile-like object with current build data
+    // Keys are build-specific, but aliases are profile-wide
+    // IMPORTANT: keys must be a direct reference, not a copy
+    return {
+      ...profile,
+      keys: profile.builds[this.currentEnvironment].keys, // Direct reference to build keys
+      aliases: profile.aliases || {}, // Profile-level aliases, not build-specific
+      mode: this.currentEnvironment, // For backward compatibility
+    }
+  }
+
+  switchProfile(profileId) {
+    if (profileId !== this.currentProfile) {
+      this.currentProfile = profileId
+      this.selectedKey = null
+
+      const profile = stoStorage.getProfile(profileId)
+      if (profile) {
+        this.currentEnvironment = profile.currentEnvironment || 'space'
+      }
+
+      this.saveCurrentProfile()
+      this.renderKeyGrid()
+      this.renderCommandChain()
+      this.updateProfileInfo()
+
+      const currentBuild = this.getCurrentProfile()
+      stoUI.showToast(
+        `Switched to profile: ${currentBuild.name} (${this.currentEnvironment})`,
+        'success'
+      )
+    }
+  }
+
+  createProfile(name, description = '', mode = 'space') {
+    const profileId = this.generateProfileId(name)
+    const profile = {
+      name,
+      description,
+      mode,
+      keys: {},
+      aliases: {},
+      created: new Date().toISOString(),
+      lastModified: new Date().toISOString(),
     }
 
-    // Profile Management
-    getCurrentProfile() {
-        const profile = stoStorage.getProfile(this.currentProfile);
-        if (!profile) return null;
-        
-        // Return current environment build data
-        return this.getCurrentBuild(profile);
+    if (stoStorage.saveProfile(profileId, profile)) {
+      this.switchProfile(profileId)
+      this.renderProfiles()
+      stoUI.showToast(`Profile "${name}" created`, 'success')
+      return profileId
     }
 
-    getCurrentBuild(profile) {
-        if (!profile) return null;
-        
-        // Convert old profile format to new format if needed
-        if (!profile.builds) {
-            profile.builds = {
-                space: {
-                    keys: profile.keys || {}
-                },
-                ground: {
-                    keys: {}
-                }
-            };
-            profile.currentEnvironment = profile.mode || 'space';
-            delete profile.mode; // Remove old mode property
-            delete profile.keys; // Move to builds
-            // Keep profile.aliases at profile level - don't move to builds
-            
-            // Save the converted profile
-            stoStorage.saveProfile(this.currentProfile, profile);
-        }
-        
-                // Ensure builds exist
-        if (!profile.builds) {
-            profile.builds = {
-                space: { keys: {} },
-                ground: { keys: {} }
-            };
-        }
+    stoUI.showToast('Failed to create profile', 'error')
+    return null
+  }
 
-        if (!profile.builds[this.currentEnvironment]) {
-            profile.builds[this.currentEnvironment] = { keys: {} };
-        }
-        
-        // Ensure the build keys object exists
-        if (!profile.builds[this.currentEnvironment].keys) {
-            profile.builds[this.currentEnvironment].keys = {};
-        }
-        
-        // Return a profile-like object with current build data
-        // Keys are build-specific, but aliases are profile-wide
-        // IMPORTANT: keys must be a direct reference, not a copy
-        return {
-            ...profile,
-            keys: profile.builds[this.currentEnvironment].keys, // Direct reference to build keys
-            aliases: profile.aliases || {}, // Profile-level aliases, not build-specific
-            mode: this.currentEnvironment // For backward compatibility
-        };
+  cloneProfile(sourceProfileId, newName) {
+    const sourceProfile = stoStorage.getProfile(sourceProfileId)
+    if (!sourceProfile) return null
+
+    const profileId = this.generateProfileId(newName)
+    const clonedProfile = {
+      ...JSON.parse(JSON.stringify(sourceProfile)), // Deep clone
+      name: newName,
+      description: `Copy of ${sourceProfile.name}`,
+      created: new Date().toISOString(),
+      lastModified: new Date().toISOString(),
     }
 
-    switchProfile(profileId) {
-        if (profileId !== this.currentProfile) {
-            this.currentProfile = profileId;
-            this.selectedKey = null;
-            
-            const profile = stoStorage.getProfile(profileId);
-            if (profile) {
-                this.currentEnvironment = profile.currentEnvironment || 'space';
-            }
-            
-            this.saveCurrentProfile();
-            this.renderKeyGrid();
-            this.renderCommandChain();
-            this.updateProfileInfo();
-            
-            const currentBuild = this.getCurrentProfile();
-            stoUI.showToast(`Switched to profile: ${currentBuild.name} (${this.currentEnvironment})`, 'success');
-        }
+    if (stoStorage.saveProfile(profileId, clonedProfile)) {
+      this.renderProfiles()
+      stoUI.showToast(
+        `Profile "${newName}" created from "${sourceProfile.name}"`,
+        'success'
+      )
+      return profileId
     }
 
-    createProfile(name, description = '', mode = 'space') {
-        const profileId = this.generateProfileId(name);
-        const profile = {
-            name,
-            description,
-            mode,
-            keys: {},
-            aliases: {},
-            created: new Date().toISOString(),
-            lastModified: new Date().toISOString()
-        };
-        
-        if (stoStorage.saveProfile(profileId, profile)) {
-            this.switchProfile(profileId);
-            this.renderProfiles();
-            stoUI.showToast(`Profile "${name}" created`, 'success');
-            return profileId;
-        }
-        
-        stoUI.showToast('Failed to create profile', 'error');
-        return null;
+    stoUI.showToast('Failed to clone profile', 'error')
+    return null
+  }
+
+  deleteProfile(profileId) {
+    const profile = stoStorage.getProfile(profileId)
+    if (!profile) return false
+
+    const data = stoStorage.getAllData()
+    const profileCount = Object.keys(data.profiles).length
+
+    if (profileCount <= 1) {
+      stoUI.showToast('Cannot delete the last profile', 'warning')
+      return false
     }
 
-    cloneProfile(sourceProfileId, newName) {
-        const sourceProfile = stoStorage.getProfile(sourceProfileId);
-        if (!sourceProfile) return null;
-        
-        const profileId = this.generateProfileId(newName);
-        const clonedProfile = {
-            ...JSON.parse(JSON.stringify(sourceProfile)), // Deep clone
-            name: newName,
-            description: `Copy of ${sourceProfile.name}`,
-            created: new Date().toISOString(),
-            lastModified: new Date().toISOString()
-        };
-        
-        if (stoStorage.saveProfile(profileId, clonedProfile)) {
-            this.renderProfiles();
-            stoUI.showToast(`Profile "${newName}" created from "${sourceProfile.name}"`, 'success');
-            return profileId;
-        }
-        
-        stoUI.showToast('Failed to clone profile', 'error');
-        return null;
+    if (stoStorage.deleteProfile(profileId)) {
+      if (this.currentProfile === profileId) {
+        // Switch to first available profile
+        const remainingProfiles = Object.keys(stoStorage.getAllData().profiles)
+        this.switchProfile(remainingProfiles[0])
+      }
+
+      this.renderProfiles()
+      stoUI.showToast(`Profile "${profile.name}" deleted`, 'success')
+      return true
     }
 
-    deleteProfile(profileId) {
-        const profile = stoStorage.getProfile(profileId);
-        if (!profile) return false;
-        
-        const data = stoStorage.getAllData();
-        const profileCount = Object.keys(data.profiles).length;
-        
-        if (profileCount <= 1) {
-            stoUI.showToast('Cannot delete the last profile', 'warning');
-            return false;
-        }
-        
-        if (stoStorage.deleteProfile(profileId)) {
-            if (this.currentProfile === profileId) {
-                // Switch to first available profile
-                const remainingProfiles = Object.keys(stoStorage.getAllData().profiles);
-                this.switchProfile(remainingProfiles[0]);
-            }
-            
-            this.renderProfiles();
-            stoUI.showToast(`Profile "${profile.name}" deleted`, 'success');
-            return true;
-        }
-        
-        stoUI.showToast('Failed to delete profile', 'error');
-        return false;
+    stoUI.showToast('Failed to delete profile', 'error')
+    return false
+  }
+
+  generateProfileId(name) {
+    const base = name.toLowerCase().replace(/[^a-z0-9]/g, '_')
+    let id = base
+    let counter = 1
+
+    const data = stoStorage.getAllData()
+    while (data.profiles[id]) {
+      id = `${base}_${counter}`
+      counter++
     }
 
-    generateProfileId(name) {
-        const base = name.toLowerCase().replace(/[^a-z0-9]/g, '_');
-        let id = base;
-        let counter = 1;
-        
-        const data = stoStorage.getAllData();
-        while (data.profiles[id]) {
-            id = `${base}_${counter}`;
-            counter++;
-        }
-        
-        return id;
+    return id
+  }
+
+  // Key Management
+  selectKey(keyName) {
+    this.selectedKey = keyName
+
+    // Update stabilize checkbox based on keybind metadata (environment-scoped)
+    const profile = this.getCurrentProfile()
+    const stabilizeCheckbox = document.getElementById('stabilizeExecutionOrder')
+    if (stabilizeCheckbox && profile && profile.keybindMetadata) {
+      let flag = false
+      if (profile.keybindMetadata[this.currentEnvironment]) {
+        const envMeta = profile.keybindMetadata[this.currentEnvironment]
+        flag = !!(envMeta[keyName] && envMeta[keyName].stabilizeExecutionOrder)
+      }
+      // Legacy fallback (flat structure)
+      if (!flag && profile.keybindMetadata[keyName]) {
+        flag = !!profile.keybindMetadata[keyName].stabilizeExecutionOrder
+      }
+      stabilizeCheckbox.checked = flag
+    } else if (stabilizeCheckbox) {
+      stabilizeCheckbox.checked = false
     }
 
-    // Key Management
-    selectKey(keyName) {
-        this.selectedKey = keyName;
-        
-        // Update stabilize checkbox based on keybind metadata (environment-scoped)
-        const profile = this.getCurrentProfile();
-        const stabilizeCheckbox = document.getElementById('stabilizeExecutionOrder');
-        if (stabilizeCheckbox && profile && profile.keybindMetadata) {
-            let flag = false;
-            if (profile.keybindMetadata[this.currentEnvironment]) {
-                const envMeta = profile.keybindMetadata[this.currentEnvironment];
-                flag = !!(envMeta[keyName] && envMeta[keyName].stabilizeExecutionOrder);
-            }
-            // Legacy fallback (flat structure)
-            if (!flag && profile.keybindMetadata[keyName]) {
-                flag = !!profile.keybindMetadata[keyName].stabilizeExecutionOrder;
-            }
-            stabilizeCheckbox.checked = flag;
-        } else if (stabilizeCheckbox) {
-            stabilizeCheckbox.checked = false;
-        }
-        
-        this.renderKeyGrid();
-        this.renderCommandChain();
-        this.updateChainActions();
+    this.renderKeyGrid()
+    this.renderCommandChain()
+    this.updateChainActions()
+  }
+
+  addKey(keyName) {
+    if (!this.isValidKeyName(keyName)) {
+      stoUI.showToast('Invalid key name', 'error')
+      return false
     }
 
-    addKey(keyName) {
-        if (!this.isValidKeyName(keyName)) {
-            stoUI.showToast('Invalid key name', 'error');
-            return false;
-        }
-        
-        const profile = this.getCurrentProfile();
-        
-        if (!profile.keys[keyName]) {
-            profile.keys[keyName] = [];
-            stoStorage.saveProfile(this.currentProfile, profile);
-            this.renderKeyGrid();
-            this.selectKey(keyName);
-            this.setModified(true);
-            
-            stoUI.showToast(`Key "${keyName}" added`, 'success');
-            return true;
-        } else {
-            stoUI.showToast(`Key "${keyName}" already exists`, 'warning');
-            return false;
-        }
+    const profile = this.getCurrentProfile()
+
+    if (!profile.keys[keyName]) {
+      profile.keys[keyName] = []
+      stoStorage.saveProfile(this.currentProfile, profile)
+      this.renderKeyGrid()
+      this.selectKey(keyName)
+      this.setModified(true)
+
+      stoUI.showToast(`Key "${keyName}" added`, 'success')
+      return true
+    } else {
+      stoUI.showToast(`Key "${keyName}" already exists`, 'warning')
+      return false
+    }
+  }
+
+  deleteKey(keyName) {
+    const profile = this.getCurrentProfile()
+    if (profile.keys[keyName]) {
+      delete profile.keys[keyName]
+      stoStorage.saveProfile(this.currentProfile, profile)
+
+      if (this.selectedKey === keyName) {
+        this.selectedKey = null
+      }
+
+      this.renderKeyGrid()
+      this.renderCommandChain()
+      this.setModified(true)
+
+      stoUI.showToast(`Key "${keyName}" deleted`, 'success')
+      return true
     }
 
-    deleteKey(keyName) {
-        const profile = this.getCurrentProfile();
-        if (profile.keys[keyName]) {
-            delete profile.keys[keyName];
-            stoStorage.saveProfile(this.currentProfile, profile);
-            
-            if (this.selectedKey === keyName) {
-                this.selectedKey = null;
-            }
-            
-            this.renderKeyGrid();
-            this.renderCommandChain();
-            this.setModified(true);
-            
-            stoUI.showToast(`Key "${keyName}" deleted`, 'success');
-            return true;
+    return false
+  }
+
+  isValidKeyName(keyName) {
+    return (
+      STO_DATA.validation.keyNamePattern.test(keyName) && keyName.length <= 20
+    )
+  }
+
+  // Command Management
+  addCommand(keyName, command) {
+    const profile = this.getCurrentProfile()
+    if (!profile.keys[keyName]) {
+      profile.keys[keyName] = []
+    }
+
+    // Handle both single commands and arrays of commands (for tray ranges)
+    if (Array.isArray(command)) {
+      // Array of commands - add each one with unique ID if not already present
+      command.forEach((cmd) => {
+        if (!cmd.id) {
+          cmd.id = this.generateCommandId()
         }
-        
-        return false;
+        profile.keys[keyName].push(cmd)
+      })
+      stoUI.showToast(`${command.length} commands added`, 'success')
+    } else {
+      // Single command
+      if (!command.id) {
+        command.id = this.generateCommandId()
+      }
+      profile.keys[keyName].push(command)
+      stoUI.showToast('Command added', 'success')
     }
 
-    isValidKeyName(keyName) {
-        return STO_DATA.validation.keyNamePattern.test(keyName) && keyName.length <= 20;
-    }
+    stoStorage.saveProfile(this.currentProfile, profile)
+    this.renderCommandChain()
+    this.renderKeyGrid()
+    this.setModified(true)
+  }
 
-    // Command Management
-    addCommand(keyName, command) {
-        const profile = this.getCurrentProfile();
-        if (!profile.keys[keyName]) {
-            profile.keys[keyName] = [];
+  deleteCommand(keyName, commandIndex) {
+    const profile = this.getCurrentProfile()
+    if (profile.keys[keyName] && profile.keys[keyName][commandIndex]) {
+      profile.keys[keyName].splice(commandIndex, 1)
+      stoStorage.saveProfile(this.currentProfile, profile)
+      this.renderCommandChain()
+      this.renderKeyGrid()
+      this.setModified(true)
+
+      stoUI.showToast('Command deleted', 'success')
+    }
+  }
+
+  moveCommand(keyName, fromIndex, toIndex) {
+    const profile = this.getCurrentProfile()
+    const commands = profile.keys[keyName]
+
+    if (
+      commands &&
+      fromIndex >= 0 &&
+      fromIndex < commands.length &&
+      toIndex >= 0 &&
+      toIndex < commands.length
+    ) {
+      const [command] = commands.splice(fromIndex, 1)
+      commands.splice(toIndex, 0, command)
+
+      stoStorage.saveProfile(this.currentProfile, profile)
+      this.renderCommandChain()
+      this.setModified(true)
+    }
+  }
+
+  generateCommandId() {
+    return 'cmd_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9)
+  }
+
+  // Rendering Methods
+  renderProfiles() {
+    const select = document.getElementById('profileSelect')
+    if (!select) return
+
+    const data = stoStorage.getAllData()
+    select.innerHTML = ''
+
+    if (Object.keys(data.profiles).length === 0) {
+      // No profiles available
+      const option = document.createElement('option')
+      option.value = ''
+      option.textContent = 'No profiles available'
+      option.disabled = true
+      select.appendChild(option)
+    } else {
+      Object.entries(data.profiles).forEach(([id, profile]) => {
+        const option = document.createElement('option')
+        option.value = id
+        option.textContent = profile.name
+        if (id === this.currentProfile) {
+          option.selected = true
         }
-        
-        // Handle both single commands and arrays of commands (for tray ranges)
-        if (Array.isArray(command)) {
-            // Array of commands - add each one with unique ID if not already present
-            command.forEach(cmd => {
-                if (!cmd.id) {
-                    cmd.id = this.generateCommandId();
-                }
-                profile.keys[keyName].push(cmd);
-            });
-            stoUI.showToast(`${command.length} commands added`, 'success');
-        } else {
-            // Single command
-            if (!command.id) {
-                command.id = this.generateCommandId();
-            }
-            profile.keys[keyName].push(command);
-            stoUI.showToast('Command added', 'success');
-        }
-        
-        stoStorage.saveProfile(this.currentProfile, profile);
-        this.renderCommandChain();
-        this.renderKeyGrid();
-        this.setModified(true);
+        select.appendChild(option)
+      })
     }
 
-    deleteCommand(keyName, commandIndex) {
-        const profile = this.getCurrentProfile();
-        if (profile.keys[keyName] && profile.keys[keyName][commandIndex]) {
-            profile.keys[keyName].splice(commandIndex, 1);
-            stoStorage.saveProfile(this.currentProfile, profile);
-            this.renderCommandChain();
-            this.renderKeyGrid();
-            this.setModified(true);
-            
-            stoUI.showToast('Command deleted', 'success');
-        }
-    }
+    this.updateProfileInfo()
+  }
 
-    moveCommand(keyName, fromIndex, toIndex) {
-        const profile = this.getCurrentProfile();
-        const commands = profile.keys[keyName];
-        
-        if (commands && fromIndex >= 0 && fromIndex < commands.length && 
-            toIndex >= 0 && toIndex < commands.length) {
-            
-            const [command] = commands.splice(fromIndex, 1);
-            commands.splice(toIndex, 0, command);
-            
-            stoStorage.saveProfile(this.currentProfile, profile);
-            this.renderCommandChain();
-            this.setModified(true);
-        }
-    }
+  updateProfileInfo() {
+    const profile = this.getCurrentProfile()
 
-    generateCommandId() {
-        return 'cmd_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
-    }
+    // Update mode buttons
+    const modeBtns = document.querySelectorAll('.mode-btn')
+    modeBtns.forEach((btn) => {
+      btn.classList.toggle(
+        'active',
+        profile && btn.dataset.mode === this.currentEnvironment
+      )
+      btn.disabled = !profile
+    })
 
-    // Rendering Methods
-    renderProfiles() {
-        const select = document.getElementById('profileSelect');
-        if (!select) return;
-        
-        const data = stoStorage.getAllData();
-        select.innerHTML = '';
-        
-        if (Object.keys(data.profiles).length === 0) {
-            // No profiles available
-            const option = document.createElement('option');
-            option.value = '';
-            option.textContent = 'No profiles available';
-            option.disabled = true;
-            select.appendChild(option);
-        } else {
-            Object.entries(data.profiles).forEach(([id, profile]) => {
-                const option = document.createElement('option');
-                option.value = id;
-                option.textContent = profile.name;
-                if (id === this.currentProfile) {
-                    option.selected = true;
-                }
-                select.appendChild(option);
-            });
-        }
-        
-        this.updateProfileInfo();
+    // Update key count
+    const keyCount = document.getElementById('keyCount')
+    if (keyCount) {
+      if (profile) {
+        const count = Object.keys(profile.keys).length
+        keyCount.textContent = `${count} key${count !== 1 ? 's' : ''}`
+      } else {
+        keyCount.textContent = 'No profile'
+      }
     }
+  }
 
-    updateProfileInfo() {
-        const profile = this.getCurrentProfile();
-        
-        // Update mode buttons
-        const modeBtns = document.querySelectorAll('.mode-btn');
-        modeBtns.forEach(btn => {
-            btn.classList.toggle('active', profile && btn.dataset.mode === this.currentEnvironment);
-            btn.disabled = !profile;
-        });
-        
-        // Update key count
-        const keyCount = document.getElementById('keyCount');
-        if (keyCount) {
-            if (profile) {
-                const count = Object.keys(profile.keys).length;
-                keyCount.textContent = `${count} key${count !== 1 ? 's' : ''}`;
-            } else {
-                keyCount.textContent = 'No profile';
-            }
-        }
-    }
+  renderKeyGrid() {
+    const grid = document.getElementById('keyGrid')
+    if (!grid) return
 
-    renderKeyGrid() {
-        const grid = document.getElementById('keyGrid');
-        if (!grid) return;
-        
-        const profile = this.getCurrentProfile();
-        if (!profile) return;
-        
-        grid.innerHTML = '';
-        
-        if (!profile) {
-            // Show empty state when no profile is available
-            grid.innerHTML = `
+    const profile = this.getCurrentProfile()
+    if (!profile) return
+
+    grid.innerHTML = ''
+
+    if (!profile) {
+      // Show empty state when no profile is available
+      grid.innerHTML = `
                 <div class="empty-state">
                     <i class="fas fa-folder-open"></i>
                     <h4>No Profile Selected</h4>
                     <p>Create a new profile or load default data to get started.</p>
                 </div>
-            `;
-            return;
-        }
-        
-        // Get all keys for this profile
-        const keys = Object.keys(profile.keys);
-        // console.log('renderKeyGrid: Profile keys:', keys);
-        // console.log('renderKeyGrid: Profile keys count:', keys.length);
-        
-        // Add common keys that might not have commands yet
-        const commonKeys = ['Space', '1', '2', '3', '4', '5', 'F1', 'F2', 'F3', 'F4'];
-        const allKeys = [...new Set([...keys, ...commonKeys])].sort();
-        // console.log('renderKeyGrid: All keys to render:', allKeys);
-        
-        // Check view preference
-        const viewMode = localStorage.getItem('keyViewMode') || 'key-types';
-        
-        if (viewMode === 'categorized') {
-            this.renderCategorizedKeyView(grid, profile, allKeys);
-        } else if (viewMode === 'key-types') {
-            this.renderKeyTypeView(grid, profile, allKeys);
-        } else {
-            this.renderSimpleKeyGrid(grid, allKeys);
-        }
-        
-        // Update toggle button icon
-        this.updateViewToggleButton(viewMode);
-        
-        // Reapply any existing filter after rendering the new view
-        const filterInput = document.getElementById('keyFilter');
-        if (filterInput && filterInput.value.trim()) {
-            this.filterKeys(filterInput.value.trim());
-        }
+            `
+      return
     }
 
-    renderSimpleKeyGrid(grid, allKeys) {
-        // Remove categorized class to use normal grid layout
-        grid.classList.remove('categorized');
-        
-        allKeys.forEach(keyName => {
-            const keyElement = this.createKeyElement(keyName);
-            grid.appendChild(keyElement);
-        });
+    // Get all keys for this profile
+    const keys = Object.keys(profile.keys)
+    // console.log('renderKeyGrid: Profile keys:', keys);
+    // console.log('renderKeyGrid: Profile keys count:', keys.length);
+
+    // Add common keys that might not have commands yet
+    const commonKeys = [
+      'Space',
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      'F1',
+      'F2',
+      'F3',
+      'F4',
+    ]
+    const allKeys = [...new Set([...keys, ...commonKeys])].sort()
+    // console.log('renderKeyGrid: All keys to render:', allKeys);
+
+    // Check view preference
+    const viewMode = localStorage.getItem('keyViewMode') || 'key-types'
+
+    if (viewMode === 'categorized') {
+      this.renderCategorizedKeyView(grid, profile, allKeys)
+    } else if (viewMode === 'key-types') {
+      this.renderKeyTypeView(grid, profile, allKeys)
+    } else {
+      this.renderSimpleKeyGrid(grid, allKeys)
     }
 
-    renderCategorizedKeyView(grid, profile, allKeys) {
-        // Add categorized class to override grid layout
-        grid.classList.add('categorized');
-        
-        // Categorize keys based on their commands, including all keys
-        const categorizedKeys = this.categorizeKeys(profile.keys, allKeys);
-        
-        // Sort categories by priority (Unknown first, then alphabetically)
-        const sortedCategories = Object.entries(categorizedKeys).sort(([aId, aData], [bId, bData]) => {
-            if (aData.priority !== bData.priority) {
-                return aData.priority - bData.priority;
-            }
-            return aData.name.localeCompare(bData.name);
-        });
-        
-        // Create category tree structure - show all categories even if empty
-        sortedCategories.forEach(([categoryId, categoryData]) => {
-            const categoryElement = this.createKeyCategoryElement(categoryId, categoryData);
-            grid.appendChild(categoryElement);
-        });
+    // Update toggle button icon
+    this.updateViewToggleButton(viewMode)
+
+    // Reapply any existing filter after rendering the new view
+    const filterInput = document.getElementById('keyFilter')
+    if (filterInput && filterInput.value.trim()) {
+      this.filterKeys(filterInput.value.trim())
+    }
+  }
+
+  renderSimpleKeyGrid(grid, allKeys) {
+    // Remove categorized class to use normal grid layout
+    grid.classList.remove('categorized')
+
+    allKeys.forEach((keyName) => {
+      const keyElement = this.createKeyElement(keyName)
+      grid.appendChild(keyElement)
+    })
+  }
+
+  renderCategorizedKeyView(grid, profile, allKeys) {
+    // Add categorized class to override grid layout
+    grid.classList.add('categorized')
+
+    // Categorize keys based on their commands, including all keys
+    const categorizedKeys = this.categorizeKeys(profile.keys, allKeys)
+
+    // Sort categories by priority (Unknown first, then alphabetically)
+    const sortedCategories = Object.entries(categorizedKeys).sort(
+      ([aId, aData], [bId, bData]) => {
+        if (aData.priority !== bData.priority) {
+          return aData.priority - bData.priority
+        }
+        return aData.name.localeCompare(bData.name)
+      }
+    )
+
+    // Create category tree structure - show all categories even if empty
+    sortedCategories.forEach(([categoryId, categoryData]) => {
+      const categoryElement = this.createKeyCategoryElement(
+        categoryId,
+        categoryData
+      )
+      grid.appendChild(categoryElement)
+    })
+  }
+
+  categorizeKeys(keysWithCommands, allKeys) {
+    const categories = {}
+
+    // Add Unknown category first (for empty keys)
+    categories.unknown = {
+      name: 'Unknown',
+      icon: 'fas fa-question-circle',
+      keys: new Set(),
+      priority: 0,
     }
 
-    categorizeKeys(keysWithCommands, allKeys) {
-        const categories = {};
-        
-        // Add Unknown category first (for empty keys)
-        categories.unknown = {
-            name: 'Unknown',
-            icon: 'fas fa-question-circle',
+    // Initialize categories from command library
+    Object.entries(STO_DATA.commands).forEach(([categoryId, categoryData]) => {
+      categories[categoryId] = {
+        name: categoryData.name,
+        icon: categoryData.icon,
+        keys: new Set(),
+        priority: 1,
+      }
+    })
+
+    // Process all keys, not just ones with commands
+    allKeys.forEach((keyName) => {
+      const commands = keysWithCommands[keyName] || []
+
+      if (!commands || commands.length === 0) {
+        categories.unknown.keys.add(keyName)
+        return
+      }
+
+      // Get all categories this key belongs to
+      const keyCategories = new Set()
+      commands.forEach((command) => {
+        if (command.type && categories[command.type]) {
+          keyCategories.add(command.type)
+        } else if (window.stoCommands) {
+          // Use command detection if type is not set
+          const detectedType = window.stoCommands.detectCommandType(
+            command.command
+          )
+          if (categories[detectedType]) {
+            keyCategories.add(detectedType)
+          }
+        }
+      })
+
+      // Add key to all relevant categories
+      if (keyCategories.size > 0) {
+        keyCategories.forEach((categoryId) => {
+          categories[categoryId].keys.add(keyName)
+        })
+      } else {
+        // Fallback for unknown command types
+        if (!categories.custom) {
+          categories.custom = {
+            name: 'Custom Commands',
+            icon: 'fas fa-cog',
             keys: new Set(),
-            priority: 0
-        };
-        
-        // Initialize categories from command library
-        Object.entries(STO_DATA.commands).forEach(([categoryId, categoryData]) => {
-            categories[categoryId] = {
-                name: categoryData.name,
-                icon: categoryData.icon,
-                keys: new Set(),
-                priority: 1
-            };
-        });
-        
-        // Process all keys, not just ones with commands
-        allKeys.forEach(keyName => {
-            const commands = keysWithCommands[keyName] || [];
-            
-            if (!commands || commands.length === 0) {
-                categories.unknown.keys.add(keyName);
-                return;
-            }
-            
-            // Get all categories this key belongs to
-            const keyCategories = new Set();
-            commands.forEach(command => {
-                if (command.type && categories[command.type]) {
-                    keyCategories.add(command.type);
-                } else if (window.stoCommands) {
-                    // Use command detection if type is not set
-                    const detectedType = window.stoCommands.detectCommandType(command.command);
-                    if (categories[detectedType]) {
-                        keyCategories.add(detectedType);
-                    }
-                }
-            });
-            
-            // Add key to all relevant categories
-            if (keyCategories.size > 0) {
-                keyCategories.forEach(categoryId => {
-                    categories[categoryId].keys.add(keyName);
-                });
-            } else {
-                // Fallback for unknown command types
-                if (!categories.custom) {
-                    categories.custom = {
-                        name: 'Custom Commands',
-                        icon: 'fas fa-cog',
-                        keys: new Set(),
-                        priority: 2
-                    };
-                }
-                categories.custom.keys.add(keyName);
-            }
-        });
-        
-        // Convert sets to arrays and sort
-        Object.values(categories).forEach(category => {
-            category.keys = Array.from(category.keys).sort(this.compareKeys.bind(this));
-        });
-        
-        return categories;
-    }
+            priority: 2,
+          }
+        }
+        categories.custom.keys.add(keyName)
+      }
+    })
 
-    createKeyCategoryElement(categoryId, categoryData, mode = 'command') {
-        const element = document.createElement('div');
-        element.className = 'category';
-        element.dataset.category = categoryId;
-        
-        // Use different storage key for key-type categories
-        const storageKey = mode === 'key-type' ? `keyTypeCategory_${categoryId}_collapsed` : `keyCategory_${categoryId}_collapsed`;
-        const isCollapsed = localStorage.getItem(storageKey) === 'true';
-        
-        element.innerHTML = `
+    // Convert sets to arrays and sort
+    Object.values(categories).forEach((category) => {
+      category.keys = Array.from(category.keys).sort(
+        this.compareKeys.bind(this)
+      )
+    })
+
+    return categories
+  }
+
+  createKeyCategoryElement(categoryId, categoryData, mode = 'command') {
+    const element = document.createElement('div')
+    element.className = 'category'
+    element.dataset.category = categoryId
+
+    // Use different storage key for key-type categories
+    const storageKey =
+      mode === 'key-type'
+        ? `keyTypeCategory_${categoryId}_collapsed`
+        : `keyCategory_${categoryId}_collapsed`
+    const isCollapsed = localStorage.getItem(storageKey) === 'true'
+
+    element.innerHTML = `
             <h4 class="${isCollapsed ? 'collapsed' : ''}" data-category="${categoryId}" data-mode="${mode}">
                 <i class="fas fa-chevron-right category-chevron"></i>
                 <i class="${categoryData.icon}"></i> 
@@ -668,475 +744,514 @@ export default class STOToolsKeybindManager {
                 <span class="key-count">(${categoryData.keys.length})</span>
             </h4>
             <div class="category-commands ${isCollapsed ? 'collapsed' : ''}">
-                ${categoryData.keys.map(keyName => this.createKeyElementHTML(keyName)).join('')}
+                ${categoryData.keys.map((keyName) => this.createKeyElementHTML(keyName)).join('')}
             </div>
-        `;
-        
-        // Add click handler for category header
-        const header = element.querySelector('h4');
-        header.addEventListener('click', () => {
-            this.toggleKeyCategory(categoryId, element, mode);
-        });
-        
-        // Add click handlers for key elements
-        const keyElements = element.querySelectorAll('.command-item');
-        keyElements.forEach(keyElement => {
-            keyElement.addEventListener('click', () => {
-                const keyName = keyElement.dataset.key;
-                this.selectKey(keyName);
-            });
-        });
-        
-        return element;
+        `
+
+    // Add click handler for category header
+    const header = element.querySelector('h4')
+    header.addEventListener('click', () => {
+      this.toggleKeyCategory(categoryId, element, mode)
+    })
+
+    // Add click handlers for key elements
+    const keyElements = element.querySelectorAll('.command-item')
+    keyElements.forEach((keyElement) => {
+      keyElement.addEventListener('click', () => {
+        const keyName = keyElement.dataset.key
+        this.selectKey(keyName)
+      })
+    })
+
+    return element
+  }
+
+  createKeyElementHTML(keyName) {
+    const profile = this.getCurrentProfile()
+    const commands = profile.keys[keyName] || []
+    const isActive = this.selectedKey === keyName
+
+    // Simple length-based font sizing for categorized view (no line breaks)
+    const keyLength = keyName.length
+    let lengthClass
+    if (keyLength <= 6) {
+      lengthClass = 'short'
+    } else if (keyLength <= 12) {
+      lengthClass = 'medium'
+    } else {
+      lengthClass = 'long'
     }
 
-    createKeyElementHTML(keyName) {
-        const profile = this.getCurrentProfile();
-        const commands = profile.keys[keyName] || [];
-        const isActive = this.selectedKey === keyName;
-        
-                // Simple length-based font sizing for categorized view (no line breaks)
-        const keyLength = keyName.length;
-        let lengthClass;
-        if (keyLength <= 6) {
-            lengthClass = 'short';
-        } else if (keyLength <= 12) {
-            lengthClass = 'medium';
-        } else {
-            lengthClass = 'long';
-        }
-        
-        return `
+    return `
             <div class="command-item ${isActive ? 'active' : ''}" data-key="${keyName}" data-length="${lengthClass}">
                 <span class="key-label">${keyName}</span>
-                ${commands.length > 0 ? `
+                ${
+                  commands.length > 0
+                    ? `
                     <span class="command-count-badge">${commands.length}</span>
-                ` : ''}
-            </div>
-        `;
-    }
-
-    toggleKeyCategory(categoryId, element, mode = 'command') {
-        const header = element.querySelector('h4');
-        const commands = element.querySelector('.category-commands');
-        const chevron = header.querySelector('.category-chevron');
-        
-        const isCollapsed = commands.classList.contains('collapsed');
-        
-        // Use different storage key for key-type categories
-        const storageKey = mode === 'key-type' ? `keyTypeCategory_${categoryId}_collapsed` : `keyCategory_${categoryId}_collapsed`;
-        
-        if (isCollapsed) {
-            commands.classList.remove('collapsed');
-            header.classList.remove('collapsed');
-            chevron.style.transform = 'rotate(90deg)';
-            localStorage.setItem(storageKey, 'false');
-        } else {
-            commands.classList.add('collapsed');
-            header.classList.add('collapsed');
-            chevron.style.transform = 'rotate(0deg)';
-            localStorage.setItem(storageKey, 'true');
-        }
-    }
-
-    formatKeyName(keyName) {
-        // Smart formatting for compound keys to use line breaks instead of tiny text
-        if (keyName.includes('+')) {
-            // Always break compound keys for better readability
-            return keyName.replace(/\+/g, '<br>+<br>');
-        }
-        return keyName;
-    }
-
-    detectKeyTypes(keyName) {
-        const types = [];
-        
-        // Check if this is a compound key with modifiers
-        if (keyName.includes('+')) {
-            const parts = keyName.split('+');
-            const hasModifier = parts.some(part => 
-                part.match(/^(Ctrl|Control|Alt|Shift|Win|Cmd|Super)$/i)
-            );
-            
-            if (hasModifier) {
-                types.push('modifiers');
-            }
-        }
-        
-        // Extract the base key from compound keys to check its type too
-        const baseKey = keyName.split('+').pop();
-        
-        // Function Keys
-        if (baseKey.match(/^F\d+$/)) types.push('function');
-        
-        // Mouse inputs - comprehensive list from STO documentation
-        else if (baseKey.match(/^(Lbutton|Rbutton|Mbutton|Leftdrag|Rightdrag|Middledrag|Leftclick|Rightclick|Middleclick|Leftdoubleclick|Rightdoubleclick|Middledoubleclick|Wheelplus|Wheelminus|Mousechord|Mouse|Wheel|LMouse|RMouse|MMouse|XMouse|Drag)/i)) types.push('mouse');
-        
-        // Numberpad
-        else if (baseKey.match(/^(Numpad|Keypad)/i)) types.push('numberpad');
-        
-        // Single Modifiers (for standalone modifier keys)
-        else if (baseKey.match(/^(Ctrl|Control|Alt|Shift|Win|Cmd|Super)$/i)) {
-            if (!types.includes('modifiers')) types.push('modifiers');
-        }
-        
-        // Navigation
-        else if (baseKey.match(/^(Up|Down|Left|Right|Home|End|PageUp|PageDown|Insert|Delete)$/i)) types.push('navigation');
-        
-        // System/Special
-        else if (baseKey.match(/^(Space|Tab|Enter|Return|Escape|Esc|Backspace|CapsLock|ScrollLock|NumLock|PrintScreen|Pause|Break)$/i)) types.push('system');
-        
-        // Numbers
-        else if (baseKey.match(/^[0-9]$/)) types.push('alphanumeric');
-        
-        // Letters
-        else if (baseKey.match(/^[A-Za-z]$/)) types.push('alphanumeric');
-        
-        // Symbols and punctuation
-        else if (baseKey.match(/^[`~!@#$%^&*()_+\-=\[\]{}\\|;':",./<>?]$/) || 
-            baseKey.match(/^(Comma|Period|Semicolon|Quote|Slash|Backslash|Minus|Plus|Equals|Bracket|Grave|Tilde)$/i)) {
-            types.push('symbols');
-        }
-        
-        // Default fallback
-        else {
-            types.push('other');
-        }
-        
-        return types.length > 0 ? types : ['other'];
-    }
-
-    categorizeKeysByType(keysWithCommands, allKeys) {
-        const categories = {
-            function: {
-                name: 'Function Keys',
-                icon: 'fas fa-keyboard',
-                keys: new Set(),
-                priority: 1
-            },
-            alphanumeric: {
-                name: 'Letters & Numbers',
-                icon: 'fas fa-font',
-                keys: new Set(),
-                priority: 2
-            },
-            numberpad: {
-                name: 'Numberpad',
-                icon: 'fas fa-calculator',
-                keys: new Set(),
-                priority: 3
-            },
-            modifiers: {
-                name: 'Modifier Keys',
-                icon: 'fas fa-hand-paper',
-                keys: new Set(),
-                priority: 4
-            },
-            navigation: {
-                name: 'Navigation',
-                icon: 'fas fa-arrows-alt',
-                keys: new Set(),
-                priority: 5
-            },
-            system: {
-                name: 'System Keys',
-                icon: 'fas fa-cogs',
-                keys: new Set(),
-                priority: 6
-            },
-            mouse: {
-                name: 'Mouse & Wheel',
-                icon: 'fas fa-mouse',
-                keys: new Set(),
-                priority: 7
-            },
-            symbols: {
-                name: 'Symbols & Punctuation',
-                icon: 'fas fa-at',
-                keys: new Set(),
-                priority: 8
-            },
-            other: {
-                name: 'Other Keys',
-                icon: 'fas fa-question-circle',
-                keys: new Set(),
-                priority: 9
-            }
-        };
-        
-        // Categorize each key by its types (can be multiple)
-        allKeys.forEach(keyName => {
-            const keyTypes = this.detectKeyTypes(keyName);
-            keyTypes.forEach(keyType => {
-                if (categories[keyType]) {
-                    categories[keyType].keys.add(keyName);
-                } else {
-                    categories.other.keys.add(keyName);
+                `
+                    : ''
                 }
-            });
-        });
-        
-        // Convert sets to arrays and sort
-        Object.values(categories).forEach(category => {
-            category.keys = Array.from(category.keys).sort(this.compareKeys.bind(this));
-        });
-        
-        return categories;
+            </div>
+        `
+  }
+
+  toggleKeyCategory(categoryId, element, mode = 'command') {
+    const header = element.querySelector('h4')
+    const commands = element.querySelector('.category-commands')
+    const chevron = header.querySelector('.category-chevron')
+
+    const isCollapsed = commands.classList.contains('collapsed')
+
+    // Use different storage key for key-type categories
+    const storageKey =
+      mode === 'key-type'
+        ? `keyTypeCategory_${categoryId}_collapsed`
+        : `keyCategory_${categoryId}_collapsed`
+
+    if (isCollapsed) {
+      commands.classList.remove('collapsed')
+      header.classList.remove('collapsed')
+      chevron.style.transform = 'rotate(90deg)'
+      localStorage.setItem(storageKey, 'false')
+    } else {
+      commands.classList.add('collapsed')
+      header.classList.add('collapsed')
+      chevron.style.transform = 'rotate(0deg)'
+      localStorage.setItem(storageKey, 'true')
+    }
+  }
+
+  formatKeyName(keyName) {
+    // Smart formatting for compound keys to use line breaks instead of tiny text
+    if (keyName.includes('+')) {
+      // Always break compound keys for better readability
+      return keyName.replace(/\+/g, '<br>+<br>')
+    }
+    return keyName
+  }
+
+  detectKeyTypes(keyName) {
+    const types = []
+
+    // Check if this is a compound key with modifiers
+    if (keyName.includes('+')) {
+      const parts = keyName.split('+')
+      const hasModifier = parts.some((part) =>
+        part.match(/^(Ctrl|Control|Alt|Shift|Win|Cmd|Super)$/i)
+      )
+
+      if (hasModifier) {
+        types.push('modifiers')
+      }
     }
 
-    renderKeyTypeView(grid, profile, allKeys) {
-        // Add categorized class to override grid layout
-        grid.classList.add('categorized');
-        
-        // Categorize keys by their input type
-        const categorizedKeys = this.categorizeKeysByType(profile.keys, allKeys);
-        
-        // Sort categories by priority
-        const sortedCategories = Object.entries(categorizedKeys).sort(([aId, aData], [bId, bData]) => {
-            return aData.priority - bData.priority;
-        });
-        
-        // Create category tree structure - show all categories even if empty
-        sortedCategories.forEach(([categoryId, categoryData]) => {
-            const categoryElement = this.createKeyCategoryElement(categoryId, categoryData, 'key-type');
-            grid.appendChild(categoryElement);
-        });
+    // Extract the base key from compound keys to check its type too
+    const baseKey = keyName.split('+').pop()
+
+    // Function Keys
+    if (baseKey.match(/^F\d+$/)) types.push('function')
+    // Mouse inputs - comprehensive list from STO documentation
+    else if (
+      baseKey.match(
+        /^(Lbutton|Rbutton|Mbutton|Leftdrag|Rightdrag|Middledrag|Leftclick|Rightclick|Middleclick|Leftdoubleclick|Rightdoubleclick|Middledoubleclick|Wheelplus|Wheelminus|Mousechord|Mouse|Wheel|LMouse|RMouse|MMouse|XMouse|Drag)/i
+      )
+    )
+      types.push('mouse')
+    // Numberpad
+    else if (baseKey.match(/^(Numpad|Keypad)/i)) types.push('numberpad')
+    // Single Modifiers (for standalone modifier keys)
+    else if (baseKey.match(/^(Ctrl|Control|Alt|Shift|Win|Cmd|Super)$/i)) {
+      if (!types.includes('modifiers')) types.push('modifiers')
     }
 
-    compareKeys(a, b) {
-        // Custom key sorting logic
-        const getKeyPriority = (key) => {
-            if (key === 'Space') return 0;
-            if (key.match(/^[0-9]$/)) return 1;
-            if (key.match(/^F[0-9]+$/)) return 2;
-            if (key.includes('Ctrl+')) return 3;
-            if (key.includes('Alt+')) return 4;
-            if (key.includes('Shift+')) return 5;
-            return 6;
-        };
-        
-        const priorityA = getKeyPriority(a);
-        const priorityB = getKeyPriority(b);
-        
-        if (priorityA !== priorityB) {
-            return priorityA - priorityB;
+    // Navigation
+    else if (
+      baseKey.match(
+        /^(Up|Down|Left|Right|Home|End|PageUp|PageDown|Insert|Delete)$/i
+      )
+    )
+      types.push('navigation')
+    // System/Special
+    else if (
+      baseKey.match(
+        /^(Space|Tab|Enter|Return|Escape|Esc|Backspace|CapsLock|ScrollLock|NumLock|PrintScreen|Pause|Break)$/i
+      )
+    )
+      types.push('system')
+    // Numbers
+    else if (baseKey.match(/^[0-9]$/)) types.push('alphanumeric')
+    // Letters
+    else if (baseKey.match(/^[A-Za-z]$/)) types.push('alphanumeric')
+    // Symbols and punctuation
+    else if (
+      baseKey.match(/^[`~!@#$%^&*()_+\-=\[\]{}\\|;':",./<>?]$/) ||
+      baseKey.match(
+        /^(Comma|Period|Semicolon|Quote|Slash|Backslash|Minus|Plus|Equals|Bracket|Grave|Tilde)$/i
+      )
+    ) {
+      types.push('symbols')
+    }
+
+    // Default fallback
+    else {
+      types.push('other')
+    }
+
+    return types.length > 0 ? types : ['other']
+  }
+
+  categorizeKeysByType(keysWithCommands, allKeys) {
+    const categories = {
+      function: {
+        name: 'Function Keys',
+        icon: 'fas fa-keyboard',
+        keys: new Set(),
+        priority: 1,
+      },
+      alphanumeric: {
+        name: 'Letters & Numbers',
+        icon: 'fas fa-font',
+        keys: new Set(),
+        priority: 2,
+      },
+      numberpad: {
+        name: 'Numberpad',
+        icon: 'fas fa-calculator',
+        keys: new Set(),
+        priority: 3,
+      },
+      modifiers: {
+        name: 'Modifier Keys',
+        icon: 'fas fa-hand-paper',
+        keys: new Set(),
+        priority: 4,
+      },
+      navigation: {
+        name: 'Navigation',
+        icon: 'fas fa-arrows-alt',
+        keys: new Set(),
+        priority: 5,
+      },
+      system: {
+        name: 'System Keys',
+        icon: 'fas fa-cogs',
+        keys: new Set(),
+        priority: 6,
+      },
+      mouse: {
+        name: 'Mouse & Wheel',
+        icon: 'fas fa-mouse',
+        keys: new Set(),
+        priority: 7,
+      },
+      symbols: {
+        name: 'Symbols & Punctuation',
+        icon: 'fas fa-at',
+        keys: new Set(),
+        priority: 8,
+      },
+      other: {
+        name: 'Other Keys',
+        icon: 'fas fa-question-circle',
+        keys: new Set(),
+        priority: 9,
+      },
+    }
+
+    // Categorize each key by its types (can be multiple)
+    allKeys.forEach((keyName) => {
+      const keyTypes = this.detectKeyTypes(keyName)
+      keyTypes.forEach((keyType) => {
+        if (categories[keyType]) {
+          categories[keyType].keys.add(keyName)
+        } else {
+          categories.other.keys.add(keyName)
         }
-        
-        return a.localeCompare(b);
+      })
+    })
+
+    // Convert sets to arrays and sort
+    Object.values(categories).forEach((category) => {
+      category.keys = Array.from(category.keys).sort(
+        this.compareKeys.bind(this)
+      )
+    })
+
+    return categories
+  }
+
+  renderKeyTypeView(grid, profile, allKeys) {
+    // Add categorized class to override grid layout
+    grid.classList.add('categorized')
+
+    // Categorize keys by their input type
+    const categorizedKeys = this.categorizeKeysByType(profile.keys, allKeys)
+
+    // Sort categories by priority
+    const sortedCategories = Object.entries(categorizedKeys).sort(
+      ([aId, aData], [bId, bData]) => {
+        return aData.priority - bData.priority
+      }
+    )
+
+    // Create category tree structure - show all categories even if empty
+    sortedCategories.forEach(([categoryId, categoryData]) => {
+      const categoryElement = this.createKeyCategoryElement(
+        categoryId,
+        categoryData,
+        'key-type'
+      )
+      grid.appendChild(categoryElement)
+    })
+  }
+
+  compareKeys(a, b) {
+    // Custom key sorting logic
+    const getKeyPriority = (key) => {
+      if (key === 'Space') return 0
+      if (key.match(/^[0-9]$/)) return 1
+      if (key.match(/^F[0-9]+$/)) return 2
+      if (key.includes('Ctrl+')) return 3
+      if (key.includes('Alt+')) return 4
+      if (key.includes('Shift+')) return 5
+      return 6
     }
 
-    createKeyElement(keyName) {
-        const profile = this.getCurrentProfile();
-        const commands = profile.keys[keyName] || [];
-        const isSelected = keyName === this.selectedKey;
-        
-        const keyElement = document.createElement('div');
-        keyElement.className = `key-item ${isSelected ? 'active' : ''}`;
-        keyElement.dataset.key = keyName;
-        keyElement.title = `${keyName}: ${commands.length} command${commands.length !== 1 ? 's' : ''}`;
-        
-        // Smart formatting for compound keys and font sizing
-        const formattedKeyName = this.formatKeyName(keyName);
-        const hasLineBreaks = formattedKeyName.includes('<br>');
-        
-        // Determine length classification
-        let lengthClass;
-        if (hasLineBreaks) {
-            // For compound keys with line breaks, check the longest part
-            const parts = keyName.split('+');
-            const longestPart = Math.max(...parts.map(part => part.length));
-            if (longestPart <= 4) {
-                lengthClass = 'short';
-            } else if (longestPart <= 8) {
-                lengthClass = 'medium';
-            } else {
-                lengthClass = 'long';
-            }
-                 } else {
-             // For single keys, use total length
-             const keyLength = keyName.length;
-             if (keyLength <= 3) {
-                 lengthClass = 'short';
-             } else if (keyLength <= 5) {
-                 lengthClass = 'medium';
-             } else if (keyLength <= 8) {
-                 lengthClass = 'long';
-             } else {
-                 lengthClass = 'extra-long';
-             }
-         }
-         
-         keyElement.dataset.length = lengthClass;
-        
-        keyElement.innerHTML = `
+    const priorityA = getKeyPriority(a)
+    const priorityB = getKeyPriority(b)
+
+    if (priorityA !== priorityB) {
+      return priorityA - priorityB
+    }
+
+    return a.localeCompare(b)
+  }
+
+  createKeyElement(keyName) {
+    const profile = this.getCurrentProfile()
+    const commands = profile.keys[keyName] || []
+    const isSelected = keyName === this.selectedKey
+
+    const keyElement = document.createElement('div')
+    keyElement.className = `key-item ${isSelected ? 'active' : ''}`
+    keyElement.dataset.key = keyName
+    keyElement.title = `${keyName}: ${commands.length} command${commands.length !== 1 ? 's' : ''}`
+
+    // Smart formatting for compound keys and font sizing
+    const formattedKeyName = this.formatKeyName(keyName)
+    const hasLineBreaks = formattedKeyName.includes('<br>')
+
+    // Determine length classification
+    let lengthClass
+    if (hasLineBreaks) {
+      // For compound keys with line breaks, check the longest part
+      const parts = keyName.split('+')
+      const longestPart = Math.max(...parts.map((part) => part.length))
+      if (longestPart <= 4) {
+        lengthClass = 'short'
+      } else if (longestPart <= 8) {
+        lengthClass = 'medium'
+      } else {
+        lengthClass = 'long'
+      }
+    } else {
+      // For single keys, use total length
+      const keyLength = keyName.length
+      if (keyLength <= 3) {
+        lengthClass = 'short'
+      } else if (keyLength <= 5) {
+        lengthClass = 'medium'
+      } else if (keyLength <= 8) {
+        lengthClass = 'long'
+      } else {
+        lengthClass = 'extra-long'
+      }
+    }
+
+    keyElement.dataset.length = lengthClass
+
+    keyElement.innerHTML = `
             <div class="key-label">${formattedKeyName}</div>
-            ${commands.length > 0 ? `
+            ${
+              commands.length > 0
+                ? `
                 <div class="activity-bar" style="width: ${Math.min(commands.length * 15, 100)}%"></div>
                 <div class="command-count-badge">${commands.length}</div>
-            ` : ''}
-        `;
-        
-        keyElement.addEventListener('click', () => {
-            this.selectKey(keyName);
-        });
-        
-        return keyElement;
-    }
-
-    updateViewToggleButton(viewMode) {
-        const toggleBtn = document.getElementById('toggleKeyViewBtn');
-        if (toggleBtn) {
-            const icon = toggleBtn.querySelector('i');
-            if (viewMode === 'categorized') {
-                icon.className = 'fas fa-sitemap';
-                toggleBtn.title = 'Switch to key type view';
-            } else if (viewMode === 'key-types') {
-                icon.className = 'fas fa-th';
-                toggleBtn.title = 'Switch to grid view';
-            } else {
-                icon.className = 'fas fa-list';
-                toggleBtn.title = 'Switch to command categories';
+            `
+                : ''
             }
-        }
+        `
+
+    keyElement.addEventListener('click', () => {
+      this.selectKey(keyName)
+    })
+
+    return keyElement
+  }
+
+  updateViewToggleButton(viewMode) {
+    const toggleBtn = document.getElementById('toggleKeyViewBtn')
+    if (toggleBtn) {
+      const icon = toggleBtn.querySelector('i')
+      if (viewMode === 'categorized') {
+        icon.className = 'fas fa-sitemap'
+        toggleBtn.title = 'Switch to key type view'
+      } else if (viewMode === 'key-types') {
+        icon.className = 'fas fa-th'
+        toggleBtn.title = 'Switch to grid view'
+      } else {
+        icon.className = 'fas fa-list'
+        toggleBtn.title = 'Switch to command categories'
+      }
+    }
+  }
+
+  toggleKeyView() {
+    const currentMode = localStorage.getItem('keyViewMode') || 'key-types'
+    let newMode
+
+    // 3-way toggle: key-types → grid → categorized → key-types
+    if (currentMode === 'key-types') {
+      newMode = 'grid'
+    } else if (currentMode === 'grid') {
+      newMode = 'categorized'
+    } else {
+      newMode = 'key-types'
     }
 
-    toggleKeyView() {
-        const currentMode = localStorage.getItem('keyViewMode') || 'key-types';
-        let newMode;
-        
-        // 3-way toggle: key-types → grid → categorized → key-types
-        if (currentMode === 'key-types') {
-            newMode = 'grid';
-        } else if (currentMode === 'grid') {
-            newMode = 'categorized';
-        } else {
-            newMode = 'key-types';
-        }
-        
-        localStorage.setItem('keyViewMode', newMode);
-        this.renderKeyGrid();
+    localStorage.setItem('keyViewMode', newMode)
+    this.renderKeyGrid()
+  }
+
+  renderCommandChain() {
+    const container = document.getElementById('commandList')
+    const title = document.getElementById('chainTitle')
+    const preview = document.getElementById('commandPreview')
+    const commandCount = document.getElementById('commandCount')
+    const emptyState = document.getElementById('emptyState')
+
+    if (!container || !title || !preview) return
+
+    if (!this.selectedKey) {
+      title.textContent = 'Select a key to edit'
+      preview.textContent = 'Select a key to see the generated command'
+      if (commandCount) commandCount.textContent = '0 commands'
+      if (emptyState) emptyState.style.display = 'block'
+      container.innerHTML =
+        '<div class="empty-state" id="emptyState"><i class="fas fa-keyboard"></i><h4>No Key Selected</h4><p>Select a key from the left panel to view and edit its command chain.</p></div>'
+      return
     }
 
-    renderCommandChain() {
-        const container = document.getElementById('commandList');
-        const title = document.getElementById('chainTitle');
-        const preview = document.getElementById('commandPreview');
-        const commandCount = document.getElementById('commandCount');
-        const emptyState = document.getElementById('emptyState');
-        
-        if (!container || !title || !preview) return;
-        
-        if (!this.selectedKey) {
-            title.textContent = 'Select a key to edit';
-            preview.textContent = 'Select a key to see the generated command';
-            if (commandCount) commandCount.textContent = '0 commands';
-            if (emptyState) emptyState.style.display = 'block';
-            container.innerHTML = '<div class="empty-state" id="emptyState"><i class="fas fa-keyboard"></i><h4>No Key Selected</h4><p>Select a key from the left panel to view and edit its command chain.</p></div>';
-            return;
-        }
-        
-        const profile = this.getCurrentProfile();
-        const commands = profile.keys[this.selectedKey] || [];
-        
-        title.textContent = `Command Chain for ${this.selectedKey}`;
-        if (commandCount) commandCount.textContent = `${commands.length} command${commands.length !== 1 ? 's' : ''}`;
-        
-        if (commands.length === 0) {
-            container.innerHTML = `
+    const profile = this.getCurrentProfile()
+    const commands = profile.keys[this.selectedKey] || []
+
+    title.textContent = `Command Chain for ${this.selectedKey}`
+    if (commandCount)
+      commandCount.textContent = `${commands.length} command${commands.length !== 1 ? 's' : ''}`
+
+    if (commands.length === 0) {
+      container.innerHTML = `
                 <div class="empty-state">
                     <i class="fas fa-plus-circle"></i>
                     <h4>No Commands</h4>
                     <p>Click "Add Command" to start building your command chain for ${this.selectedKey}.</p>
                 </div>
-            `;
-            preview.textContent = `${this.selectedKey} ""`;
-        } else {
-            container.innerHTML = '';
-            commands.forEach((command, index) => {
-                const element = this.createCommandElement(command, index);
-                container.appendChild(element);
-            });
-            
-            // Update preview with optional mirroring
-            const stabilizeCheckbox = document.getElementById('stabilizeExecutionOrder');
-            const shouldStabilize = stabilizeCheckbox && stabilizeCheckbox.checked;
-            
-            let commandString;
-            if (shouldStabilize && commands.length > 1) {
-                commandString = stoKeybinds.generateMirroredCommandString(commands);
-            } else {
-                commandString = commands.map(cmd => cmd.command).join(' $$ ');
-            }
-            
-            preview.textContent = `${this.selectedKey} "${commandString}"`;
+            `
+      preview.textContent = `${this.selectedKey} ""`
+    } else {
+      container.innerHTML = ''
+      commands.forEach((command, index) => {
+        const element = this.createCommandElement(command, index)
+        container.appendChild(element)
+      })
+
+      // Update preview with optional mirroring
+      const stabilizeCheckbox = document.getElementById(
+        'stabilizeExecutionOrder'
+      )
+      const shouldStabilize = stabilizeCheckbox && stabilizeCheckbox.checked
+
+      let commandString
+      if (shouldStabilize && commands.length > 1) {
+        commandString = stoKeybinds.generateMirroredCommandString(commands)
+      } else {
+        commandString = commands.map((cmd) => cmd.command).join(' $$ ')
+      }
+
+      preview.textContent = `${this.selectedKey} "${commandString}"`
+    }
+  }
+
+  createCommandElement(command, index) {
+    const element = document.createElement('div')
+    element.className = 'command-item-row'
+    element.dataset.index = index
+    element.draggable = true
+
+    // Check if this command matches a library definition
+    const commandDef = this.findCommandDefinition(command)
+    const isParameterized = commandDef && commandDef.customizable
+
+    // Use library definition for display if available
+    let displayName = command.text
+    let displayIcon = command.icon
+
+    if (commandDef) {
+      displayName = commandDef.name
+      displayIcon = commandDef.icon
+
+      // For parameterized commands, add parameter details to the name
+      if (isParameterized && command.parameters) {
+        if (commandDef.commandId === 'tray_with_backup') {
+          const p = command.parameters
+          displayName = `${commandDef.name} (${p.active} ${p.tray} ${p.slot} ${p.backup_tray} ${p.backup_slot})`
+        } else if (commandDef.commandId === 'custom_tray') {
+          const p = command.parameters
+          displayName = `${commandDef.name} (${p.tray} ${p.slot})`
+        } else if (commandDef.commandId === 'target') {
+          const p = command.parameters
+          displayName = `${commandDef.name}: ${p.entityName}`
         }
+      } else if (isParameterized) {
+        // Extract parameters from command string for display
+        if (command.command.includes('TrayExecByTrayWithBackup')) {
+          const parts = command.command.split(' ')
+          if (parts.length >= 6) {
+            displayName = `${commandDef.name} (${parts[1]} ${parts[2]} ${parts[3]} ${parts[4]} ${parts[5]})`
+          }
+        } else if (command.command.includes('TrayExec')) {
+          const parts = command.command.replace('+', '').split(' ')
+          if (parts.length >= 3) {
+            displayName = `${commandDef.name} (${parts[1]} ${parts[2]})`
+          }
+        } else if (command.command.includes('Target ')) {
+          const match = command.command.match(/Target "([^"]+)"/)
+          if (match) {
+            displayName = `${commandDef.name}: ${match[1]}`
+          }
+        }
+      }
     }
 
-    createCommandElement(command, index) {
-        const element = document.createElement('div');
-        element.className = 'command-item-row';
-        element.dataset.index = index;
-        element.draggable = true;
-        
-        // Check if this command matches a library definition
-        const commandDef = this.findCommandDefinition(command);
-        const isParameterized = commandDef && commandDef.customizable;
-        
-        // Use library definition for display if available
-        let displayName = command.text;
-        let displayIcon = command.icon;
-        
-        if (commandDef) {
-            displayName = commandDef.name;
-            displayIcon = commandDef.icon;
-            
-            // For parameterized commands, add parameter details to the name
-            if (isParameterized && command.parameters) {
-                if (commandDef.commandId === 'tray_with_backup') {
-                    const p = command.parameters;
-                    displayName = `${commandDef.name} (${p.active} ${p.tray} ${p.slot} ${p.backup_tray} ${p.backup_slot})`;
-                } else if (commandDef.commandId === 'custom_tray') {
-                    const p = command.parameters;
-                    displayName = `${commandDef.name} (${p.tray} ${p.slot})`;
-                } else if (commandDef.commandId === 'target') {
-                    const p = command.parameters;
-                    displayName = `${commandDef.name}: ${p.entityName}`;
-                }
-            } else if (isParameterized) {
-                // Extract parameters from command string for display
-                if (command.command.includes('TrayExecByTrayWithBackup')) {
-                    const parts = command.command.split(' ');
-                    if (parts.length >= 6) {
-                        displayName = `${commandDef.name} (${parts[1]} ${parts[2]} ${parts[3]} ${parts[4]} ${parts[5]})`;
-                    }
-                } else if (command.command.includes('TrayExec')) {
-                    const parts = command.command.replace('+', '').split(' ');
-                    if (parts.length >= 3) {
-                        displayName = `${commandDef.name} (${parts[1]} ${parts[2]})`;
-                    }
-                } else if (command.command.includes('Target ')) {
-                    const match = command.command.match(/Target "([^"]+)"/);
-                    if (match) {
-                        displayName = `${commandDef.name}: ${match[1]}`;
-                    }
-                }
-            }
-        }
-        
-        // Add parameters data attribute for styling
-        if (isParameterized) {
-            element.dataset.parameters = 'true';
-            element.classList.add('customizable');
-        }
-        
-        // Check if command has a warning
-        const warningInfo = this.getCommandWarning(command);
-        const warningIcon = warningInfo ? `<span class="command-warning-icon" title="${warningInfo}"><i class="fas fa-exclamation-triangle"></i></span>` : '';
-        
-        // Add parameter indicator for tray commands and other parameterized commands
-        const parameterIndicator = isParameterized ? ' <span class="param-indicator" title="Editable parameters">⚙️</span>' : '';
-        
-        element.innerHTML = `
+    // Add parameters data attribute for styling
+    if (isParameterized) {
+      element.dataset.parameters = 'true'
+      element.classList.add('customizable')
+    }
+
+    // Check if command has a warning
+    const warningInfo = this.getCommandWarning(command)
+    const warningIcon = warningInfo
+      ? `<span class="command-warning-icon" title="${warningInfo}"><i class="fas fa-exclamation-triangle"></i></span>`
+      : ''
+
+    // Add parameter indicator for tray commands and other parameterized commands
+    const parameterIndicator = isParameterized
+      ? ' <span class="param-indicator" title="Editable parameters">⚙️</span>'
+      : ''
+
+    element.innerHTML = `
             <div class="command-number">${index + 1}</div>
             <div class="command-content">
                 <span class="command-icon">${displayIcon}</span>
@@ -1160,54 +1275,56 @@ export default class STOToolsKeybindManager {
                     <i class="fas fa-chevron-down"></i>
                 </button>
             </div>
-        `;
-        
-        return element;
-    }
+        `
 
-    getCommandWarning(command) {
-        // Look up the command in the data structure to find its warning
-        const categories = STO_DATA.commands;
-        
-        for (const [categoryId, category] of Object.entries(categories)) {
-            for (const [cmdId, cmdData] of Object.entries(category.commands)) {
-                // Match by command text or actual command
-                if (cmdData.command === command.command || 
-                    cmdData.name === command.text ||
-                    command.command.includes(cmdData.command)) {
-                    return cmdData.warning || null;
-                }
-            }
+    return element
+  }
+
+  getCommandWarning(command) {
+    // Look up the command in the data structure to find its warning
+    const categories = STO_DATA.commands
+
+    for (const [categoryId, category] of Object.entries(categories)) {
+      for (const [cmdId, cmdData] of Object.entries(category.commands)) {
+        // Match by command text or actual command
+        if (
+          cmdData.command === command.command ||
+          cmdData.name === command.text ||
+          command.command.includes(cmdData.command)
+        ) {
+          return cmdData.warning || null
         }
-        
-        return null;
+      }
     }
 
-    setupCommandLibrary() {
-        const container = document.getElementById('commandCategories');
-        if (!container) return;
-        
-        container.innerHTML = '';
-        
-        Object.entries(STO_DATA.commands).forEach(([categoryId, category]) => {
-            const categoryElement = this.createCategoryElement(categoryId, category);
-            container.appendChild(categoryElement);
-        });
-        
-        // Apply environment filtering after creating elements
-        this.filterCommandLibrary();
-    }
+    return null
+  }
 
-    createCategoryElement(categoryId, category) {
-        const element = document.createElement('div');
-        element.className = 'category';
-        element.dataset.category = categoryId;
-        
-        // Check if category should be collapsed (similar to Keys UI)
-        const storageKey = `commandCategory_${categoryId}_collapsed`;
-        const isCollapsed = localStorage.getItem(storageKey) === 'true';
-        
-        element.innerHTML = `
+  setupCommandLibrary() {
+    const container = document.getElementById('commandCategories')
+    if (!container) return
+
+    container.innerHTML = ''
+
+    Object.entries(STO_DATA.commands).forEach(([categoryId, category]) => {
+      const categoryElement = this.createCategoryElement(categoryId, category)
+      container.appendChild(categoryElement)
+    })
+
+    // Apply environment filtering after creating elements
+    this.filterCommandLibrary()
+  }
+
+  createCategoryElement(categoryId, category) {
+    const element = document.createElement('div')
+    element.className = 'category'
+    element.dataset.category = categoryId
+
+    // Check if category should be collapsed (similar to Keys UI)
+    const storageKey = `commandCategory_${categoryId}_collapsed`
+    const isCollapsed = localStorage.getItem(storageKey) === 'true'
+
+    element.innerHTML = `
             <h4 class="${isCollapsed ? 'collapsed' : ''}" data-category="${categoryId}">
                 <i class="fas fa-chevron-right category-chevron"></i>
                 <i class="${category.icon}"></i> 
@@ -1215,692 +1332,731 @@ export default class STOToolsKeybindManager {
                 <span class="command-count">(${Object.keys(category.commands).length})</span>
             </h4>
             <div class="category-commands ${isCollapsed ? 'collapsed' : ''}">
-                ${Object.entries(category.commands).map(([cmdId, cmd]) => `
+                ${Object.entries(category.commands)
+                  .map(
+                    ([cmdId, cmd]) => `
                     <div class="command-item ${cmd.customizable ? 'customizable' : ''}" data-command="${cmdId}" title="${cmd.description}${cmd.customizable ? ' (Customizable)' : ''}">
                         ${cmd.icon} ${cmd.name}${cmd.customizable ? ' <span class="param-indicator">⚙️</span>' : ''}
                     </div>
-                `).join('')}
+                `
+                  )
+                  .join('')}
             </div>
-        `;
-        
-        // Add click handler for category header
-        const header = element.querySelector('h4');
-        header.addEventListener('click', () => {
-            this.toggleCommandCategory(categoryId, element);
-        });
-        
-        // Add click handlers for commands
-        element.addEventListener('click', (e) => {
-            if (e.target.classList.contains('command-item')) {
-                const commandId = e.target.dataset.command;
-                this.addCommandFromLibrary(categoryId, commandId);
+        `
+
+    // Add click handler for category header
+    const header = element.querySelector('h4')
+    header.addEventListener('click', () => {
+      this.toggleCommandCategory(categoryId, element)
+    })
+
+    // Add click handlers for commands
+    element.addEventListener('click', (e) => {
+      if (e.target.classList.contains('command-item')) {
+        const commandId = e.target.dataset.command
+        this.addCommandFromLibrary(categoryId, commandId)
+      }
+    })
+
+    return element
+  }
+
+  toggleCommandCategory(categoryId, element) {
+    const header = element.querySelector('h4')
+    const commands = element.querySelector('.category-commands')
+    const chevron = header.querySelector('.category-chevron')
+
+    const isCollapsed = commands.classList.contains('collapsed')
+    const storageKey = `commandCategory_${categoryId}_collapsed`
+
+    if (isCollapsed) {
+      commands.classList.remove('collapsed')
+      header.classList.remove('collapsed')
+      chevron.style.transform = 'rotate(90deg)'
+      localStorage.setItem(storageKey, 'false')
+    } else {
+      commands.classList.add('collapsed')
+      header.classList.add('collapsed')
+      chevron.style.transform = 'rotate(0deg)'
+      localStorage.setItem(storageKey, 'true')
+    }
+  }
+
+  addCommandFromLibrary(categoryId, commandId) {
+    if (!this.selectedKey) {
+      stoUI.showToast('Please select a key first', 'warning')
+      return
+    }
+
+    const commandDef = STO_DATA.commands[categoryId].commands[commandId]
+    if (!commandDef) return
+
+    // Check if command is parameterized
+    if (commandDef.customizable && commandDef.parameters) {
+      this.showParameterModal(categoryId, commandId, commandDef)
+      return
+    }
+
+    const command = {
+      command: commandDef.command,
+      type: categoryId,
+      icon: commandDef.icon,
+      text: commandDef.name,
+      id: this.generateCommandId(),
+    }
+
+    this.addCommand(this.selectedKey, command)
+  }
+
+  setupDragAndDrop() {
+    const commandList = document.getElementById('commandList')
+    if (!commandList) return
+
+    stoUI.initDragAndDrop(commandList, {
+      dragSelector: '.command-item-row',
+      dropZoneSelector: '.command-item-row',
+      onDrop: (e, dragState, dropZone) => {
+        if (!this.selectedKey) return
+
+        const fromIndex = parseInt(dragState.dragElement.dataset.index)
+        const toIndex = parseInt(dropZone.dataset.index)
+
+        if (fromIndex !== toIndex) {
+          this.moveCommand(this.selectedKey, fromIndex, toIndex)
+        }
+      },
+    })
+  }
+
+  updateChainActions() {
+    const hasSelectedKey = !!this.selectedKey
+
+    // Enable/disable buttons based on selection
+    // Note: addAliasBtn is not included because aliases are independent of key selection
+    const buttonsToToggle = [
+      'addCommandBtn',
+      'addFromTemplateBtn',
+      'importFromKeyBtn',
+      'deleteKeyBtn',
+      'duplicateKeyBtn',
+    ]
+
+    buttonsToToggle.forEach((btnId) => {
+      const btn = document.getElementById(btnId)
+      if (btn) {
+        btn.disabled = !hasSelectedKey
+      }
+    })
+  }
+
+  // Event Handlers
+  setupEventListeners() {
+    // Profile management
+    const profileSelect = document.getElementById('profileSelect')
+    profileSelect?.addEventListener('change', (e) => {
+      this.switchProfile(e.target.value)
+    })
+
+    // Mode switching
+    document.querySelectorAll('.mode-btn').forEach((btn) => {
+      btn.addEventListener('click', (e) => {
+        const mode = e.target.dataset.mode
+        this.switchMode(mode)
+      })
+    })
+
+    // File operations
+    eventBus.onDom('openProjectBtn', 'click', 'project-open', () => {
+      this.openProject()
+    })
+
+    eventBus.onDom('saveProjectBtn', 'click', 'project-save', () => {
+      this.saveProject()
+    })
+
+    eventBus.onDom('exportKeybindsBtn', 'click', 'keybinds-export', () => {
+      this.exportKeybinds()
+    })
+
+    // Vertigo VFX manager
+    eventBus.onDom('vertigoBtn', 'click', 'vertigo-open', () => {
+      this.showVertigoModal()
+    })
+
+    // Key management
+    eventBus.onDom('addKeyBtn', 'click', 'key-add', () => {
+      this.showKeySelectionModal()
+    })
+
+    eventBus.onDom('deleteKeyBtn', 'click', 'key-delete', () => {
+      if (this.selectedKey) {
+        this.confirmDeleteKey(this.selectedKey)
+      }
+    })
+
+    eventBus.onDom('duplicateKeyBtn', 'click', 'key-duplicate', () => {
+      if (this.selectedKey) {
+        this.duplicateKey(this.selectedKey)
+      }
+    })
+
+    // Command management
+    eventBus.onDom('addCommandBtn', 'click', 'command-add', () => {
+      modalManager.show('addCommandModal')
+    })
+
+    eventBus.onDom(
+      'addFromTemplateBtn',
+      'click',
+      'command-add-template',
+      () => {
+        this.showTemplateModal()
+      }
+    )
+
+    eventBus.onDom('clearChainBtn', 'click', 'command-chain-clear', () => {
+      if (this.selectedKey) {
+        this.confirmClearChain(this.selectedKey)
+      }
+    })
+
+    eventBus.onDom(
+      'validateChainBtn',
+      'click',
+      'command-chain-validate',
+      () => {
+        this.validateCurrentChain()
+      }
+    )
+
+    // Stabilization checkbox
+    eventBus.onDom(
+      'stabilizeExecutionOrder',
+      'change',
+      'stabilize-change',
+      (e) => {
+        // Persist stabilization flag to stored profile (environment-scoped)
+        if (this.selectedKey) {
+          const env = this.currentEnvironment
+          const storedProfile = stoStorage.getProfile(this.currentProfile)
+          if (storedProfile) {
+            if (!storedProfile.keybindMetadata) {
+              storedProfile.keybindMetadata = {}
             }
-        });
-        
-        return element;
-    }
-
-    toggleCommandCategory(categoryId, element) {
-        const header = element.querySelector('h4');
-        const commands = element.querySelector('.category-commands');
-        const chevron = header.querySelector('.category-chevron');
-        
-        const isCollapsed = commands.classList.contains('collapsed');
-        const storageKey = `commandCategory_${categoryId}_collapsed`;
-        
-        if (isCollapsed) {
-            commands.classList.remove('collapsed');
-            header.classList.remove('collapsed');
-            chevron.style.transform = 'rotate(90deg)';
-            localStorage.setItem(storageKey, 'false');
-        } else {
-            commands.classList.add('collapsed');
-            header.classList.add('collapsed');
-            chevron.style.transform = 'rotate(0deg)';
-            localStorage.setItem(storageKey, 'true');
-        }
-    }
-
-    addCommandFromLibrary(categoryId, commandId) {
-        if (!this.selectedKey) {
-            stoUI.showToast('Please select a key first', 'warning');
-            return;
-        }
-        
-        const commandDef = STO_DATA.commands[categoryId].commands[commandId];
-        if (!commandDef) return;
-        
-        // Check if command is parameterized
-        if (commandDef.customizable && commandDef.parameters) {
-            this.showParameterModal(categoryId, commandId, commandDef);
-            return;
-        }
-        
-        const command = {
-            command: commandDef.command,
-            type: categoryId,
-            icon: commandDef.icon,
-            text: commandDef.name,
-            id: this.generateCommandId()
-        };
-        
-        this.addCommand(this.selectedKey, command);
-    }
-
-    setupDragAndDrop() {
-        const commandList = document.getElementById('commandList');
-        if (!commandList) return;
-        
-        stoUI.initDragAndDrop(commandList, {
-            dragSelector: '.command-item-row',
-            dropZoneSelector: '.command-item-row',
-            onDrop: (e, dragState, dropZone) => {
-                if (!this.selectedKey) return;
-                
-                const fromIndex = parseInt(dragState.dragElement.dataset.index);
-                const toIndex = parseInt(dropZone.dataset.index);
-                
-                if (fromIndex !== toIndex) {
-                    this.moveCommand(this.selectedKey, fromIndex, toIndex);
-                }
+            if (!storedProfile.keybindMetadata[env]) {
+              storedProfile.keybindMetadata[env] = {}
             }
-        });
-    }
-
-    updateChainActions() {
-        const hasSelectedKey = !!this.selectedKey;
-        
-        // Enable/disable buttons based on selection
-        // Note: addAliasBtn is not included because aliases are independent of key selection
-        const buttonsToToggle = [
-            'addCommandBtn',
-            'addFromTemplateBtn', 
-            'importFromKeyBtn',
-            'deleteKeyBtn',
-            'duplicateKeyBtn'
-        ];
-        
-        buttonsToToggle.forEach(btnId => {
-            const btn = document.getElementById(btnId);
-            if (btn) {
-                btn.disabled = !hasSelectedKey;
+            if (!storedProfile.keybindMetadata[env][this.selectedKey]) {
+              storedProfile.keybindMetadata[env][this.selectedKey] = {}
             }
-        });
-    }
+            storedProfile.keybindMetadata[env][
+              this.selectedKey
+            ].stabilizeExecutionOrder = e.target.checked
 
-    // Event Handlers
-    setupEventListeners() {
-        // Profile management
-        const profileSelect = document.getElementById('profileSelect');
-        profileSelect?.addEventListener('change', (e) => {
-            this.switchProfile(e.target.value);
-        });
-        
-        // Mode switching
-        document.querySelectorAll('.mode-btn').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const mode = e.target.dataset.mode;
-                this.switchMode(mode);
-            });
-        });
-        
-        // File operations
-        eventBus.onDom('openProjectBtn', 'click', 'project-open', () => {
-            this.openProject();
-        });
-        
-        eventBus.onDom('saveProjectBtn', 'click', 'project-save', () => {
-            this.saveProject();
-        });
-        
-        eventBus.onDom('exportKeybindsBtn', 'click', 'keybinds-export', () => {
-            this.exportKeybinds();
-        });
-        
-        // Vertigo VFX manager
-        eventBus.onDom('vertigoBtn', 'click', 'vertigo-open', () => {
-            this.showVertigoModal();
-        });
-        
-        // Key management
-        eventBus.onDom('addKeyBtn', 'click', 'key-add', () => {
-            this.showKeySelectionModal();
-        });
-        
-        eventBus.onDom('deleteKeyBtn', 'click', 'key-delete', () => {
-            if (this.selectedKey) {
-                this.confirmDeleteKey(this.selectedKey);
+            // Save immediately and mark modified
+            stoStorage.saveProfile(this.currentProfile, storedProfile)
+            this.setModified(true)
+          }
+        }
+        this.renderCommandChain() // Update preview when checkbox changes
+      }
+    )
+
+    // Search and filter
+    eventBus.onDom('keyFilter', 'input', 'key-filter', (e) => {
+      this.filterKeys(e.target.value)
+    })
+
+    eventBus.onDom('commandSearch', 'input', 'command-search', (e) => {
+      this.filterCommands(e.target.value)
+    })
+
+    eventBus.onDom('showAllKeysBtn', 'click', 'show-all-keys', () => {
+      this.showAllKeys()
+    })
+
+    // Key view toggle
+    eventBus.onDom('toggleKeyViewBtn', 'click', 'toggle-key-view', () => {
+      this.toggleKeyView()
+    })
+
+    // Library toggle
+    eventBus.onDom('toggleLibraryBtn', 'click', 'toggle-library', () => {
+      this.toggleLibrary()
+    })
+
+    // Modal handlers
+    this.setupModalHandlers()
+
+    // Auto-save
+    setInterval(() => {
+      if (this.isModified) {
+        this.saveData()
+      }
+    }, 30000) // Auto-save every 30 seconds
+  }
+
+  setupModalHandlers() {
+    // Add Key Modal
+    eventBus.onDom('confirmAddKeyBtn', 'click', 'key-add-confirm', () => {
+      const keyName = document.getElementById('newKeyName')?.value.trim()
+      if (keyName) {
+        this.addKey(keyName)
+        modalManager.hide('addKeyModal')
+      }
+    })
+
+    // Key suggestions
+    document.querySelectorAll('.key-suggestion').forEach((btn) => {
+      btn.addEventListener('click', (e) => {
+        const keyName = e.target.dataset.key
+        const input = document.getElementById('newKeyName')
+        if (input) {
+          input.value = keyName
+        }
+      })
+    })
+
+    // Add Command Modal
+    eventBus.onDom('saveCommandBtn', 'click', 'command-save', () => {
+      this.saveCommandFromModal()
+    })
+
+    // Modal close handlers
+    document.querySelectorAll('.modal-close, [data-modal]').forEach((btn) => {
+      btn.addEventListener('click', (e) => {
+        const modalId =
+          e.target.dataset.modal || e.target.closest('button').dataset.modal
+        if (modalId) {
+          modalManager.hide(modalId)
+
+          // Handle Vertigo modal cancellation - rollback to initial state
+          if (modalId === 'vertigoModal') {
+            // Only rollback if we're not in the middle of saving
+            if (this.vertigoInitialState && !this.vertigoSaving) {
+              vertigoManager.selectedEffects.space = new Set(
+                this.vertigoInitialState.selectedEffects.space
+              )
+              vertigoManager.selectedEffects.ground = new Set(
+                this.vertigoInitialState.selectedEffects.ground
+              )
+              vertigoManager.showPlayerSay =
+                this.vertigoInitialState.showPlayerSay
             }
-        });
-        
-        eventBus.onDom('duplicateKeyBtn', 'click', 'key-duplicate', () => {
-            if (this.selectedKey) {
-                this.duplicateKey(this.selectedKey);
+
+            // Clean up stored state
+            delete this.vertigoInitialState
+            this.vertigoSaving = false
+          }
+        }
+      })
+    })
+  }
+
+  // Utility Methods
+  saveProfile() {
+    const virtualProfile = this.getCurrentProfile()
+
+    if (!virtualProfile) {
+      return
+    }
+
+    // Save current build data to the proper structure
+    this.saveCurrentBuild()
+
+    // Get the actual stored profile structure AFTER saveCurrentBuild
+    const actualProfile = stoStorage.getProfile(this.currentProfile)
+    if (!actualProfile) {
+      return
+    }
+
+    // Update profile-level data (aliases, metadata, etc.) from virtual profile
+    // but preserve the builds structure that was just saved
+    const updatedProfile = {
+      ...actualProfile, // Keep the actual structure with builds (now includes saved keybinds)
+      // Update profile-level fields from virtual profile
+      name: virtualProfile.name,
+      description: virtualProfile.description || actualProfile.description,
+      aliases: virtualProfile.aliases || {},
+      keybindMetadata:
+        virtualProfile.keybindMetadata || actualProfile.keybindMetadata,
+      // Preserve existing profile fields
+      created: actualProfile.created,
+      lastModified: new Date().toISOString(),
+      currentEnvironment: this.currentEnvironment,
+    }
+
+    stoStorage.saveProfile(this.currentProfile, updatedProfile)
+  }
+
+  switchMode(mode) {
+    if (this.currentEnvironment !== mode) {
+      // Save current build before switching
+      this.saveCurrentBuild()
+
+      this.currentEnvironment = mode
+
+      // Update profile's current environment
+      const profile = stoStorage.getProfile(this.currentProfile)
+      if (profile) {
+        profile.currentEnvironment = mode
+        stoStorage.saveProfile(this.currentProfile, profile)
+      }
+
+      // Update UI button states
+      this.updateModeButtons()
+
+      this.updateProfileInfo()
+      this.renderKeyGrid()
+      this.renderCommandChain()
+      this.filterCommandLibrary() // Apply environment filter to command library
+      this.setModified(true)
+
+      stoUI.showToast(`Switched to ${mode} mode`, 'success')
+    }
+  }
+
+  updateModeButtons() {
+    // Update the active state of mode buttons
+    const spaceBtn = document.querySelector('[data-mode="space"]')
+    const groundBtn = document.querySelector('[data-mode="ground"]')
+
+    if (spaceBtn && groundBtn) {
+      spaceBtn.classList.toggle('active', this.currentEnvironment === 'space')
+      groundBtn.classList.toggle('active', this.currentEnvironment === 'ground')
+    }
+  }
+
+  saveCurrentBuild() {
+    const profile = stoStorage.getProfile(this.currentProfile)
+    const currentBuild = this.getCurrentProfile()
+
+    if (profile && currentBuild) {
+      // Ensure builds structure exists
+      if (!profile.builds) {
+        profile.builds = {
+          space: { keys: {} },
+          ground: { keys: {} },
+        }
+      }
+
+      // Save current build data
+      profile.builds[this.currentEnvironment] = {
+        keys: currentBuild.keys || {},
+        // Note: aliases are profile-level, not build-specific
+      }
+
+      stoStorage.saveProfile(this.currentProfile, profile)
+    }
+  }
+
+  async confirmDeleteKey(keyName) {
+    const confirmed = await stoUI.confirm(
+      `Are you sure you want to delete the key "${keyName}" and all its commands?`,
+      'Delete Key',
+      'danger'
+    )
+
+    if (confirmed) {
+      this.deleteKey(keyName)
+    }
+  }
+
+  async confirmClearChain(keyName) {
+    const confirmed = await stoUI.confirm(
+      `Are you sure you want to clear all commands for "${keyName}"?`,
+      'Clear Commands',
+      'warning'
+    )
+
+    if (confirmed) {
+      const profile = this.getCurrentProfile()
+      profile.keys[keyName] = []
+      this.saveCurrentBuild() // Use saveCurrentBuild for build-level data
+      this.renderCommandChain()
+      this.renderKeyGrid()
+      this.setModified(true)
+
+      stoUI.showToast(`Commands cleared for ${keyName}`, 'success')
+    }
+  }
+
+  openProject() {
+    const input = document.getElementById('fileInput')
+    input.accept = '.json'
+    input.onchange = (e) => {
+      const file = e.target.files[0]
+      if (file) {
+        const reader = new FileReader()
+        reader.onload = (e) => {
+          try {
+            const success = stoStorage.importData(e.target.result)
+            if (success) {
+              this.loadData()
+              this.renderProfiles()
+              this.renderKeyGrid()
+              this.renderCommandChain()
+              stoUI.showToast('Project loaded successfully', 'success')
+            } else {
+              stoUI.showToast('Failed to load project file', 'error')
             }
-        });
-        
-        // Command management
-        eventBus.onDom('addCommandBtn', 'click', 'command-add', () => {
-            modalManager.show('addCommandModal');
-        });
-        
-        eventBus.onDom('addFromTemplateBtn', 'click', 'command-add-template', () => {
-            this.showTemplateModal();
-        });
-        
-        eventBus.onDom('clearChainBtn', 'click', 'command-chain-clear', () => {
-            if (this.selectedKey) {
-                this.confirmClearChain(this.selectedKey);
-            }
-        });
-        
-        eventBus.onDom('validateChainBtn', 'click', 'command-chain-validate', () => {
-            this.validateCurrentChain();
-        });
-        
-        // Stabilization checkbox
-        eventBus.onDom('stabilizeExecutionOrder', 'change', 'stabilize-change', (e) => {
-            // Persist stabilization flag to stored profile (environment-scoped)
-            if (this.selectedKey) {
-                const env = this.currentEnvironment;
-                const storedProfile = stoStorage.getProfile(this.currentProfile);
-                if (storedProfile) {
-                    if (!storedProfile.keybindMetadata) {
-                        storedProfile.keybindMetadata = {};
-                    }
-                    if (!storedProfile.keybindMetadata[env]) {
-                        storedProfile.keybindMetadata[env] = {};
-                    }
-                    if (!storedProfile.keybindMetadata[env][this.selectedKey]) {
-                        storedProfile.keybindMetadata[env][this.selectedKey] = {};
-                    }
-                    storedProfile.keybindMetadata[env][this.selectedKey].stabilizeExecutionOrder = e.target.checked;
+          } catch (error) {
+            stoUI.showToast('Invalid project file', 'error')
+          }
+        }
+        reader.readAsText(file)
+      }
+    }
+    input.click()
+  }
 
-                    // Save immediately and mark modified
-                    stoStorage.saveProfile(this.currentProfile, storedProfile);
-                    this.setModified(true);
-                }
-            }
-            this.renderCommandChain(); // Update preview when checkbox changes
-        });
-        
-        // Search and filter
-        eventBus.onDom('keyFilter', 'input', 'key-filter', (e) => {
-            this.filterKeys(e.target.value);
-        });
-        
-        eventBus.onDom('commandSearch', 'input', 'command-search', (e) => {
-            this.filterCommands(e.target.value);
-        });
-        
-        eventBus.onDom('showAllKeysBtn', 'click', 'show-all-keys', () => {
-            this.showAllKeys();
-        });
-        
-        // Key view toggle
-        eventBus.onDom('toggleKeyViewBtn', 'click', 'toggle-key-view', () => {
-            this.toggleKeyView();
-        });
-        
-        // Library toggle
-        eventBus.onDom('toggleLibraryBtn', 'click', 'toggle-library', () => {
-            this.toggleLibrary();
-        });
-        
-        // Modal handlers
-        this.setupModalHandlers();
-        
-        // Auto-save
-        setInterval(() => {
-            if (this.isModified) {
-                this.saveData();
-            }
-        }, 30000); // Auto-save every 30 seconds
+  saveProject() {
+    const data = stoStorage.exportData()
+    const blob = new Blob([data], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'sto_keybinds.json'
+    a.click()
+    URL.revokeObjectURL(url)
+
+    stoUI.showToast('Project exported successfully', 'success')
+  }
+
+  exportKeybinds() {
+    const profile = this.getCurrentProfile()
+    if (!profile) return
+
+    // Generate keybind file (per-key stabilization handled within export manager)
+    const content = stoExport.generateSTOKeybindFile(profile, {
+      environment: this.currentEnvironment,
+    })
+
+    // Download the file
+    const blob = new Blob([content], { type: 'text/plain' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+
+    // Include environment in filename
+    const safeName = profile.name.replace(/[^a-zA-Z0-9]/g, '_')
+    a.download = `${safeName}_${this.currentEnvironment}_keybinds.txt`
+    a.click()
+    URL.revokeObjectURL(url)
+
+    stoUI.showToast(
+      `${this.currentEnvironment} keybinds exported successfully`,
+      'success'
+    )
+  }
+
+  isFirstTime() {
+    return !localStorage.getItem('sto_keybind_manager_visited')
+  }
+
+  showWelcomeMessage() {
+    localStorage.setItem('sto_keybind_manager_visited', 'true')
+    modalManager.show('aboutModal')
+  }
+
+  // Additional Methods
+  duplicateKey(keyName) {
+    const profile = this.getCurrentProfile()
+    const commands = profile.keys[keyName]
+
+    if (!commands || commands.length === 0) {
+      stoUI.showToast('No commands to duplicate', 'warning')
+      return
     }
 
-    setupModalHandlers() {
-        // Add Key Modal
-        eventBus.onDom('confirmAddKeyBtn', 'click', 'key-add-confirm', () => {
-            const keyName = document.getElementById('newKeyName')?.value.trim();
-            if (keyName) {
-                this.addKey(keyName);
-                modalManager.hide('addKeyModal');
-            }
-        });
-        
-        // Key suggestions
-        document.querySelectorAll('.key-suggestion').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const keyName = e.target.dataset.key;
-                const input = document.getElementById('newKeyName');
-                if (input) {
-                    input.value = keyName;
-                }
-            });
-        });
-        
-        // Add Command Modal
-        eventBus.onDom('saveCommandBtn', 'click', 'command-save', () => {
-            this.saveCommandFromModal();
-        });
-        
-        // Modal close handlers
-        document.querySelectorAll('.modal-close, [data-modal]').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const modalId = e.target.dataset.modal || e.target.closest('button').dataset.modal;
-                if (modalId) {
-                    modalManager.hide(modalId);
-                    
-                    // Handle Vertigo modal cancellation - rollback to initial state
-                    if (modalId === 'vertigoModal') {
-                        // Only rollback if we're not in the middle of saving
-                        if (this.vertigoInitialState && !this.vertigoSaving) {
-                            vertigoManager.selectedEffects.space = new Set(this.vertigoInitialState.selectedEffects.space);
-                            vertigoManager.selectedEffects.ground = new Set(this.vertigoInitialState.selectedEffects.ground);
-                            vertigoManager.showPlayerSay = this.vertigoInitialState.showPlayerSay;
-                        }
-                        
-                        // Clean up stored state
-                        delete this.vertigoInitialState;
-                        this.vertigoSaving = false;
-                    }
-                }
-            });
-        });
+    // Find a suitable new key name
+    let newKeyName = keyName + '_copy'
+    let counter = 1
+
+    while (profile.keys[newKeyName]) {
+      newKeyName = `${keyName}_copy_${counter}`
+      counter++
     }
 
-    // Utility Methods
-    saveProfile() {
-        const virtualProfile = this.getCurrentProfile();
-        
-        if (!virtualProfile) {
-            return;
-        }
-        
-        // Save current build data to the proper structure
-        this.saveCurrentBuild();
-        
-        // Get the actual stored profile structure AFTER saveCurrentBuild
-        const actualProfile = stoStorage.getProfile(this.currentProfile);
-        if (!actualProfile) {
-            return;
-        }
-        
-        // Update profile-level data (aliases, metadata, etc.) from virtual profile
-        // but preserve the builds structure that was just saved
-        const updatedProfile = {
-            ...actualProfile, // Keep the actual structure with builds (now includes saved keybinds)
-            // Update profile-level fields from virtual profile
-            name: virtualProfile.name,
-            description: virtualProfile.description || actualProfile.description,
-            aliases: virtualProfile.aliases || {},
-            keybindMetadata: virtualProfile.keybindMetadata || actualProfile.keybindMetadata,
-            // Preserve existing profile fields
-            created: actualProfile.created,
-            lastModified: new Date().toISOString(),
-            currentEnvironment: this.currentEnvironment
-        };
-        
-        stoStorage.saveProfile(this.currentProfile, updatedProfile);
+    // Clone commands
+    const clonedCommands = commands.map((cmd) => ({
+      ...cmd,
+      id: this.generateCommandId(),
+    }))
+
+    profile.keys[newKeyName] = clonedCommands
+    stoStorage.saveProfile(this.currentProfile, profile)
+    this.renderKeyGrid()
+    this.setModified(true)
+
+    stoUI.showToast(`Key "${keyName}" duplicated as "${newKeyName}"`, 'success')
+  }
+
+  showTemplateModal() {
+    stoUI.showToast('Template system coming soon', 'info')
+  }
+
+  validateCurrentChain() {
+    if (!this.selectedKey) {
+      stoUI.showToast('No key selected', 'warning')
+      return
     }
 
-    switchMode(mode) {
-        if (this.currentEnvironment !== mode) {
-            // Save current build before switching
-            this.saveCurrentBuild();
-            
-            this.currentEnvironment = mode;
-            
-            // Update profile's current environment
-            const profile = stoStorage.getProfile(this.currentProfile);
-            if (profile) {
-                profile.currentEnvironment = mode;
-                stoStorage.saveProfile(this.currentProfile, profile);
-            }
-            
-            // Update UI button states
-            this.updateModeButtons();
-            
-            this.updateProfileInfo();
-            this.renderKeyGrid();
-            this.renderCommandChain();
-            this.filterCommandLibrary(); // Apply environment filter to command library
-            this.setModified(true);
-            
-            stoUI.showToast(`Switched to ${mode} mode`, 'success');
-        }
-    }
-    
-    updateModeButtons() {
-        // Update the active state of mode buttons
-        const spaceBtn = document.querySelector('[data-mode="space"]');
-        const groundBtn = document.querySelector('[data-mode="ground"]');
-        
-        if (spaceBtn && groundBtn) {
-            spaceBtn.classList.toggle('active', this.currentEnvironment === 'space');
-            groundBtn.classList.toggle('active', this.currentEnvironment === 'ground');
-        }
+    const profile = this.getCurrentProfile()
+    const commands = profile.keys[this.selectedKey] || []
+
+    if (commands.length === 0) {
+      stoUI.showToast('No commands to validate', 'warning')
+      return
     }
 
-    saveCurrentBuild() {
-        const profile = stoStorage.getProfile(this.currentProfile);
-        const currentBuild = this.getCurrentProfile();
-        
-        if (profile && currentBuild) {
-            // Ensure builds structure exists
-            if (!profile.builds) {
-                profile.builds = {
-                    space: { keys: {} },
-                    ground: { keys: {} }
-                };
-            }
-            
-            // Save current build data
-            profile.builds[this.currentEnvironment] = {
-                keys: currentBuild.keys || {}
-                // Note: aliases are profile-level, not build-specific
-            };
-            
-            stoStorage.saveProfile(this.currentProfile, profile);
-        }
+    const validation = stoKeybinds.validateKeybind(this.selectedKey, commands)
+
+    if (validation.valid) {
+      stoUI.showToast('Command chain is valid', 'success')
+    } else {
+      const errorMsg = 'Validation errors:\n' + validation.errors.join('\n')
+      stoUI.showToast(errorMsg, 'error', 5000)
+    }
+  }
+
+  filterKeys(filter) {
+    const filterLower = filter.toLowerCase()
+
+    // Filter grid view keys (.key-item)
+    const keyItems = document.querySelectorAll('.key-item')
+    keyItems.forEach((item) => {
+      const keyName = item.dataset.key.toLowerCase()
+      const visible = !filter || keyName.includes(filterLower)
+      item.style.display = visible ? 'flex' : 'none'
+    })
+
+    // Filter categorized/key-type view keys (.command-item[data-key])
+    const commandItems = document.querySelectorAll('.command-item[data-key]')
+    commandItems.forEach((item) => {
+      const keyName = item.dataset.key.toLowerCase()
+      const visible = !filter || keyName.includes(filterLower)
+      item.style.display = visible ? 'flex' : 'none'
+    })
+
+    // Hide/show categories based on whether they have visible keys
+    const categories = document.querySelectorAll('.category')
+    categories.forEach((category) => {
+      const visibleKeys = category.querySelectorAll(
+        '.command-item[data-key]:not([style*="display: none"])'
+      )
+      const categoryVisible = !filter || visibleKeys.length > 0
+      category.style.display = categoryVisible ? 'block' : 'none'
+    })
+  }
+
+  filterCommands(filter) {
+    const commandItems = document.querySelectorAll('.command-item')
+    const filterLower = filter.toLowerCase()
+
+    // Filter command items
+    commandItems.forEach((item) => {
+      const text = item.textContent.toLowerCase()
+      const visible = !filter || text.includes(filterLower)
+      item.style.display = visible ? 'flex' : 'none'
+    })
+
+    // Hide/show categories based on whether they have visible commands
+    const categories = document.querySelectorAll('.category')
+    categories.forEach((category) => {
+      const visibleCommands = category.querySelectorAll(
+        '.command-item:not([style*="display: none"])'
+      )
+      const categoryVisible = !filter || visibleCommands.length > 0
+      category.style.display = categoryVisible ? 'block' : 'none'
+    })
+  }
+
+  showAllKeys() {
+    // Show all grid view keys
+    const keyItems = document.querySelectorAll('.key-item')
+    keyItems.forEach((item) => {
+      item.style.display = 'flex'
+    })
+
+    // Show all categorized/key-type view keys
+    const commandItems = document.querySelectorAll('.command-item[data-key]')
+    commandItems.forEach((item) => {
+      item.style.display = 'flex'
+    })
+
+    // Show all categories
+    const categories = document.querySelectorAll('.category')
+    categories.forEach((category) => {
+      category.style.display = 'block'
+    })
+
+    const filterInput = document.getElementById('keyFilter')
+    if (filterInput) {
+      filterInput.value = ''
+    }
+  }
+
+  toggleLibrary() {
+    const content = document.getElementById('libraryContent')
+    const btn = document.getElementById('toggleLibraryBtn')
+
+    if (content && btn) {
+      const isCollapsed = content.style.display === 'none'
+      content.style.display = isCollapsed ? 'block' : 'none'
+
+      const icon = btn.querySelector('i')
+      if (icon) {
+        icon.className = isCollapsed
+          ? 'fas fa-chevron-up'
+          : 'fas fa-chevron-down'
+      }
+    }
+  }
+
+  saveCommandFromModal() {
+    if (!this.selectedKey) {
+      stoUI.showToast('Please select a key first', 'warning')
+      return
     }
 
-    async confirmDeleteKey(keyName) {
-        const confirmed = await stoUI.confirm(
-            `Are you sure you want to delete the key "${keyName}" and all its commands?`,
-            'Delete Key',
-            'danger'
-        );
-        
-        if (confirmed) {
-            this.deleteKey(keyName);
-        }
+    const command = stoCommands.getCurrentCommand()
+    if (!command) {
+      stoUI.showToast('Please configure a command', 'warning')
+      return
     }
 
-    async confirmClearChain(keyName) {
-        const confirmed = await stoUI.confirm(
-            `Are you sure you want to clear all commands for "${keyName}"?`,
-            'Clear Commands',
-            'warning'
-        );
-        
-        if (confirmed) {
-            const profile = this.getCurrentProfile();
-            profile.keys[keyName] = [];
-            this.saveCurrentBuild(); // Use saveCurrentBuild for build-level data
-            this.renderCommandChain();
-            this.renderKeyGrid();
-            this.setModified(true);
-            
-            stoUI.showToast(`Commands cleared for ${keyName}`, 'success');
-        }
+    const validation = stoCommands.validateCommand(command)
+    if (!validation.valid) {
+      stoUI.showToast(validation.error, 'error')
+      return
     }
 
-    openProject() {
-        const input = document.getElementById('fileInput');
-        input.accept = '.json';
-        input.onchange = (e) => {
-            const file = e.target.files[0];
-            if (file) {
-                const reader = new FileReader();
-                reader.onload = (e) => {
-                    try {
-                        const success = stoStorage.importData(e.target.result);
-                        if (success) {
-                            this.loadData();
-                            this.renderProfiles();
-                            this.renderKeyGrid();
-                            this.renderCommandChain();
-                            stoUI.showToast('Project loaded successfully', 'success');
-                        } else {
-                            stoUI.showToast('Failed to load project file', 'error');
-                        }
-                    } catch (error) {
-                        stoUI.showToast('Invalid project file', 'error');
-                    }
-                };
-                reader.readAsText(file);
-            }
-        };
-        input.click();
+    this.addCommand(this.selectedKey, command)
+    modalManager.hide('addCommandModal')
+  }
+
+  // Parameter Modal for Customizable Commands
+  showParameterModal(categoryId, commandId, commandDef) {
+    this.currentParameterCommand = { categoryId, commandId, commandDef }
+
+    // Create modal if it doesn't exist
+    if (!document.getElementById('parameterModal')) {
+      this.createParameterModal()
     }
 
-    saveProject() {
-        const data = stoStorage.exportData();
-        const blob = new Blob([data], { type: 'application/json' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = 'sto_keybinds.json';
-        a.click();
-        URL.revokeObjectURL(url);
-        
-        stoUI.showToast('Project exported successfully', 'success');
-    }
+    // Populate modal with parameter inputs
+    this.populateParameterModal(commandDef)
 
-    exportKeybinds() {
-        const profile = this.getCurrentProfile();
-        if (!profile) return;
+    // Show modal
+    modalManager.show('parameterModal')
+  }
 
-        // Generate keybind file (per-key stabilization handled within export manager)
-        const content = stoExport.generateSTOKeybindFile(profile, { environment: this.currentEnvironment });
-
-        // Download the file
-        const blob = new Blob([content], { type: 'text/plain' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-
-        // Include environment in filename
-        const safeName = profile.name.replace(/[^a-zA-Z0-9]/g, '_');
-        a.download = `${safeName}_${this.currentEnvironment}_keybinds.txt`;
-        a.click();
-        URL.revokeObjectURL(url);
-
-        stoUI.showToast(`${this.currentEnvironment} keybinds exported successfully`, 'success');
-    }
-
-    isFirstTime() {
-        return !localStorage.getItem('sto_keybind_manager_visited');
-    }
-
-    showWelcomeMessage() {
-        localStorage.setItem('sto_keybind_manager_visited', 'true');
-        modalManager.show('aboutModal');
-    }
-
-    // Additional Methods
-    duplicateKey(keyName) {
-        const profile = this.getCurrentProfile();
-        const commands = profile.keys[keyName];
-        
-        if (!commands || commands.length === 0) {
-            stoUI.showToast('No commands to duplicate', 'warning');
-            return;
-        }
-        
-        // Find a suitable new key name
-        let newKeyName = keyName + '_copy';
-        let counter = 1;
-        
-        while (profile.keys[newKeyName]) {
-            newKeyName = `${keyName}_copy_${counter}`;
-            counter++;
-        }
-        
-        // Clone commands
-        const clonedCommands = commands.map(cmd => ({
-            ...cmd,
-            id: this.generateCommandId()
-        }));
-        
-        profile.keys[newKeyName] = clonedCommands;
-        stoStorage.saveProfile(this.currentProfile, profile);
-        this.renderKeyGrid();
-        this.setModified(true);
-        
-        stoUI.showToast(`Key "${keyName}" duplicated as "${newKeyName}"`, 'success');
-    }
-    
-    showTemplateModal() {
-        stoUI.showToast('Template system coming soon', 'info');
-    }
-    
-    validateCurrentChain() {
-        if (!this.selectedKey) {
-            stoUI.showToast('No key selected', 'warning');
-            return;
-        }
-        
-        const profile = this.getCurrentProfile();
-        const commands = profile.keys[this.selectedKey] || [];
-        
-        if (commands.length === 0) {
-            stoUI.showToast('No commands to validate', 'warning');
-            return;
-        }
-        
-        const validation = stoKeybinds.validateKeybind(this.selectedKey, commands);
-        
-        if (validation.valid) {
-            stoUI.showToast('Command chain is valid', 'success');
-        } else {
-            const errorMsg = 'Validation errors:\n' + validation.errors.join('\n');
-            stoUI.showToast(errorMsg, 'error', 5000);
-        }
-    }
-    
-    filterKeys(filter) {
-        const filterLower = filter.toLowerCase();
-        
-        // Filter grid view keys (.key-item)
-        const keyItems = document.querySelectorAll('.key-item');
-        keyItems.forEach(item => {
-            const keyName = item.dataset.key.toLowerCase();
-            const visible = !filter || keyName.includes(filterLower);
-            item.style.display = visible ? 'flex' : 'none';
-        });
-        
-        // Filter categorized/key-type view keys (.command-item[data-key])
-        const commandItems = document.querySelectorAll('.command-item[data-key]');
-        commandItems.forEach(item => {
-            const keyName = item.dataset.key.toLowerCase();
-            const visible = !filter || keyName.includes(filterLower);
-            item.style.display = visible ? 'flex' : 'none';
-        });
-        
-        // Hide/show categories based on whether they have visible keys
-        const categories = document.querySelectorAll('.category');
-        categories.forEach(category => {
-            const visibleKeys = category.querySelectorAll('.command-item[data-key]:not([style*="display: none"])');
-            const categoryVisible = !filter || visibleKeys.length > 0;
-            category.style.display = categoryVisible ? 'block' : 'none';
-        });
-    }
-    
-    filterCommands(filter) {
-        const commandItems = document.querySelectorAll('.command-item');
-        const filterLower = filter.toLowerCase();
-        
-        // Filter command items
-        commandItems.forEach(item => {
-            const text = item.textContent.toLowerCase();
-            const visible = !filter || text.includes(filterLower);
-            item.style.display = visible ? 'flex' : 'none';
-        });
-        
-        // Hide/show categories based on whether they have visible commands
-        const categories = document.querySelectorAll('.category');
-        categories.forEach(category => {
-            const visibleCommands = category.querySelectorAll('.command-item:not([style*="display: none"])');
-            const categoryVisible = !filter || visibleCommands.length > 0;
-            category.style.display = categoryVisible ? 'block' : 'none';
-        });
-    }
-    
-    showAllKeys() {
-        // Show all grid view keys
-        const keyItems = document.querySelectorAll('.key-item');
-        keyItems.forEach(item => {
-            item.style.display = 'flex';
-        });
-        
-        // Show all categorized/key-type view keys
-        const commandItems = document.querySelectorAll('.command-item[data-key]');
-        commandItems.forEach(item => {
-            item.style.display = 'flex';
-        });
-        
-        // Show all categories
-        const categories = document.querySelectorAll('.category');
-        categories.forEach(category => {
-            category.style.display = 'block';
-        });
-        
-        const filterInput = document.getElementById('keyFilter');
-        if (filterInput) {
-            filterInput.value = '';
-        }
-    }
-    
-    toggleLibrary() {
-        const content = document.getElementById('libraryContent');
-        const btn = document.getElementById('toggleLibraryBtn');
-        
-        if (content && btn) {
-            const isCollapsed = content.style.display === 'none';
-            content.style.display = isCollapsed ? 'block' : 'none';
-            
-            const icon = btn.querySelector('i');
-            if (icon) {
-                icon.className = isCollapsed ? 'fas fa-chevron-up' : 'fas fa-chevron-down';
-            }
-        }
-    }
-    
-    saveCommandFromModal() {
-        if (!this.selectedKey) {
-            stoUI.showToast('Please select a key first', 'warning');
-            return;
-        }
-        
-        const command = stoCommands.getCurrentCommand();
-        if (!command) {
-            stoUI.showToast('Please configure a command', 'warning');
-            return;
-        }
-        
-        const validation = stoCommands.validateCommand(command);
-        if (!validation.valid) {
-            stoUI.showToast(validation.error, 'error');
-            return;
-        }
-        
-        this.addCommand(this.selectedKey, command);
-        modalManager.hide('addCommandModal');
-    }
-    
-    // Parameter Modal for Customizable Commands
-    showParameterModal(categoryId, commandId, commandDef) {
-        this.currentParameterCommand = { categoryId, commandId, commandDef };
-        
-        // Create modal if it doesn't exist
-        if (!document.getElementById('parameterModal')) {
-            this.createParameterModal();
-        }
-        
-        // Populate modal with parameter inputs
-        this.populateParameterModal(commandDef);
-        
-        // Show modal
-        modalManager.show('parameterModal');
-    }
-    
-    createParameterModal() {
-        const modal = document.createElement('div');
-        modal.className = 'modal';
-        modal.id = 'parameterModal';
-        modal.innerHTML = `
+  createParameterModal() {
+    const modal = document.createElement('div')
+    modal.className = 'modal'
+    modal.id = 'parameterModal'
+    modal.innerHTML = `
             <div class="modal-content">
                 <div class="modal-header">
                     <h3 id="parameterModalTitle">Configure Command Parameters</h3>
@@ -1924,1359 +2080,1528 @@ export default class STOToolsKeybindManager {
                     <button class="btn btn-secondary" data-modal="parameterModal">Cancel</button>
                 </div>
             </div>
-        `;
-        
-        document.body.appendChild(modal);
-        
-        // Add event listeners
-        eventBus.onDom('saveParameterCommandBtn', 'click', 'parameter-command-save', () => {
-            this.saveParameterCommand();
-        });
-        
-        // Close modal handlers - handle both X button and Cancel button
-        const closeButtons = modal.querySelectorAll('.modal-close, [data-modal="parameterModal"]');
-        closeButtons.forEach(button => {
-            button.addEventListener('click', () => {
-                this.cancelParameterCommand();
-            });
-        });
+        `
+
+    document.body.appendChild(modal)
+
+    // Add event listeners
+    eventBus.onDom(
+      'saveParameterCommandBtn',
+      'click',
+      'parameter-command-save',
+      () => {
+        this.saveParameterCommand()
+      }
+    )
+
+    // Close modal handlers - handle both X button and Cancel button
+    const closeButtons = modal.querySelectorAll(
+      '.modal-close, [data-modal="parameterModal"]'
+    )
+    closeButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        this.cancelParameterCommand()
+      })
+    })
+  }
+
+  cancelParameterCommand() {
+    // Clean up state
+    this.currentParameterCommand = null
+
+    // Reset modal button text in case we were editing
+    const saveBtn = document.getElementById('saveParameterCommandBtn')
+    if (saveBtn) {
+      saveBtn.textContent = 'Add Command'
     }
-    
-    cancelParameterCommand() {
-        // Clean up state
-        this.currentParameterCommand = null;
-        
-        // Reset modal button text in case we were editing
-        const saveBtn = document.getElementById('saveParameterCommandBtn');
-        if (saveBtn) {
-            saveBtn.textContent = 'Add Command';
+
+    // Hide modal
+    modalManager.hide('parameterModal')
+  }
+
+  populateParameterModal(commandDef) {
+    const container = document.getElementById('parameterInputs')
+    const titleElement = document.getElementById('parameterModalTitle')
+
+    titleElement.textContent = `Configure: ${commandDef.name}`
+    container.innerHTML = ''
+
+    // Create input for each parameter
+    Object.entries(commandDef.parameters).forEach(([paramName, paramDef]) => {
+      const inputGroup = document.createElement('div')
+      inputGroup.className = 'form-group'
+
+      const label = document.createElement('label')
+      label.textContent = this.formatParameterName(paramName)
+      label.setAttribute('for', `param_${paramName}`)
+
+      let input // Declare input variable outside the if/else blocks
+
+      // For message parameters, create input with $Target button
+      if (paramName === 'message') {
+        const inputContainer = document.createElement('div')
+        inputContainer.className = 'input-with-button'
+
+        input = document.createElement('input')
+        input.type = 'text'
+        input.id = `param_${paramName}`
+        input.name = paramName
+        input.value = paramDef.default || ''
+
+        if (paramDef.placeholder) {
+          input.placeholder = paramDef.placeholder
         }
-        
-        // Hide modal
-        modalManager.hide('parameterModal');
-    }
-    
-    populateParameterModal(commandDef) {
-        const container = document.getElementById('parameterInputs');
-        const titleElement = document.getElementById('parameterModalTitle');
-        
-        titleElement.textContent = `Configure: ${commandDef.name}`;
-        container.innerHTML = '';
-        
-        // Create input for each parameter
-        Object.entries(commandDef.parameters).forEach(([paramName, paramDef]) => {
-            const inputGroup = document.createElement('div');
-            inputGroup.className = 'form-group';
-            
-            const label = document.createElement('label');
-            label.textContent = this.formatParameterName(paramName);
-            label.setAttribute('for', `param_${paramName}`);
-            
-            let input; // Declare input variable outside the if/else blocks
-            
-            // For message parameters, create input with $Target button
-            if (paramName === 'message') {
-                const inputContainer = document.createElement('div');
-                inputContainer.className = 'input-with-button';
-                
-                input = document.createElement('input');
-                input.type = 'text';
-                input.id = `param_${paramName}`;
-                input.name = paramName;
-                input.value = paramDef.default || '';
-                
-                if (paramDef.placeholder) {
-                    input.placeholder = paramDef.placeholder;
-                }
-                
-                const targetButton = document.createElement('button');
-                targetButton.type = 'button';
-                targetButton.className = 'btn btn-small insert-target-btn';
-                targetButton.title = 'Insert $Target variable';
-                targetButton.innerHTML = '<i class="fas fa-crosshairs"></i> $Target';
-                
-                inputContainer.appendChild(input);
-                inputContainer.appendChild(targetButton);
-                
-                const help = document.createElement('small');
-                help.textContent = this.getParameterHelp(paramName, paramDef);
-                
-                const variableHelp = document.createElement('div');
-                variableHelp.className = 'variable-help';
-                variableHelp.innerHTML = '<strong>$Target</strong> - Use to include your current target\'s name in the message';
-                
-                inputGroup.appendChild(label);
-                inputGroup.appendChild(inputContainer);
-                inputGroup.appendChild(help);
-                inputGroup.appendChild(variableHelp);
-                
-                // Note: Event handling is done by global event delegation in commands.js
-            } else {
-                // Handle different parameter types
-                if (paramDef.type === 'select') {
-                    // Create select dropdown
-                    input = document.createElement('select');
-                    input.id = `param_${paramName}`;
-                    input.name = paramName;
-                    
-                    // Add options
-                    paramDef.options.forEach(option => {
-                        const optionElement = document.createElement('option');
-                        optionElement.value = option;
-                        optionElement.textContent = option === 'STOTrayExecByTray' 
-                            ? 'STOTrayExecByTray (shows key binding on UI)' 
-                            : 'TrayExecByTray (no UI indication)';
-                        if (option === paramDef.default) {
-                            optionElement.selected = true;
-                        }
-                        input.appendChild(optionElement);
-                    });
-                } else {
-                    // Regular input for non-select parameters
-                    input = document.createElement('input');
-                    input.type = paramDef.type === 'number' ? 'number' : 'text';
-                    input.id = `param_${paramName}`;
-                    input.name = paramName;
-                    input.value = paramDef.default || '';
-                    
-                    if (paramDef.placeholder) {
-                        input.placeholder = paramDef.placeholder;
-                    }
-                    
-                    if (paramDef.type === 'number') {
-                        if (paramDef.min !== undefined) input.min = paramDef.min;
-                        if (paramDef.max !== undefined) input.max = paramDef.max;
-                        if (paramDef.step !== undefined) input.step = paramDef.step;
-                    }
-                }
-                
-                const help = document.createElement('small');
-                help.textContent = this.getParameterHelp(paramName, paramDef);
-                
-                inputGroup.appendChild(label);
-                inputGroup.appendChild(input);
-                inputGroup.appendChild(help);
+
+        const targetButton = document.createElement('button')
+        targetButton.type = 'button'
+        targetButton.className = 'btn btn-small insert-target-btn'
+        targetButton.title = 'Insert $Target variable'
+        targetButton.innerHTML = '<i class="fas fa-crosshairs"></i> $Target'
+
+        inputContainer.appendChild(input)
+        inputContainer.appendChild(targetButton)
+
+        const help = document.createElement('small')
+        help.textContent = this.getParameterHelp(paramName, paramDef)
+
+        const variableHelp = document.createElement('div')
+        variableHelp.className = 'variable-help'
+        variableHelp.innerHTML =
+          "<strong>$Target</strong> - Use to include your current target's name in the message"
+
+        inputGroup.appendChild(label)
+        inputGroup.appendChild(inputContainer)
+        inputGroup.appendChild(help)
+        inputGroup.appendChild(variableHelp)
+
+        // Note: Event handling is done by global event delegation in commands.js
+      } else {
+        // Handle different parameter types
+        if (paramDef.type === 'select') {
+          // Create select dropdown
+          input = document.createElement('select')
+          input.id = `param_${paramName}`
+          input.name = paramName
+
+          // Add options
+          paramDef.options.forEach((option) => {
+            const optionElement = document.createElement('option')
+            optionElement.value = option
+            optionElement.textContent =
+              option === 'STOTrayExecByTray'
+                ? 'STOTrayExecByTray (shows key binding on UI)'
+                : 'TrayExecByTray (no UI indication)'
+            if (option === paramDef.default) {
+              optionElement.selected = true
             }
-            container.appendChild(inputGroup);
-            
-            // Add real-time preview update
-            input.addEventListener('input', () => {
-                this.updateParameterPreview();
-            });
-            
-            // Also listen for 'change' event for select elements
-            if (input.tagName === 'SELECT') {
-                input.addEventListener('change', () => {
-                    this.updateParameterPreview();
-                });
-            }
-        });
-        
-        // Initial preview update
-        this.updateParameterPreview();
-    }
-    
-    formatParameterName(paramName) {
-        return paramName.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
-    }
-    
-    getParameterHelp(paramName, paramDef) {
-        const helps = {
-            entityName: 'Name of the entity to target (e.g., ship name, player name)',
-            active: 'Whether the command is active (1 = active, 0 = inactive)',
-            tray: 'Primary tray number (0-9, where 0 is the first tray)',
-            slot: 'Primary slot number (0-9, where 0 is the first slot)',
-            backup_tray: 'Backup tray number (0-9, where 0 is the first tray)',
-            backup_slot: 'Backup slot number (0-9, where 0 is the first slot)',
-            amount: 'Throttle adjustment amount (-1 to 1)',
-            position: 'Throttle position (-1 = full reverse, 0 = stop, 1 = full forward)',
-            distance: 'Camera distance from target',
-            filename: 'Name of the keybind file (without extension)',
-            message: 'Text message to send',
-            state: 'Enable (1) or disable (0) combat log',
-            command_type: 'STOTrayExecByTray shows key binding on UI, TrayExecByTray does not'
-        };
-        
-        return helps[paramName] || `${paramDef.type} value ${paramDef.min !== undefined ? `(${paramDef.min} to ${paramDef.max})` : ''}`;
-    }
-    
-    updateParameterPreview() {
-        if (!this.currentParameterCommand) return;
-        
-        const { categoryId, commandId, commandDef } = this.currentParameterCommand;
-        const params = this.getParameterValues();
-        
-        // Generate command using the command builder
-        const command = this.buildParameterizedCommand(categoryId, commandId, commandDef, params);
-        
-        const preview = document.getElementById('parameterCommandPreview');
-        if (preview && command) {
-            // Support both single and array command results
-            if (Array.isArray(command)) {
-                const commandStrings = command.map(cmd => cmd.command);
-                preview.textContent = commandStrings.join(' $$ ');
-            } else {
-                preview.textContent = command.command;
-            }
+            input.appendChild(optionElement)
+          })
+        } else {
+          // Regular input for non-select parameters
+          input = document.createElement('input')
+          input.type = paramDef.type === 'number' ? 'number' : 'text'
+          input.id = `param_${paramName}`
+          input.name = paramName
+          input.value = paramDef.default || ''
+
+          if (paramDef.placeholder) {
+            input.placeholder = paramDef.placeholder
+          }
+
+          if (paramDef.type === 'number') {
+            if (paramDef.min !== undefined) input.min = paramDef.min
+            if (paramDef.max !== undefined) input.max = paramDef.max
+            if (paramDef.step !== undefined) input.step = paramDef.step
+          }
         }
+
+        const help = document.createElement('small')
+        help.textContent = this.getParameterHelp(paramName, paramDef)
+
+        inputGroup.appendChild(label)
+        inputGroup.appendChild(input)
+        inputGroup.appendChild(help)
+      }
+      container.appendChild(inputGroup)
+
+      // Add real-time preview update
+      input.addEventListener('input', () => {
+        this.updateParameterPreview()
+      })
+
+      // Also listen for 'change' event for select elements
+      if (input.tagName === 'SELECT') {
+        input.addEventListener('change', () => {
+          this.updateParameterPreview()
+        })
+      }
+    })
+
+    // Initial preview update
+    this.updateParameterPreview()
+  }
+
+  formatParameterName(paramName) {
+    return paramName.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())
+  }
+
+  getParameterHelp(paramName, paramDef) {
+    const helps = {
+      entityName: 'Name of the entity to target (e.g., ship name, player name)',
+      active: 'Whether the command is active (1 = active, 0 = inactive)',
+      tray: 'Primary tray number (0-9, where 0 is the first tray)',
+      slot: 'Primary slot number (0-9, where 0 is the first slot)',
+      backup_tray: 'Backup tray number (0-9, where 0 is the first tray)',
+      backup_slot: 'Backup slot number (0-9, where 0 is the first slot)',
+      amount: 'Throttle adjustment amount (-1 to 1)',
+      position:
+        'Throttle position (-1 = full reverse, 0 = stop, 1 = full forward)',
+      distance: 'Camera distance from target',
+      filename: 'Name of the keybind file (without extension)',
+      message: 'Text message to send',
+      state: 'Enable (1) or disable (0) combat log',
+      command_type:
+        'STOTrayExecByTray shows key binding on UI, TrayExecByTray does not',
     }
-    
-    getParameterValues() {
-        const params = {};
-        const inputs = document.querySelectorAll('#parameterInputs input, #parameterInputs select');
-        
-        inputs.forEach(input => {
-            const paramName = input.name;
-            let value = input.value;
-            
-            if (input.type === 'number') {
-                value = parseFloat(value) || 0;
-            }
-            
-            params[paramName] = value;
-        });
-        
-        return params;
+
+    return (
+      helps[paramName] ||
+      `${paramDef.type} value ${paramDef.min !== undefined ? `(${paramDef.min} to ${paramDef.max})` : ''}`
+    )
+  }
+
+  updateParameterPreview() {
+    if (!this.currentParameterCommand) return
+
+    const { categoryId, commandId, commandDef } = this.currentParameterCommand
+    const params = this.getParameterValues()
+
+    // Generate command using the command builder
+    const command = this.buildParameterizedCommand(
+      categoryId,
+      commandId,
+      commandDef,
+      params
+    )
+
+    const preview = document.getElementById('parameterCommandPreview')
+    if (preview && command) {
+      // Support both single and array command results
+      if (Array.isArray(command)) {
+        const commandStrings = command.map((cmd) => cmd.command)
+        preview.textContent = commandStrings.join(' $$ ')
+      } else {
+        preview.textContent = command.command
+      }
     }
-    
-    buildParameterizedCommand(categoryId, commandId, commandDef, params) {
-        // Use the command builder logic from commands.js
-        const builders = {
-            targeting: (params) => {
-                if (commandId === 'target' && params.entityName) {
-                    return {
-                        command: `${commandDef.command} "${params.entityName}"`,
-                        text: `Target: ${params.entityName}`
-                    };
-                }
-                return { command: commandDef.command, text: commandDef.name };
-            },
-            tray: (params) => {
-                const tray = params.tray || 0;
-                const slot = params.slot || 0;
-                
-                if (commandId === 'tray_with_backup') {
-                    const active = params.active !== undefined ? params.active : 1;
-                    const backupTray = params.backup_tray || 0;
-                    const backupSlot = params.backup_slot || 0;
-                    
-                    return {
-                        command: `TrayExecByTrayWithBackup ${active} ${tray} ${slot} ${backupTray} ${backupSlot}`,
-                        text: `Execute Tray ${tray + 1} Slot ${slot + 1} (backup: Tray ${backupTray + 1} Slot ${backupSlot + 1})`
-                    };
-                } else if (commandId === 'tray_range') {
-                    const startTray = params.start_tray || 0;
-                    const startSlot = params.start_slot || 0;
-                    const endTray = params.end_tray || 0;
-                    const endSlot = params.end_slot || 0;
-                    const commandType = params.command_type || 'STOTrayExecByTray';
-                    
-                    const commands = stoCommands.generateTrayRangeCommands(startTray, startSlot, endTray, endSlot, commandType);
-                    
-                    // Return array of command objects with slot-specific parameters
-                    return commands.map((cmd, index) => {
-                        // Attempt to extract tray and slot numbers from the command string
-                        let trayParam, slotParam;
-                        try {
-                            const parts = cmd.replace('+', '').trim().split(/\s+/);
-                            trayParam = parseInt(parts[1]);
-                            slotParam = parseInt(parts[2]);
-                        } catch (_) {
-                            trayParam = undefined;
-                            slotParam = undefined;
-                        }
+  }
 
-                        return {
-                            command: cmd,
-                            type: categoryId,
-                            icon: commandDef.icon,
-                            text: index === 0 ? `Execute Range: Tray ${startTray + 1} Slot ${startSlot + 1} to Tray ${endTray + 1} Slot ${endSlot + 1}` : cmd,
-                            id: this.generateCommandId(),
-                            parameters: { tray: trayParam, slot: slotParam }
-                        };
-                    });
-                } else if (commandId === 'tray_range_with_backup') {
-                    const active = params.active || 1;
-                    const startTray = params.start_tray || 0;
-                    const startSlot = params.start_slot || 0;
-                    const endTray = params.end_tray || 0;
-                    const endSlot = params.end_slot || 0;
-                    const backupStartTray = params.backup_start_tray || 0;
-                    const backupStartSlot = params.backup_start_slot || 0;
-                    const backupEndTray = params.backup_end_tray || 0;
-                    const backupEndSlot = params.backup_end_slot || 0;
-                    
-                    const commands = stoCommands.generateTrayRangeWithBackupCommands(
-                        active, startTray, startSlot, endTray, endSlot,
-                        backupStartTray, backupStartSlot, backupEndTray, backupEndSlot
-                    );
-                    
-                    // Return array with parsed parameters for each command
-                    return commands.map((cmd, index) => {
-                        let activeParam, primaryTray, primarySlot, backupTrayParam, backupSlotParam;
-                        try {
-                            const parts = cmd.trim().split(/\s+/);
-                            // TrayExecByTrayWithBackup <active> <tray> <slot> <backup_tray> <backup_slot>
-                            activeParam = parseInt(parts[1]);
-                            primaryTray = parseInt(parts[2]);
-                            primarySlot = parseInt(parts[3]);
-                            backupTrayParam = parseInt(parts[4]);
-                            backupSlotParam = parseInt(parts[5]);
-                        } catch (_) {}
+  getParameterValues() {
+    const params = {}
+    const inputs = document.querySelectorAll(
+      '#parameterInputs input, #parameterInputs select'
+    )
 
-                        return {
-                            command: cmd,
-                            type: categoryId,
-                            icon: commandDef.icon,
-                            text: index === 0 ? `Execute Range with Backup: Tray ${startTray + 1}-${endTray + 1}` : cmd,
-                            id: this.generateCommandId(),
-                            parameters: {
-                                active: activeParam,
-                                tray: primaryTray,
-                                slot: primarySlot,
-                                backup_tray: backupTrayParam,
-                                backup_slot: backupSlotParam
-                            }
-                        };
-                    });
-                } else if (commandId === 'whole_tray') {
-                    const commandType = params.command_type || 'STOTrayExecByTray';
-                    const commands = stoCommands.generateWholeTrayCommands(tray, commandType);
-                    
-                    // Return array of command objects instead of single command with $$
-                    return commands.map((cmd, index) => {
-                        // Extract slot number
-                        let slotParam;
-                        try {
-                            const parts = cmd.replace('+', '').trim().split(/\s+/);
-                            slotParam = parseInt(parts[2]);
-                        } catch (_) {
-                            slotParam = undefined;
-                        }
+    inputs.forEach((input) => {
+      const paramName = input.name
+      let value = input.value
 
-                        return {
-                            command: cmd,
-                            type: categoryId,
-                            icon: commandDef.icon,
-                            text: index === 0 ? `Execute Whole Tray ${tray + 1}` : cmd,
-                            id: this.generateCommandId(),
-                            parameters: { tray, slot: slotParam }
-                        };
-                    });
-                } else if (commandId === 'whole_tray_with_backup') {
-                    const active = params.active || 1;
-                    const backupTray = params.backup_tray || 0;
-                    
-                    const commands = stoCommands.generateWholeTrayWithBackupCommands(active, tray, backupTray);
-                    
-                    // Return array with parsed parameters for each command
-                    return commands.map((cmd, index) => {
-                        let activeParam, primaryTray, primarySlot, backupTrayParam, backupSlotParam;
-                        try {
-                            const parts = cmd.trim().split(/\s+/);
-                            // TrayExecByTrayWithBackup <active> <tray> <slot> <backup_tray> <backup_slot>
-                            activeParam = parseInt(parts[1]);
-                            primaryTray = parseInt(parts[2]);
-                            primarySlot = parseInt(parts[3]);
-                            backupTrayParam = parseInt(parts[4]);
-                            backupSlotParam = parseInt(parts[5]);
-                        } catch (_) {}
+      if (input.type === 'number') {
+        value = parseFloat(value) || 0
+      }
 
-                        return {
-                            command: cmd,
-                            type: categoryId,
-                            icon: commandDef.icon,
-                            text: index === 0 ? `Execute Whole Tray ${tray + 1} (with backup Tray ${backupTray + 1})` : cmd,
-                            id: this.generateCommandId(),
-                            parameters: {
-                                active: activeParam,
-                                tray: primaryTray,
-                                slot: primarySlot,
-                                backup_tray: backupTrayParam,
-                                backup_slot: backupSlotParam
-                            }
-                        };
-                    });
-                } else {
-                    // Preserve original command format when editing
-                    const isEditing = this.currentParameterCommand && this.currentParameterCommand.isEditing;
-                    const commandType = params.command_type || 'STOTrayExecByTray';
-                    const prefix = '+';
-                    
-                    if (isEditing) {
-                        const profile = this.getCurrentProfile();
-                        const existingCommand = profile.keys[this.selectedKey][this.currentParameterCommand.editIndex];
-                        if (existingCommand && (existingCommand.command.startsWith('TrayExecByTray') || existingCommand.command.startsWith('+TrayExecByTray'))) {
-                            return {
-                                command: `+TrayExecByTray ${tray} ${slot}`,
-                                text: `Execute Tray ${tray + 1} Slot ${slot + 1}`
-                            };
-                        }
-                    }
-                    
-                    return {
-                        command: `${prefix}${commandType} ${tray} ${slot}`,
-                        text: `Execute Tray ${tray + 1} Slot ${slot + 1}`
-                    };
-                }
-            },
-            movement: (params) => {
-                let command = commandDef.command;
-                if (commandId === 'throttle_adjust' && params.amount !== undefined) {
-                    command = `${commandDef.command} ${params.amount}`;
-                } else if (commandId === 'throttle_set' && params.position !== undefined) {
-                    command = `${commandDef.command} ${params.position}`;
-                }
-                return { command, text: commandDef.name };
-            },
-            camera: (params) => {
-                let command = commandDef.command;
-                if (commandId === 'cam_distance' && params.distance !== undefined) {
-                    command = `${commandDef.command} ${params.distance}`;
-                }
-                return { command, text: commandDef.name };
-            },
-            communication: (params) => ({
-                command: `${commandDef.command} ${params.message || 'Message text here'}`,
-                text: `${commandDef.name}: ${params.message || 'Message text here'}`
-            }),
-            system: (params) => {
-                let command = commandDef.command;
-                if ((commandId === 'bind_save_file' || commandId === 'bind_load_file') && params.filename) {
-                    command = `${commandDef.command} ${params.filename}`;
-                } else if (commandId === 'combat_log' && params.state !== undefined) {
-                    command = `${commandDef.command} ${params.state}`;
-                }
-                return { command, text: commandDef.name };
-            }
-        };
-        
-        const builder = builders[categoryId];
-        if (builder) {
-            const result = builder(params);
-            // If tray (or other) builder returned an array of command objects, forward it
-            if (Array.isArray(result)) {
-                return result;
+      params[paramName] = value
+    })
+
+    return params
+  }
+
+  buildParameterizedCommand(categoryId, commandId, commandDef, params) {
+    // Use the command builder logic from commands.js
+    const builders = {
+      targeting: (params) => {
+        if (commandId === 'target' && params.entityName) {
+          return {
+            command: `${commandDef.command} "${params.entityName}"`,
+            text: `Target: ${params.entityName}`,
+          }
+        }
+        return { command: commandDef.command, text: commandDef.name }
+      },
+      tray: (params) => {
+        const tray = params.tray || 0
+        const slot = params.slot || 0
+
+        if (commandId === 'tray_with_backup') {
+          const active = params.active !== undefined ? params.active : 1
+          const backupTray = params.backup_tray || 0
+          const backupSlot = params.backup_slot || 0
+
+          return {
+            command: `TrayExecByTrayWithBackup ${active} ${tray} ${slot} ${backupTray} ${backupSlot}`,
+            text: `Execute Tray ${tray + 1} Slot ${slot + 1} (backup: Tray ${backupTray + 1} Slot ${backupSlot + 1})`,
+          }
+        } else if (commandId === 'tray_range') {
+          const startTray = params.start_tray || 0
+          const startSlot = params.start_slot || 0
+          const endTray = params.end_tray || 0
+          const endSlot = params.end_slot || 0
+          const commandType = params.command_type || 'STOTrayExecByTray'
+
+          const commands = stoCommands.generateTrayRangeCommands(
+            startTray,
+            startSlot,
+            endTray,
+            endSlot,
+            commandType
+          )
+
+          // Return array of command objects with slot-specific parameters
+          return commands.map((cmd, index) => {
+            // Attempt to extract tray and slot numbers from the command string
+            let trayParam, slotParam
+            try {
+              const parts = cmd.replace('+', '').trim().split(/\s+/)
+              trayParam = parseInt(parts[1])
+              slotParam = parseInt(parts[2])
+            } catch (_) {
+              trayParam = undefined
+              slotParam = undefined
             }
 
-            // Otherwise wrap single command
             return {
-                command: result.command,
-                type: categoryId,
-                icon: commandDef.icon,
-                text: result.text,
-                id: this.generateCommandId(),
-                parameters: params
-            };
-        }
-        
-        return null;
-    }
-    
-    saveParameterCommand() {
-        if (!this.selectedKey || !this.currentParameterCommand) return;
-        
-        const { categoryId, commandId, commandDef, editIndex, isEditing } = this.currentParameterCommand;
-        const params = this.getParameterValues();
-        
-        const command = this.buildParameterizedCommand(categoryId, commandId, commandDef, params);
-        
-        if (command) {
-            if (isEditing && editIndex !== undefined) {
-                // For arrays of commands, we need to handle replacement differently
-                if (Array.isArray(command)) {
-                    const profile = this.getCurrentProfile();
-                    const commands = profile.keys[this.selectedKey];
-                    
-                    // Remove the old command and insert the new array of commands
-                    commands.splice(editIndex, 1, ...command);
-                    
-                    stoStorage.saveProfile(this.currentProfile, profile);
-                    this.renderCommandChain();
-                    this.setModified(true);
-                    stoUI.showToast(`${command.length} commands updated successfully`, 'success');
-                } else {
-                    // Update existing single command
-                    const profile = this.getCurrentProfile();
-                    profile.keys[this.selectedKey][editIndex] = command;
-                    stoStorage.saveProfile(this.currentProfile, profile);
-                    this.renderCommandChain();
-                    this.setModified(true);
-                    stoUI.showToast('Command updated successfully', 'success');
-                }
-            } else {
-                // Add new command (addCommand already handles arrays)
-                this.addCommand(this.selectedKey, command);
+              command: cmd,
+              type: categoryId,
+              icon: commandDef.icon,
+              text:
+                index === 0
+                  ? `Execute Range: Tray ${startTray + 1} Slot ${startSlot + 1} to Tray ${endTray + 1} Slot ${endSlot + 1}`
+                  : cmd,
+              id: this.generateCommandId(),
+              parameters: { tray: trayParam, slot: slotParam },
             }
-            
-            modalManager.hide('parameterModal');
-            this.currentParameterCommand = null;
-            
-            // Reset modal button text
-            document.getElementById('saveParameterCommandBtn').textContent = 'Add Command';
-        }
-    }
-    
-    editCommand(index) {
-        if (!this.selectedKey) return;
-        
-        const profile = this.getCurrentProfile();
-        const commands = profile.keys[this.selectedKey];
-        
-        if (!commands || !commands[index]) return;
-        
-        const command = commands[index];
-        
-        // Check if this is a parameterized command that can be edited
-        if (command.parameters && command.type) {
-            // Find the original command definition
-            const commandDef = this.findCommandDefinition(command);
-            if (commandDef && commandDef.customizable) {
-                this.editParameterizedCommand(index, command, commandDef);
-                return;
+          })
+        } else if (commandId === 'tray_range_with_backup') {
+          const active = params.active || 1
+          const startTray = params.start_tray || 0
+          const startSlot = params.start_slot || 0
+          const endTray = params.end_tray || 0
+          const endSlot = params.end_slot || 0
+          const backupStartTray = params.backup_start_tray || 0
+          const backupStartSlot = params.backup_start_slot || 0
+          const backupEndTray = params.backup_end_tray || 0
+          const backupEndSlot = params.backup_end_slot || 0
+
+          const commands = stoCommands.generateTrayRangeWithBackupCommands(
+            active,
+            startTray,
+            startSlot,
+            endTray,
+            endSlot,
+            backupStartTray,
+            backupStartSlot,
+            backupEndTray,
+            backupEndSlot
+          )
+
+          // Return array with parsed parameters for each command
+          return commands.map((cmd, index) => {
+            let activeParam,
+              primaryTray,
+              primarySlot,
+              backupTrayParam,
+              backupSlotParam
+            try {
+              const parts = cmd.trim().split(/\s+/)
+              // TrayExecByTrayWithBackup <active> <tray> <slot> <backup_tray> <backup_slot>
+              activeParam = parseInt(parts[1])
+              primaryTray = parseInt(parts[2])
+              primarySlot = parseInt(parts[3])
+              backupTrayParam = parseInt(parts[4])
+              backupSlotParam = parseInt(parts[5])
+            } catch (_) {}
+
+            return {
+              command: cmd,
+              type: categoryId,
+              icon: commandDef.icon,
+              text:
+                index === 0
+                  ? `Execute Range with Backup: Tray ${startTray + 1}-${endTray + 1}`
+                  : cmd,
+              id: this.generateCommandId(),
+              parameters: {
+                active: activeParam,
+                tray: primaryTray,
+                slot: primarySlot,
+                backup_tray: backupTrayParam,
+                backup_slot: backupSlotParam,
+              },
             }
-        }
-        
-        // Also check if command is detectable as parameterized via findCommandDefinition
-        const commandDef = this.findCommandDefinition(command);
-        if (commandDef && commandDef.customizable) {
-            this.editParameterizedCommand(index, command, commandDef);
-            return;
-        }
-        
-        // For non-parameterized commands, show command details
-        stoUI.showToast(`Command: ${command.command}\nType: ${command.type}`, 'info', 3000);
-    }
-    
-    findCommandDefinition(command) {
-        // Special handling for tray execution commands - detect by command string
-        if (command.command.includes('TrayExec')) {
-            const trayCategory = STO_DATA.commands.tray;
-            if (trayCategory) {
-                // Check for multiple TrayExecByTrayWithBackup commands (range with backup)
-                if (command.command.includes('TrayExecByTrayWithBackup') && command.command.includes('$$')) {
-                    const parts = command.command.split('$$').map(s => s.trim());
-                    if (parts.length > 1) {
-                        const trayRangeWithBackupDef = trayCategory.commands.tray_range_with_backup;
-                        if (trayRangeWithBackupDef) {
-                            return { commandId: 'tray_range_with_backup', ...trayRangeWithBackupDef };
-                        }
-                    }
-                }
-                // Check for multiple STOTrayExecByTray/TrayExecByTray commands (range)
-                else if ((command.command.includes('STOTrayExecByTray') || command.command.includes('TrayExecByTray')) && 
-                         command.command.includes('$$') && !command.command.includes('WithBackup')) {
-                    const parts = command.command.split('$$').map(s => s.trim());
-                    if (parts.length > 1) {
-                        const trayRangeDef = trayCategory.commands.tray_range;
-                        if (trayRangeDef) {
-                            return { commandId: 'tray_range', ...trayRangeDef };
-                        }
-                    }
-                }
-                // Check for single TrayExecByTrayWithBackup
-                else if (command.command.includes('TrayExecByTrayWithBackup')) {
-                    const trayWithBackupDef = trayCategory.commands.tray_with_backup;
-                    if (trayWithBackupDef) {
-                        return { commandId: 'tray_with_backup', ...trayWithBackupDef };
-                    }
-                }
-                // Check for STOTrayExecByTray or TrayExecByTray (both use same dialog)
-                else if (command.command.includes('STOTrayExecByTray') || 
-                         (command.command.includes('TrayExecByTray') && !command.command.includes('WithBackup'))) {
-                    const customTrayDef = trayCategory.commands.custom_tray;
-                    if (customTrayDef) {
-                        return { commandId: 'custom_tray', ...customTrayDef };
-                    }
-                }
+          })
+        } else if (commandId === 'whole_tray') {
+          const commandType = params.command_type || 'STOTrayExecByTray'
+          const commands = stoCommands.generateWholeTrayCommands(
+            tray,
+            commandType
+          )
+
+          // Return array of command objects instead of single command with $$
+          return commands.map((cmd, index) => {
+            // Extract slot number
+            let slotParam
+            try {
+              const parts = cmd.replace('+', '').trim().split(/\s+/)
+              slotParam = parseInt(parts[2])
+            } catch (_) {
+              slotParam = undefined
             }
-        }
-        
-        const category = STO_DATA.commands[command.type];
-        if (!category) return null;
-        
-        // First try to find exact command match (for non-customizable commands)
-        for (const [commandId, commandDef] of Object.entries(category.commands)) {
-            if (commandDef.command === command.command) {
-                return { commandId, ...commandDef };
+
+            return {
+              command: cmd,
+              type: categoryId,
+              icon: commandDef.icon,
+              text: index === 0 ? `Execute Whole Tray ${tray + 1}` : cmd,
+              id: this.generateCommandId(),
+              parameters: { tray, slot: slotParam },
             }
-        }
-        
-        // Then try to find the command by matching the base command string (for customizable commands)
-        for (const [commandId, commandDef] of Object.entries(category.commands)) {
-            if (commandDef.customizable && command.command.startsWith(commandDef.command.split(' ')[0])) {
-                return { commandId, ...commandDef };
+          })
+        } else if (commandId === 'whole_tray_with_backup') {
+          const active = params.active || 1
+          const backupTray = params.backup_tray || 0
+
+          const commands = stoCommands.generateWholeTrayWithBackupCommands(
+            active,
+            tray,
+            backupTray
+          )
+
+          // Return array with parsed parameters for each command
+          return commands.map((cmd, index) => {
+            let activeParam,
+              primaryTray,
+              primarySlot,
+              backupTrayParam,
+              backupSlotParam
+            try {
+              const parts = cmd.trim().split(/\s+/)
+              // TrayExecByTrayWithBackup <active> <tray> <slot> <backup_tray> <backup_slot>
+              activeParam = parseInt(parts[1])
+              primaryTray = parseInt(parts[2])
+              primarySlot = parseInt(parts[3])
+              backupTrayParam = parseInt(parts[4])
+              backupSlotParam = parseInt(parts[5])
+            } catch (_) {}
+
+            return {
+              command: cmd,
+              type: categoryId,
+              icon: commandDef.icon,
+              text:
+                index === 0
+                  ? `Execute Whole Tray ${tray + 1} (with backup Tray ${backupTray + 1})`
+                  : cmd,
+              id: this.generateCommandId(),
+              parameters: {
+                active: activeParam,
+                tray: primaryTray,
+                slot: primarySlot,
+                backup_tray: backupTrayParam,
+                backup_slot: backupSlotParam,
+              },
             }
-        }
-        
-        return null;
-    }
-    
-    editParameterizedCommand(index, command, commandDef) {
-        this.currentParameterCommand = { 
-            categoryId: command.type, 
-            commandId: commandDef.commandId, 
-            commandDef,
-            editIndex: index,
-            isEditing: true
-        };
-        
-        // Create modal if it doesn't exist
-        if (!document.getElementById('parameterModal')) {
-            this.createParameterModal();
-        }
-        
-        // Populate modal with existing parameter values
-        this.populateParameterModalForEdit(commandDef, command.parameters);
-        
-        // Change modal title and button text for editing
-        document.getElementById('parameterModalTitle').textContent = `Edit: ${commandDef.name}`;
-        document.getElementById('saveParameterCommandBtn').textContent = 'Update Command';
-        
-        // Show modal
-        modalManager.show('parameterModal');
-    }
-    
-    populateParameterModalForEdit(commandDef, existingParams) {
-        const container = document.getElementById('parameterInputs');
-        container.innerHTML = '';
-        
-        // Create input for each parameter with existing values
-        Object.entries(commandDef.parameters).forEach(([paramName, paramDef]) => {
-            const inputGroup = document.createElement('div');
-            inputGroup.className = 'form-group';
-            
-            const label = document.createElement('label');
-            label.textContent = this.formatParameterName(paramName);
-            label.setAttribute('for', `param_${paramName}`);
-            
-            let input;
-            
-            // Handle different parameter types
-            if (paramDef.type === 'select') {
-                // Create select dropdown
-                input = document.createElement('select');
-                input.id = `param_${paramName}`;
-                input.name = paramName;
-                
-                // Add options
-                paramDef.options.forEach(option => {
-                    const optionElement = document.createElement('option');
-                    optionElement.value = option;
-                    optionElement.textContent = option === 'STOTrayExecByTray' 
-                        ? 'STOTrayExecByTray (shows key binding on UI)' 
-                        : 'TrayExecByTray (no UI indication)';
-                    input.appendChild(optionElement);
-                });
-                
-                // Set existing value or default
-                const existingValue = existingParams && existingParams[paramName] !== undefined 
-                    ? existingParams[paramName] 
-                    : paramDef.default;
-                input.value = existingValue !== undefined && existingValue !== null ? existingValue : paramDef.default;
-            } else {
-                // Regular input for non-select parameters
-                input = document.createElement('input');
-                input.type = paramDef.type === 'number' ? 'number' : 'text';
-                input.id = `param_${paramName}`;
-                input.name = paramName;
-                
-                // Use existing parameter value or default
-                const existingValue = existingParams && existingParams[paramName] !== undefined 
-                    ? existingParams[paramName] 
-                    : paramDef.default;
-                input.value = existingValue !== undefined && existingValue !== null ? existingValue : '';
-                
-                if (paramDef.placeholder) {
-                    input.placeholder = paramDef.placeholder;
-                }
-                
-                if (paramDef.type === 'number') {
-                    if (paramDef.min !== undefined) input.min = paramDef.min;
-                    if (paramDef.max !== undefined) input.max = paramDef.max;
-                    if (paramDef.step !== undefined) input.step = paramDef.step;
-                }
+          })
+        } else {
+          // Preserve original command format when editing
+          const isEditing =
+            this.currentParameterCommand &&
+            this.currentParameterCommand.isEditing
+          const commandType = params.command_type || 'STOTrayExecByTray'
+          const prefix = '+'
+
+          if (isEditing) {
+            const profile = this.getCurrentProfile()
+            const existingCommand =
+              profile.keys[this.selectedKey][
+                this.currentParameterCommand.editIndex
+              ]
+            if (
+              existingCommand &&
+              (existingCommand.command.startsWith('TrayExecByTray') ||
+                existingCommand.command.startsWith('+TrayExecByTray'))
+            ) {
+              return {
+                command: `+TrayExecByTray ${tray} ${slot}`,
+                text: `Execute Tray ${tray + 1} Slot ${slot + 1}`,
+              }
             }
-            
-            const help = document.createElement('small');
-            help.textContent = this.getParameterHelp(paramName, paramDef);
-            
-            inputGroup.appendChild(label);
-            inputGroup.appendChild(input);
-            inputGroup.appendChild(help);
-            container.appendChild(inputGroup);
-            
-            // Add real-time preview update
-            input.addEventListener('input', () => {
-                this.updateParameterPreview();
-            });
-            
-            // Also listen for 'change' event for select elements
-            if (input.tagName === 'SELECT') {
-                input.addEventListener('change', () => {
-                    this.updateParameterPreview();
-                });
-            }
-        });
-        
-        // Initial preview update
-        this.updateParameterPreview();
+          }
+
+          return {
+            command: `${prefix}${commandType} ${tray} ${slot}`,
+            text: `Execute Tray ${tray + 1} Slot ${slot + 1}`,
+          }
+        }
+      },
+      movement: (params) => {
+        let command = commandDef.command
+        if (commandId === 'throttle_adjust' && params.amount !== undefined) {
+          command = `${commandDef.command} ${params.amount}`
+        } else if (
+          commandId === 'throttle_set' &&
+          params.position !== undefined
+        ) {
+          command = `${commandDef.command} ${params.position}`
+        }
+        return { command, text: commandDef.name }
+      },
+      camera: (params) => {
+        let command = commandDef.command
+        if (commandId === 'cam_distance' && params.distance !== undefined) {
+          command = `${commandDef.command} ${params.distance}`
+        }
+        return { command, text: commandDef.name }
+      },
+      communication: (params) => ({
+        command: `${commandDef.command} ${params.message || 'Message text here'}`,
+        text: `${commandDef.name}: ${params.message || 'Message text here'}`,
+      }),
+      system: (params) => {
+        let command = commandDef.command
+        if (
+          (commandId === 'bind_save_file' || commandId === 'bind_load_file') &&
+          params.filename
+        ) {
+          command = `${commandDef.command} ${params.filename}`
+        } else if (commandId === 'combat_log' && params.state !== undefined) {
+          command = `${commandDef.command} ${params.state}`
+        }
+        return { command, text: commandDef.name }
+      },
     }
 
-    filterCommandLibrary() {
-        // Filter commands in the command library based on current environment
-        const commandItems = document.querySelectorAll('.command-item');
-        
-        commandItems.forEach(item => {
-            const commandId = item.dataset.command;
-            if (!commandId) return;
-            
-            // Find the command definition
-            let commandDef = null;
-            let categoryKey = null;
-            
-            // Search through all categories for this command
-            for (const [catKey, category] of Object.entries(STO_DATA.commands)) {
-                if (category.commands[commandId]) {
-                    commandDef = category.commands[commandId];
-                    categoryKey = catKey;
-                    break;
-                }
-            }
-            
-            if (commandDef) {
-                let shouldShow = true;
-                
-                // Check if command has environment restriction
-                if (commandDef.environment) {
-                    // If command has specific environment, only show it in that environment
-                    shouldShow = commandDef.environment === this.currentEnvironment;
-                } else {
-                    // If no environment specified, show in all environments
-                    shouldShow = true;
-                }
-                
-                // Apply visibility
-                item.style.display = shouldShow ? 'flex' : 'none';
-            }
-        });
-        
-        // Hide/show categories based on whether they have visible commands
-        const categories = document.querySelectorAll('.category');
-        categories.forEach(category => {
-            const visibleCommands = category.querySelectorAll('.command-item:not([style*="display: none"])');
-            const categoryVisible = visibleCommands.length > 0;
-            category.style.display = categoryVisible ? 'block' : 'none';
-        });
+    const builder = builders[categoryId]
+    if (builder) {
+      const result = builder(params)
+      // If tray (or other) builder returned an array of command objects, forward it
+      if (Array.isArray(result)) {
+        return result
+      }
+
+      // Otherwise wrap single command
+      return {
+        command: result.command,
+        type: categoryId,
+        icon: commandDef.icon,
+        text: result.text,
+        id: this.generateCommandId(),
+        parameters: params,
+      }
     }
 
-    showKeySelectionModal() {
-        this.setupKeySelectionModal();
-        modalManager.show('keySelectionModal');
-    }
+    return null
+  }
 
-    setupKeySelectionModal() {
-        // Populate common keys
-        this.populateCommonKeys();
-        
-        // Setup "Find other keys" button
-        const findKeysBtn = document.getElementById('findOtherKeysBtn');
-        if (findKeysBtn) {
-            findKeysBtn.onclick = () => this.showFullKeyList();
+  saveParameterCommand() {
+    if (!this.selectedKey || !this.currentParameterCommand) return
+
+    const { categoryId, commandId, commandDef, editIndex, isEditing } =
+      this.currentParameterCommand
+    const params = this.getParameterValues()
+
+    const command = this.buildParameterizedCommand(
+      categoryId,
+      commandId,
+      commandDef,
+      params
+    )
+
+    if (command) {
+      if (isEditing && editIndex !== undefined) {
+        // For arrays of commands, we need to handle replacement differently
+        if (Array.isArray(command)) {
+          const profile = this.getCurrentProfile()
+          const commands = profile.keys[this.selectedKey]
+
+          // Remove the old command and insert the new array of commands
+          commands.splice(editIndex, 1, ...command)
+
+          stoStorage.saveProfile(this.currentProfile, profile)
+          this.renderCommandChain()
+          this.setModified(true)
+          stoUI.showToast(
+            `${command.length} commands updated successfully`,
+            'success'
+          )
+        } else {
+          // Update existing single command
+          const profile = this.getCurrentProfile()
+          profile.keys[this.selectedKey][editIndex] = command
+          stoStorage.saveProfile(this.currentProfile, profile)
+          this.renderCommandChain()
+          this.setModified(true)
+          stoUI.showToast('Command updated successfully', 'success')
         }
-        
-        // Setup search functionality
-        const searchInput = document.getElementById('keySearchInput');
-        if (searchInput) {
-            searchInput.oninput = (e) => this.filterKeyList(e.target.value);
-        }
+      } else {
+        // Add new command (addCommand already handles arrays)
+        this.addCommand(this.selectedKey, command)
+      }
+
+      modalManager.hide('parameterModal')
+      this.currentParameterCommand = null
+
+      // Reset modal button text
+      document.getElementById('saveParameterCommandBtn').textContent =
+        'Add Command'
+    }
+  }
+
+  editCommand(index) {
+    if (!this.selectedKey) return
+
+    const profile = this.getCurrentProfile()
+    const commands = profile.keys[this.selectedKey]
+
+    if (!commands || !commands[index]) return
+
+    const command = commands[index]
+
+    // Check if this is a parameterized command that can be edited
+    if (command.parameters && command.type) {
+      // Find the original command definition
+      const commandDef = this.findCommandDefinition(command)
+      if (commandDef && commandDef.customizable) {
+        this.editParameterizedCommand(index, command, commandDef)
+        return
+      }
     }
 
-    populateCommonKeys() {
-        const commonKeysGrid = document.getElementById('commonKeysGrid');
-        if (!commonKeysGrid) return;
+    // Also check if command is detectable as parameterized via findCommandDefinition
+    const commandDef = this.findCommandDefinition(command)
+    if (commandDef && commandDef.customizable) {
+      this.editParameterizedCommand(index, command, commandDef)
+      return
+    }
 
-        const commonKeys = STO_DATA.keys.common.keys;
-        commonKeysGrid.innerHTML = '';
+    // For non-parameterized commands, show command details
+    stoUI.showToast(
+      `Command: ${command.command}\nType: ${command.type}`,
+      'info',
+      3000
+    )
+  }
 
-        commonKeys.forEach(keyData => {
-            const keyButton = document.createElement('div');
-            keyButton.className = 'key-button';
-            keyButton.onclick = () => this.selectKeyFromModal(keyData.key);
-            
-            keyButton.innerHTML = `
+  findCommandDefinition(command) {
+    // Special handling for tray execution commands - detect by command string
+    if (command.command.includes('TrayExec')) {
+      const trayCategory = STO_DATA.commands.tray
+      if (trayCategory) {
+        // Check for multiple TrayExecByTrayWithBackup commands (range with backup)
+        if (
+          command.command.includes('TrayExecByTrayWithBackup') &&
+          command.command.includes('$$')
+        ) {
+          const parts = command.command.split('$$').map((s) => s.trim())
+          if (parts.length > 1) {
+            const trayRangeWithBackupDef =
+              trayCategory.commands.tray_range_with_backup
+            if (trayRangeWithBackupDef) {
+              return {
+                commandId: 'tray_range_with_backup',
+                ...trayRangeWithBackupDef,
+              }
+            }
+          }
+        }
+        // Check for multiple STOTrayExecByTray/TrayExecByTray commands (range)
+        else if (
+          (command.command.includes('STOTrayExecByTray') ||
+            command.command.includes('TrayExecByTray')) &&
+          command.command.includes('$$') &&
+          !command.command.includes('WithBackup')
+        ) {
+          const parts = command.command.split('$$').map((s) => s.trim())
+          if (parts.length > 1) {
+            const trayRangeDef = trayCategory.commands.tray_range
+            if (trayRangeDef) {
+              return { commandId: 'tray_range', ...trayRangeDef }
+            }
+          }
+        }
+        // Check for single TrayExecByTrayWithBackup
+        else if (command.command.includes('TrayExecByTrayWithBackup')) {
+          const trayWithBackupDef = trayCategory.commands.tray_with_backup
+          if (trayWithBackupDef) {
+            return { commandId: 'tray_with_backup', ...trayWithBackupDef }
+          }
+        }
+        // Check for STOTrayExecByTray or TrayExecByTray (both use same dialog)
+        else if (
+          command.command.includes('STOTrayExecByTray') ||
+          (command.command.includes('TrayExecByTray') &&
+            !command.command.includes('WithBackup'))
+        ) {
+          const customTrayDef = trayCategory.commands.custom_tray
+          if (customTrayDef) {
+            return { commandId: 'custom_tray', ...customTrayDef }
+          }
+        }
+      }
+    }
+
+    const category = STO_DATA.commands[command.type]
+    if (!category) return null
+
+    // First try to find exact command match (for non-customizable commands)
+    for (const [commandId, commandDef] of Object.entries(category.commands)) {
+      if (commandDef.command === command.command) {
+        return { commandId, ...commandDef }
+      }
+    }
+
+    // Then try to find the command by matching the base command string (for customizable commands)
+    for (const [commandId, commandDef] of Object.entries(category.commands)) {
+      if (
+        commandDef.customizable &&
+        command.command.startsWith(commandDef.command.split(' ')[0])
+      ) {
+        return { commandId, ...commandDef }
+      }
+    }
+
+    return null
+  }
+
+  editParameterizedCommand(index, command, commandDef) {
+    this.currentParameterCommand = {
+      categoryId: command.type,
+      commandId: commandDef.commandId,
+      commandDef,
+      editIndex: index,
+      isEditing: true,
+    }
+
+    // Create modal if it doesn't exist
+    if (!document.getElementById('parameterModal')) {
+      this.createParameterModal()
+    }
+
+    // Populate modal with existing parameter values
+    this.populateParameterModalForEdit(commandDef, command.parameters)
+
+    // Change modal title and button text for editing
+    document.getElementById('parameterModalTitle').textContent =
+      `Edit: ${commandDef.name}`
+    document.getElementById('saveParameterCommandBtn').textContent =
+      'Update Command'
+
+    // Show modal
+    modalManager.show('parameterModal')
+  }
+
+  populateParameterModalForEdit(commandDef, existingParams) {
+    const container = document.getElementById('parameterInputs')
+    container.innerHTML = ''
+
+    // Create input for each parameter with existing values
+    Object.entries(commandDef.parameters).forEach(([paramName, paramDef]) => {
+      const inputGroup = document.createElement('div')
+      inputGroup.className = 'form-group'
+
+      const label = document.createElement('label')
+      label.textContent = this.formatParameterName(paramName)
+      label.setAttribute('for', `param_${paramName}`)
+
+      let input
+
+      // Handle different parameter types
+      if (paramDef.type === 'select') {
+        // Create select dropdown
+        input = document.createElement('select')
+        input.id = `param_${paramName}`
+        input.name = paramName
+
+        // Add options
+        paramDef.options.forEach((option) => {
+          const optionElement = document.createElement('option')
+          optionElement.value = option
+          optionElement.textContent =
+            option === 'STOTrayExecByTray'
+              ? 'STOTrayExecByTray (shows key binding on UI)'
+              : 'TrayExecByTray (no UI indication)'
+          input.appendChild(optionElement)
+        })
+
+        // Set existing value or default
+        const existingValue =
+          existingParams && existingParams[paramName] !== undefined
+            ? existingParams[paramName]
+            : paramDef.default
+        input.value =
+          existingValue !== undefined && existingValue !== null
+            ? existingValue
+            : paramDef.default
+      } else {
+        // Regular input for non-select parameters
+        input = document.createElement('input')
+        input.type = paramDef.type === 'number' ? 'number' : 'text'
+        input.id = `param_${paramName}`
+        input.name = paramName
+
+        // Use existing parameter value or default
+        const existingValue =
+          existingParams && existingParams[paramName] !== undefined
+            ? existingParams[paramName]
+            : paramDef.default
+        input.value =
+          existingValue !== undefined && existingValue !== null
+            ? existingValue
+            : ''
+
+        if (paramDef.placeholder) {
+          input.placeholder = paramDef.placeholder
+        }
+
+        if (paramDef.type === 'number') {
+          if (paramDef.min !== undefined) input.min = paramDef.min
+          if (paramDef.max !== undefined) input.max = paramDef.max
+          if (paramDef.step !== undefined) input.step = paramDef.step
+        }
+      }
+
+      const help = document.createElement('small')
+      help.textContent = this.getParameterHelp(paramName, paramDef)
+
+      inputGroup.appendChild(label)
+      inputGroup.appendChild(input)
+      inputGroup.appendChild(help)
+      container.appendChild(inputGroup)
+
+      // Add real-time preview update
+      input.addEventListener('input', () => {
+        this.updateParameterPreview()
+      })
+
+      // Also listen for 'change' event for select elements
+      if (input.tagName === 'SELECT') {
+        input.addEventListener('change', () => {
+          this.updateParameterPreview()
+        })
+      }
+    })
+
+    // Initial preview update
+    this.updateParameterPreview()
+  }
+
+  filterCommandLibrary() {
+    // Filter commands in the command library based on current environment
+    const commandItems = document.querySelectorAll('.command-item')
+
+    commandItems.forEach((item) => {
+      const commandId = item.dataset.command
+      if (!commandId) return
+
+      // Find the command definition
+      let commandDef = null
+      let categoryKey = null
+
+      // Search through all categories for this command
+      for (const [catKey, category] of Object.entries(STO_DATA.commands)) {
+        if (category.commands[commandId]) {
+          commandDef = category.commands[commandId]
+          categoryKey = catKey
+          break
+        }
+      }
+
+      if (commandDef) {
+        let shouldShow = true
+
+        // Check if command has environment restriction
+        if (commandDef.environment) {
+          // If command has specific environment, only show it in that environment
+          shouldShow = commandDef.environment === this.currentEnvironment
+        } else {
+          // If no environment specified, show in all environments
+          shouldShow = true
+        }
+
+        // Apply visibility
+        item.style.display = shouldShow ? 'flex' : 'none'
+      }
+    })
+
+    // Hide/show categories based on whether they have visible commands
+    const categories = document.querySelectorAll('.category')
+    categories.forEach((category) => {
+      const visibleCommands = category.querySelectorAll(
+        '.command-item:not([style*="display: none"])'
+      )
+      const categoryVisible = visibleCommands.length > 0
+      category.style.display = categoryVisible ? 'block' : 'none'
+    })
+  }
+
+  showKeySelectionModal() {
+    this.setupKeySelectionModal()
+    modalManager.show('keySelectionModal')
+  }
+
+  setupKeySelectionModal() {
+    // Populate common keys
+    this.populateCommonKeys()
+
+    // Setup "Find other keys" button
+    const findKeysBtn = document.getElementById('findOtherKeysBtn')
+    if (findKeysBtn) {
+      findKeysBtn.onclick = () => this.showFullKeyList()
+    }
+
+    // Setup search functionality
+    const searchInput = document.getElementById('keySearchInput')
+    if (searchInput) {
+      searchInput.oninput = (e) => this.filterKeyList(e.target.value)
+    }
+  }
+
+  populateCommonKeys() {
+    const commonKeysGrid = document.getElementById('commonKeysGrid')
+    if (!commonKeysGrid) return
+
+    const commonKeys = STO_DATA.keys.common.keys
+    commonKeysGrid.innerHTML = ''
+
+    commonKeys.forEach((keyData) => {
+      const keyButton = document.createElement('div')
+      keyButton.className = 'key-button'
+      keyButton.onclick = () => this.selectKeyFromModal(keyData.key)
+
+      keyButton.innerHTML = `
                 <div class="key-name">${keyData.key}</div>
                 <div class="key-desc">${keyData.description}</div>
-            `;
-            
-            commonKeysGrid.appendChild(keyButton);
-        });
+            `
+
+      commonKeysGrid.appendChild(keyButton)
+    })
+  }
+
+  showFullKeyList() {
+    const fullKeysSection = document.getElementById('fullKeysSection')
+    const findKeysBtn = document.getElementById('findOtherKeysBtn')
+
+    if (fullKeysSection && findKeysBtn) {
+      fullKeysSection.style.display = 'block'
+      findKeysBtn.style.display = 'none'
+
+      // Populate categories if not already done
+      this.populateKeyCategories()
     }
+  }
 
-    showFullKeyList() {
-        const fullKeysSection = document.getElementById('fullKeysSection');
-        const findKeysBtn = document.getElementById('findOtherKeysBtn');
-        
-        if (fullKeysSection && findKeysBtn) {
-            fullKeysSection.style.display = 'block';
-            findKeysBtn.style.display = 'none';
-            
-            // Populate categories if not already done
-            this.populateKeyCategories();
-        }
-    }
+  populateKeyCategories() {
+    const keyCategories = document.getElementById('keyCategories')
+    if (!keyCategories) return
 
-    populateKeyCategories() {
-        const keyCategories = document.getElementById('keyCategories');
-        if (!keyCategories) return;
+    keyCategories.innerHTML = ''
 
-        keyCategories.innerHTML = '';
+    // Skip common keys since they're already shown above
+    Object.entries(STO_DATA.keys).forEach(([categoryId, categoryData]) => {
+      if (categoryId === 'common') return
 
-        // Skip common keys since they're already shown above
-        Object.entries(STO_DATA.keys).forEach(([categoryId, categoryData]) => {
-            if (categoryId === 'common') return;
-            
-            // Debug logging
-            console.log('Processing category:', categoryId, categoryData);
-            
-            // Validate category data
-            if (!categoryData || !categoryData.name || !categoryData.keys) {
-                console.warn(`Invalid category data for categoryId: ${categoryId}`, categoryData);
-                return;
-            }
+      // Debug logging
+      console.log('Processing category:', categoryId, categoryData)
 
-            const categoryElement = document.createElement('div');
-            categoryElement.className = 'key-category';
-            
-            const headerElement = document.createElement('div');
-            headerElement.className = 'key-category-header';
-            headerElement.onclick = () => this.toggleKeySelectionCategory(categoryId);
-            
-            headerElement.innerHTML = `
+      // Validate category data
+      if (!categoryData || !categoryData.name || !categoryData.keys) {
+        console.warn(
+          `Invalid category data for categoryId: ${categoryId}`,
+          categoryData
+        )
+        return
+      }
+
+      const categoryElement = document.createElement('div')
+      categoryElement.className = 'key-category'
+
+      const headerElement = document.createElement('div')
+      headerElement.className = 'key-category-header'
+      headerElement.onclick = () => this.toggleKeySelectionCategory(categoryId)
+
+      headerElement.innerHTML = `
                 <div>
                     <h5>${categoryData.name}</h5>
                     <div class="category-desc">${categoryData.description || ''}</div>
                 </div>
                 <i class="fas fa-chevron-right category-chevron"></i>
-            `;
-            
-            const contentElement = document.createElement('div');
-            contentElement.className = 'key-category-content collapsed';
-            contentElement.id = `key-category-${categoryId}`;
-            
-            // Populate keys for this category
-            if (Array.isArray(categoryData.keys)) {
-                categoryData.keys.forEach(keyData => {
-                    if (keyData && keyData.key) {
-                        const keyButton = document.createElement('div');
-                        keyButton.className = 'key-button';
-                        keyButton.onclick = () => this.selectKeyFromModal(keyData.key);
-                        
-                        keyButton.innerHTML = `
+            `
+
+      const contentElement = document.createElement('div')
+      contentElement.className = 'key-category-content collapsed'
+      contentElement.id = `key-category-${categoryId}`
+
+      // Populate keys for this category
+      if (Array.isArray(categoryData.keys)) {
+        categoryData.keys.forEach((keyData) => {
+          if (keyData && keyData.key) {
+            const keyButton = document.createElement('div')
+            keyButton.className = 'key-button'
+            keyButton.onclick = () => this.selectKeyFromModal(keyData.key)
+
+            keyButton.innerHTML = `
                             <div class="key-name">${keyData.key}</div>
                             <div class="key-desc">${keyData.description || ''}</div>
-                        `;
-                        
-                        contentElement.appendChild(keyButton);
-                    }
-                });
-            }
-            
-            categoryElement.appendChild(headerElement);
-            categoryElement.appendChild(contentElement);
-            keyCategories.appendChild(categoryElement);
-        });
+                        `
+
+            contentElement.appendChild(keyButton)
+          }
+        })
+      }
+
+      categoryElement.appendChild(headerElement)
+      categoryElement.appendChild(contentElement)
+      keyCategories.appendChild(categoryElement)
+    })
+  }
+
+  toggleKeySelectionCategory(categoryId) {
+    const content = document.getElementById(`key-category-${categoryId}`)
+    if (!content) {
+      console.warn(
+        `Key selection category content not found for categoryId: ${categoryId}`
+      )
+      return
     }
 
-    toggleKeySelectionCategory(categoryId) {
-        const content = document.getElementById(`key-category-${categoryId}`);
-        if (!content) {
-            console.warn(`Key selection category content not found for categoryId: ${categoryId}`);
-            return;
+    const header = content.previousElementSibling
+
+    if (content && header) {
+      const isCollapsed = content.classList.contains('collapsed')
+
+      if (isCollapsed) {
+        content.classList.remove('collapsed')
+        header.classList.remove('collapsed')
+        // Update chevron rotation
+        const chevron = header.querySelector('.category-chevron')
+        if (chevron) {
+          chevron.style.transform = 'rotate(90deg)'
         }
-        
-        const header = content.previousElementSibling;
-        
-        if (content && header) {
-            const isCollapsed = content.classList.contains('collapsed');
-            
-            if (isCollapsed) {
-                content.classList.remove('collapsed');
-                header.classList.remove('collapsed');
-                // Update chevron rotation
-                const chevron = header.querySelector('.category-chevron');
-                if (chevron) {
-                    chevron.style.transform = 'rotate(90deg)';
-                }
-            } else {
-                content.classList.add('collapsed');
-                header.classList.add('collapsed');
-                // Update chevron rotation
-                const chevron = header.querySelector('.category-chevron');
-                if (chevron) {
-                    chevron.style.transform = 'rotate(0deg)';
-                }
-            }
+      } else {
+        content.classList.add('collapsed')
+        header.classList.add('collapsed')
+        // Update chevron rotation
+        const chevron = header.querySelector('.category-chevron')
+        if (chevron) {
+          chevron.style.transform = 'rotate(0deg)'
         }
+      }
     }
+  }
 
-    filterKeyList(searchTerm) {
-        const term = searchTerm.toLowerCase().trim();
-        
-        // Filter through all key buttons in categories
-        const keyButtons = document.querySelectorAll('#keyCategories .key-button');
-        
-        keyButtons.forEach(button => {
-            const keyName = button.querySelector('.key-name').textContent.toLowerCase();
-            const keyDesc = button.querySelector('.key-desc').textContent.toLowerCase();
-            
-            const matches = keyName.includes(term) || keyDesc.includes(term);
-            button.style.display = matches ? 'flex' : 'none';
-        });
-        
-        // Show/hide categories based on visible keys
-        const categories = document.querySelectorAll('.key-category');
-        categories.forEach(category => {
-            const visibleKeys = category.querySelectorAll('.key-button:not([style*="display: none"])');
-            const hasVisibleKeys = visibleKeys.length > 0;
-            
-            if (term === '') {
-                // If no search term, show all categories but keep them collapsed
-                category.style.display = 'block';
-            } else {
-                // If searching, show categories with matches and expand them
-                category.style.display = hasVisibleKeys ? 'block' : 'none';
-                
-                if (hasVisibleKeys) {
-                    const content = category.querySelector('.key-category-content');
-                    const header = category.querySelector('.key-category-header');
-                    if (content && header) {
-                        content.classList.remove('collapsed');
-                        header.classList.remove('collapsed');
-                    }
-                }
-            }
-        });
-    }
+  filterKeyList(searchTerm) {
+    const term = searchTerm.toLowerCase().trim()
 
-    selectKeyFromModal(keyName) {
-        modalManager.hide('keySelectionModal');
-        this.selectKey(keyName);
-    }
+    // Filter through all key buttons in categories
+    const keyButtons = document.querySelectorAll('#keyCategories .key-button')
 
-    insertTargetVariable(input) {
-        const targetVar = '$Target';
-        const cursorPosition = input.selectionStart;
-        const value = input.value;
-        const newValue = value.slice(0, cursorPosition) + targetVar + value.slice(cursorPosition);
-        input.value = newValue;
-        input.setSelectionRange(cursorPosition + targetVar.length, cursorPosition + targetVar.length);
-        input.focus();
-        
-        // Trigger input event to update preview
-        input.dispatchEvent(new Event('input', { bubbles: true }));
-    }
+    keyButtons.forEach((button) => {
+      const keyName = button
+        .querySelector('.key-name')
+        .textContent.toLowerCase()
+      const keyDesc = button
+        .querySelector('.key-desc')
+        .textContent.toLowerCase()
 
-    // Vertigo VFX Manager Methods
-    showVertigoModal() {
-        // Load state from root profile (not build-specific view)
-        const rootProfile = stoStorage.getProfile(this.currentProfile);
-        if (rootProfile) {
-            vertigoManager.loadState(rootProfile);
+      const matches = keyName.includes(term) || keyDesc.includes(term)
+      button.style.display = matches ? 'flex' : 'none'
+    })
+
+    // Show/hide categories based on visible keys
+    const categories = document.querySelectorAll('.key-category')
+    categories.forEach((category) => {
+      const visibleKeys = category.querySelectorAll(
+        '.key-button:not([style*="display: none"])'
+      )
+      const hasVisibleKeys = visibleKeys.length > 0
+
+      if (term === '') {
+        // If no search term, show all categories but keep them collapsed
+        category.style.display = 'block'
+      } else {
+        // If searching, show categories with matches and expand them
+        category.style.display = hasVisibleKeys ? 'block' : 'none'
+
+        if (hasVisibleKeys) {
+          const content = category.querySelector('.key-category-content')
+          const header = category.querySelector('.key-category-header')
+          if (content && header) {
+            content.classList.remove('collapsed')
+            header.classList.remove('collapsed')
+          }
         }
-        
-        // Store the initial state for potential rollback on cancel
-        this.vertigoInitialState = {
-            selectedEffects: {
-                space: new Set(vertigoManager.selectedEffects.space),
-                ground: new Set(vertigoManager.selectedEffects.ground)
-            },
-            showPlayerSay: vertigoManager.showPlayerSay
-        };
-        
-        this.populateVertigoModal();
-        this.setupVertigoEventListeners();
-        modalManager.show('vertigoModal');
+      }
+    })
+  }
+
+  selectKeyFromModal(keyName) {
+    modalManager.hide('keySelectionModal')
+    this.selectKey(keyName)
+  }
+
+  insertTargetVariable(input) {
+    const targetVar = '$Target'
+    const cursorPosition = input.selectionStart
+    const value = input.value
+    const newValue =
+      value.slice(0, cursorPosition) + targetVar + value.slice(cursorPosition)
+    input.value = newValue
+    input.setSelectionRange(
+      cursorPosition + targetVar.length,
+      cursorPosition + targetVar.length
+    )
+    input.focus()
+
+    // Trigger input event to update preview
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  }
+
+  // Vertigo VFX Manager Methods
+  showVertigoModal() {
+    // Load state from root profile (not build-specific view)
+    const rootProfile = stoStorage.getProfile(this.currentProfile)
+    if (rootProfile) {
+      vertigoManager.loadState(rootProfile)
     }
 
-    populateVertigoModal() {
-        // Populate space effects
-        const spaceList = document.getElementById('spaceEffectsList');
-        if (spaceList) {
-            spaceList.innerHTML = '';
-            VFX_EFFECTS.space.forEach(effect => {
-                const effectItem = this.createEffectItem('space', effect);
-                spaceList.appendChild(effectItem);
-            });
-        }
-
-        // Populate ground effects
-        const groundList = document.getElementById('groundEffectsList');
-        if (groundList) {
-            groundList.innerHTML = '';
-            VFX_EFFECTS.ground.forEach(effect => {
-                const effectItem = this.createEffectItem('ground', effect);
-                groundList.appendChild(effectItem);
-            });
-        }
-
-        // Update UI state based on loaded data
-        this.updateVertigoCheckboxes('space');
-        this.updateVertigoCheckboxes('ground');
-        
-        // Update PlayerSay checkbox
-        const playerSayCheckbox = document.getElementById('vertigoShowPlayerSay');
-        if (playerSayCheckbox) {
-            playerSayCheckbox.checked = vertigoManager.showPlayerSay;
-        }
-        
-        // Update effect counts and preview
-        this.updateVertigoEffectCounts();
-        this.updateVertigoPreview();
+    // Store the initial state for potential rollback on cancel
+    this.vertigoInitialState = {
+      selectedEffects: {
+        space: new Set(vertigoManager.selectedEffects.space),
+        ground: new Set(vertigoManager.selectedEffects.ground),
+      },
+      showPlayerSay: vertigoManager.showPlayerSay,
     }
 
-    createEffectItem(environment, effect) {
-        const item = document.createElement('div');
-        item.className = 'effect-item';
-        item.innerHTML = `
+    this.populateVertigoModal()
+    this.setupVertigoEventListeners()
+    modalManager.show('vertigoModal')
+  }
+
+  populateVertigoModal() {
+    // Populate space effects
+    const spaceList = document.getElementById('spaceEffectsList')
+    if (spaceList) {
+      spaceList.innerHTML = ''
+      VFX_EFFECTS.space.forEach((effect) => {
+        const effectItem = this.createEffectItem('space', effect)
+        spaceList.appendChild(effectItem)
+      })
+    }
+
+    // Populate ground effects
+    const groundList = document.getElementById('groundEffectsList')
+    if (groundList) {
+      groundList.innerHTML = ''
+      VFX_EFFECTS.ground.forEach((effect) => {
+        const effectItem = this.createEffectItem('ground', effect)
+        groundList.appendChild(effectItem)
+      })
+    }
+
+    // Update UI state based on loaded data
+    this.updateVertigoCheckboxes('space')
+    this.updateVertigoCheckboxes('ground')
+
+    // Update PlayerSay checkbox
+    const playerSayCheckbox = document.getElementById('vertigoShowPlayerSay')
+    if (playerSayCheckbox) {
+      playerSayCheckbox.checked = vertigoManager.showPlayerSay
+    }
+
+    // Update effect counts and preview
+    this.updateVertigoEffectCounts()
+    this.updateVertigoPreview()
+  }
+
+  createEffectItem(environment, effect) {
+    const item = document.createElement('div')
+    item.className = 'effect-item'
+    item.innerHTML = `
             <input type="checkbox" id="effect_${environment}_${effect.effect.replace(/[^a-zA-Z0-9]/g, '_')}" 
                    data-environment="${environment}" 
                    data-effect="${effect.effect}">
             <label for="effect_${environment}_${effect.effect.replace(/[^a-zA-Z0-9]/g, '_')}" 
                    class="effect-label">${effect.label}</label>
-        `;
-        
-        const checkbox = item.querySelector('input[type="checkbox"]');
-        checkbox.addEventListener('change', () => {
-            vertigoManager.toggleEffect(environment, effect.effect);
-            this.updateVertigoEffectCounts();
-            this.updateVertigoPreview();
-            item.classList.toggle('selected', checkbox.checked);
-            
-            // Note: Don't save immediately - only save when "Generate Aliases" is clicked
-            // This allows for proper transaction behavior with rollback on cancel
-        });
+        `
 
-        const label = item.querySelector('.effect-label');
-        label.addEventListener('click', () => {
-            checkbox.checked = !checkbox.checked;
-            checkbox.dispatchEvent(new Event('change'));
-        });
+    const checkbox = item.querySelector('input[type="checkbox"]')
+    checkbox.addEventListener('change', () => {
+      vertigoManager.toggleEffect(environment, effect.effect)
+      this.updateVertigoEffectCounts()
+      this.updateVertigoPreview()
+      item.classList.toggle('selected', checkbox.checked)
 
-        return item;
-    }
+      // Note: Don't save immediately - only save when "Generate Aliases" is clicked
+      // This allows for proper transaction behavior with rollback on cancel
+    })
 
-    setupVertigoEventListeners() {
-        // Clear existing listeners to avoid duplicates
-        const existingListeners = ['spaceSelectAll', 'spaceClearAll', 'groundSelectAll', 'groundClearAll', 'vertigoShowPlayerSay', 'saveVertigoBtn'];
-        existingListeners.forEach(id => {
-            const element = document.getElementById(id);
-            if (element) {
-                element.replaceWith(element.cloneNode(true));
-            }
-        });
+    const label = item.querySelector('.effect-label')
+    label.addEventListener('click', () => {
+      checkbox.checked = !checkbox.checked
+      checkbox.dispatchEvent(new Event('change'))
+    })
 
-        // Space controls
-        eventBus.onDom('spaceSelectAll', 'click', 'vertigo-space-select-all', () => {
-            try {
-                vertigoManager.selectAllEffects('space');
-                this.updateVertigoCheckboxes('space');
-                this.updateVertigoEffectCounts();
-                this.updateVertigoPreview();
-                
-                // Note: Don't save immediately - only save when "Generate Aliases" is clicked
-            } catch (error) {
-                if (error instanceof InvalidEnvironmentError) {
-                    stoUI.showToast(`Error: ${error.message}`, 'error');
-                } else {
-                    stoUI.showToast('Failed to select all space effects', 'error');
-                    console.error('Error selecting all space effects:', error);
-                }
-            }
-        });
+    return item
+  }
 
-        eventBus.onDom('spaceClearAll', 'click', 'vertigo-space-clear-all', () => {
-            vertigoManager.selectedEffects.space.clear();
-            this.updateVertigoCheckboxes('space');
-            this.updateVertigoEffectCounts();
-            this.updateVertigoPreview();
-            
-            // Note: Don't save immediately - only save when "Generate Aliases" is clicked
-        });
+  setupVertigoEventListeners() {
+    // Clear existing listeners to avoid duplicates
+    const existingListeners = [
+      'spaceSelectAll',
+      'spaceClearAll',
+      'groundSelectAll',
+      'groundClearAll',
+      'vertigoShowPlayerSay',
+      'saveVertigoBtn',
+    ]
+    existingListeners.forEach((id) => {
+      const element = document.getElementById(id)
+      if (element) {
+        element.replaceWith(element.cloneNode(true))
+      }
+    })
 
-        // Ground controls
-        eventBus.onDom('groundSelectAll', 'click', 'vertigo-ground-select-all', () => {
-            try {
-                vertigoManager.selectAllEffects('ground');
-                this.updateVertigoCheckboxes('ground');
-                this.updateVertigoEffectCounts();
-                this.updateVertigoPreview();
-                
-                // Note: Don't save immediately - only save when "Generate Aliases" is clicked
-            } catch (error) {
-                if (error instanceof InvalidEnvironmentError) {
-                    stoUI.showToast(`Error: ${error.message}`, 'error');
-                } else {
-                    stoUI.showToast('Failed to select all ground effects', 'error');
-                    console.error('Error selecting all ground effects:', error);
-                }
-            }
-        });
-
-        eventBus.onDom('groundClearAll', 'click', 'vertigo-ground-clear-all', () => {
-            vertigoManager.selectedEffects.ground.clear();
-            this.updateVertigoCheckboxes('ground');
-            this.updateVertigoEffectCounts();
-            this.updateVertigoPreview();
-            
-            // Note: Don't save immediately - only save when "Generate Aliases" is clicked
-        });
-
-        // Show Player Say toggle
-        eventBus.onDom('vertigoShowPlayerSay', 'change', 'vertigo-show-playersay', (e) => {
-            vertigoManager.showPlayerSay = e.target.checked;
-            this.updateVertigoPreview();
-            
-            // Note: Don't save immediately - only save when "Generate Aliases" is clicked
-        });
-
-        // Generate aliases button
-        eventBus.onDom('saveVertigoBtn', 'click', 'vertigo-save', () => {
-            this.generateVertigoAliases();
-        });
-    }
-
-    updateVertigoCheckboxes(environment) {
-        const checkboxes = document.querySelectorAll(`input[data-environment="${environment}"]`);
-        checkboxes.forEach(checkbox => {
-            const effectName = checkbox.dataset.effect;
-            const isSelected = vertigoManager.isEffectSelected(environment, effectName);
-            checkbox.checked = isSelected;
-            checkbox.closest('.effect-item').classList.toggle('selected', isSelected);
-        });
-    }
-
-    updateVertigoEffectCounts() {
-        const spaceCount = vertigoManager.getEffectCount('space');
-        const groundCount = vertigoManager.getEffectCount('ground');
-        
-        const spaceCounter = document.getElementById('spaceEffectCount');
-        const groundCounter = document.getElementById('groundEffectCount');
-        
-        if (spaceCounter) {
-            spaceCounter.textContent = `${spaceCount} selected`;
-        }
-        
-        if (groundCounter) {
-            groundCounter.textContent = `${groundCount} selected`;
-        }
-    }
-
-    updateVertigoPreview() {
-        const spacePreview = document.getElementById('spaceAliasCommand');
-        const groundPreview = document.getElementById('groundAliasCommand');
-        
-        // Update space preview
-        if (spacePreview) {
-            try {
-                const spaceAlias = vertigoManager.generateAlias('space');
-                spacePreview.textContent = spaceAlias || 'No space effects selected';
-            } catch (error) {
-                if (error instanceof InvalidEnvironmentError) {
-                    spacePreview.textContent = 'Error: Invalid environment';
-                    stoUI.showToast(`Space preview error: ${error.message}`, 'error');
-                } else {
-                    spacePreview.textContent = 'Error generating preview';
-                    console.error('Error generating space alias preview:', error);
-                }
-            }
-        }
-        
-        // Update ground preview
-        if (groundPreview) {
-            try {
-                const groundAlias = vertigoManager.generateAlias('ground');
-                groundPreview.textContent = groundAlias || 'No ground effects selected';
-            } catch (error) {
-                if (error instanceof InvalidEnvironmentError) {
-                    groundPreview.textContent = 'Error: Invalid environment';
-                    stoUI.showToast(`Ground preview error: ${error.message}`, 'error');
-                } else {
-                    groundPreview.textContent = 'Error generating preview';
-                    console.error('Error generating ground alias preview:', error);
-                }
-            }
-        }
-    }
-
-    generateVertigoAliases() {
-        let spaceAlias = '';
-        let groundAlias = '';
-        
-        // Generate aliases with error handling
+    // Space controls
+    eventBus.onDom(
+      'spaceSelectAll',
+      'click',
+      'vertigo-space-select-all',
+      () => {
         try {
-            spaceAlias = vertigoManager.generateAlias('space');
+          vertigoManager.selectAllEffects('space')
+          this.updateVertigoCheckboxes('space')
+          this.updateVertigoEffectCounts()
+          this.updateVertigoPreview()
+
+          // Note: Don't save immediately - only save when "Generate Aliases" is clicked
         } catch (error) {
-            if (error instanceof InvalidEnvironmentError) {
-                stoUI.showToast(`Space alias error: ${error.message}`, 'error');
-                return;
-            } else {
-                stoUI.showToast('Failed to generate space alias', 'error');
-                console.error('Error generating space alias:', error);
-                return;
-            }
+          if (error instanceof InvalidEnvironmentError) {
+            stoUI.showToast(`Error: ${error.message}`, 'error')
+          } else {
+            stoUI.showToast('Failed to select all space effects', 'error')
+            console.error('Error selecting all space effects:', error)
+          }
         }
-        
+      }
+    )
+
+    eventBus.onDom('spaceClearAll', 'click', 'vertigo-space-clear-all', () => {
+      vertigoManager.selectedEffects.space.clear()
+      this.updateVertigoCheckboxes('space')
+      this.updateVertigoEffectCounts()
+      this.updateVertigoPreview()
+
+      // Note: Don't save immediately - only save when "Generate Aliases" is clicked
+    })
+
+    // Ground controls
+    eventBus.onDom(
+      'groundSelectAll',
+      'click',
+      'vertigo-ground-select-all',
+      () => {
         try {
-            groundAlias = vertigoManager.generateAlias('ground');
+          vertigoManager.selectAllEffects('ground')
+          this.updateVertigoCheckboxes('ground')
+          this.updateVertigoEffectCounts()
+          this.updateVertigoPreview()
+
+          // Note: Don't save immediately - only save when "Generate Aliases" is clicked
         } catch (error) {
-            if (error instanceof InvalidEnvironmentError) {
-                stoUI.showToast(`Ground alias error: ${error.message}`, 'error');
-                return;
-            } else {
-                stoUI.showToast('Failed to generate ground alias', 'error');
-                console.error('Error generating ground alias:', error);
-                return;
-            }
+          if (error instanceof InvalidEnvironmentError) {
+            stoUI.showToast(`Error: ${error.message}`, 'error')
+          } else {
+            stoUI.showToast('Failed to select all ground effects', 'error')
+            console.error('Error selecting all ground effects:', error)
+          }
         }
-        
-        if (!spaceAlias && !groundAlias) {
-            stoUI.showToast('No effects selected. Please select at least one effect to generate aliases.', 'warning');
-            return;
-        }
+      }
+    )
 
-        const currentProfile = this.getCurrentProfile();
-        if (!currentProfile) {
-            stoUI.showToast('No profile selected', 'error');
-            return;
-        }
+    eventBus.onDom(
+      'groundClearAll',
+      'click',
+      'vertigo-ground-clear-all',
+      () => {
+        vertigoManager.selectedEffects.ground.clear()
+        this.updateVertigoCheckboxes('ground')
+        this.updateVertigoEffectCounts()
+        this.updateVertigoPreview()
 
-        // Get the root profile object (not the build-specific view)
-        const rootProfile = stoStorage.getProfile(this.currentProfile);
-        if (!rootProfile) {
-            stoUI.showToast('No profile found', 'error');
-            return;
-        }
+        // Note: Don't save immediately - only save when "Generate Aliases" is clicked
+      }
+    )
 
-        let addedCount = 0;
+    // Show Player Say toggle
+    eventBus.onDom(
+      'vertigoShowPlayerSay',
+      'change',
+      'vertigo-show-playersay',
+      (e) => {
+        vertigoManager.showPlayerSay = e.target.checked
+        this.updateVertigoPreview()
 
-        // Ensure aliases structure exists at profile level (not build-specific)
-        if (!rootProfile.aliases) {
-            rootProfile.aliases = {};
-        }
+        // Note: Don't save immediately - only save when "Generate Aliases" is clicked
+      }
+    )
 
-        // Add space alias if effects are selected
-        if (spaceAlias) {
-            const spaceAliasName = 'dynFxSetFXExlusionList_Space';
-            // Extract commands from the full alias (remove the alias name and brackets)
-            // spaceAlias format: 'alias aliasName <& commands&>'
-            const match = spaceAlias.match(/alias\s+\w+\s+<&\s+(.+?)&>/);
-            const spaceCommands = match ? match[1] : '';
-            
-            rootProfile.aliases[spaceAliasName] = {
-                name: spaceAliasName,
-                description: 'VFX - Disable Space Visual Effects',
-                commands: spaceCommands,
-                created: new Date().toISOString(),
-                lastModified: new Date().toISOString()
-            };
-            addedCount++;
-        }
+    // Generate aliases button
+    eventBus.onDom('saveVertigoBtn', 'click', 'vertigo-save', () => {
+      this.generateVertigoAliases()
+    })
+  }
 
-        // Add ground alias if effects are selected
-        if (groundAlias) {
-            const groundAliasName = 'dynFxSetFXExlusionList_Ground';
-            // Extract commands from the full alias (remove the alias name and brackets)
-            // groundAlias format: 'alias aliasName <& commands&>'
-            const match = groundAlias.match(/alias\s+\w+\s+<&\s+(.+?)&>/);
-            const groundCommands = match ? match[1] : '';
-            
-            rootProfile.aliases[groundAliasName] = {
-                name: groundAliasName,
-                description: 'VFX - Disable Ground Visual Effects',
-                commands: groundCommands,
-                created: new Date().toISOString(),
-                lastModified: new Date().toISOString()
-            };
-            addedCount++;
-        }
+  updateVertigoCheckboxes(environment) {
+    const checkboxes = document.querySelectorAll(
+      `input[data-environment="${environment}"]`
+    )
+    checkboxes.forEach((checkbox) => {
+      const effectName = checkbox.dataset.effect
+      const isSelected = vertigoManager.isEffectSelected(
+        environment,
+        effectName
+      )
+      checkbox.checked = isSelected
+      checkbox.closest('.effect-item').classList.toggle('selected', isSelected)
+    })
+  }
 
-        // Save current state to root profile so it persists (commit the transaction)
-        vertigoManager.saveState(rootProfile);
+  updateVertigoEffectCounts() {
+    const spaceCount = vertigoManager.getEffectCount('space')
+    const groundCount = vertigoManager.getEffectCount('ground')
 
-        // Save the root profile to storage
-        stoStorage.saveProfile(this.currentProfile, rootProfile);
+    const spaceCounter = document.getElementById('spaceEffectCount')
+    const groundCounter = document.getElementById('groundEffectCount')
 
-        // Save the changes - follow the same pattern as aliases.js
-        this.saveProfile();
-        this.setModified(true);
-
-        // Update the command library to show the new VFX aliases
-        if (typeof stoAliases !== 'undefined' && stoAliases.updateCommandLibrary) {
-            stoAliases.updateCommandLibrary();
-        }
-
-        // Update the stored initial state to the new saved state
-        this.vertigoInitialState = {
-            selectedEffects: {
-                space: new Set(vertigoManager.selectedEffects.space),
-                ground: new Set(vertigoManager.selectedEffects.ground)
-            },
-            showPlayerSay: vertigoManager.showPlayerSay
-        };
-
-        // Set flag to indicate we're saving (not canceling)
-        this.vertigoSaving = true;
-
-        // Close modal and show success message
-        modalManager.hide('vertigoModal');
-        stoUI.showToast(`Generated ${addedCount} Vertigo alias${addedCount > 1 ? 'es' : ''}! Check the Alias Manager to bind them to keys.`, 'success');
+    if (spaceCounter) {
+      spaceCounter.textContent = `${spaceCount} selected`
     }
 
-    // Theme Management
-    applyTheme() {
-        const settings = stoStorage.getSettings();
-        const theme = settings.theme || 'default';
-        
-        if (theme === 'dark') {
-            document.documentElement.setAttribute('data-theme', 'dark');
+    if (groundCounter) {
+      groundCounter.textContent = `${groundCount} selected`
+    }
+  }
+
+  updateVertigoPreview() {
+    const spacePreview = document.getElementById('spaceAliasCommand')
+    const groundPreview = document.getElementById('groundAliasCommand')
+
+    // Update space preview
+    if (spacePreview) {
+      try {
+        const spaceAlias = vertigoManager.generateAlias('space')
+        spacePreview.textContent = spaceAlias || 'No space effects selected'
+      } catch (error) {
+        if (error instanceof InvalidEnvironmentError) {
+          spacePreview.textContent = 'Error: Invalid environment'
+          stoUI.showToast(`Space preview error: ${error.message}`, 'error')
         } else {
-            document.documentElement.removeAttribute('data-theme');
+          spacePreview.textContent = 'Error generating preview'
+          console.error('Error generating space alias preview:', error)
         }
-        
-        this.updateThemeToggleButton(theme);
+      }
     }
 
-    toggleTheme() {
-        const settings = stoStorage.getSettings();
-        const currentTheme = settings.theme || 'default';
-        const newTheme = currentTheme === 'dark' ? 'default' : 'dark';
-        
-        settings.theme = newTheme;
-        stoStorage.saveSettings(settings);
-        
-        this.applyTheme();
-        
-        const themeName = newTheme === 'dark' ? 'Dark Mode' : 'Light Mode';
-        stoUI.showToast(`Switched to ${themeName}`, 'success');
+    // Update ground preview
+    if (groundPreview) {
+      try {
+        const groundAlias = vertigoManager.generateAlias('ground')
+        groundPreview.textContent = groundAlias || 'No ground effects selected'
+      } catch (error) {
+        if (error instanceof InvalidEnvironmentError) {
+          groundPreview.textContent = 'Error: Invalid environment'
+          stoUI.showToast(`Ground preview error: ${error.message}`, 'error')
+        } else {
+          groundPreview.textContent = 'Error generating preview'
+          console.error('Error generating ground alias preview:', error)
+        }
+      }
+    }
+  }
+
+  generateVertigoAliases() {
+    let spaceAlias = ''
+    let groundAlias = ''
+
+    // Generate aliases with error handling
+    try {
+      spaceAlias = vertigoManager.generateAlias('space')
+    } catch (error) {
+      if (error instanceof InvalidEnvironmentError) {
+        stoUI.showToast(`Space alias error: ${error.message}`, 'error')
+        return
+      } else {
+        stoUI.showToast('Failed to generate space alias', 'error')
+        console.error('Error generating space alias:', error)
+        return
+      }
     }
 
-    updateThemeToggleButton(theme) {
-        const themeToggleBtn = document.getElementById('themeToggleBtn');
-        const themeToggleText = document.getElementById('themeToggleText');
-        const themeIcon = themeToggleBtn?.querySelector('i');
-        
-        if (themeToggleBtn && themeToggleText && themeIcon) {
-            if (theme === 'dark') {
-                themeIcon.className = 'fas fa-sun';
-                themeToggleText.textContent = 'Light Mode';
-            } else {
-                themeIcon.className = 'fas fa-moon';
-                themeToggleText.textContent = 'Dark Mode';
-            }
-        }
+    try {
+      groundAlias = vertigoManager.generateAlias('ground')
+    } catch (error) {
+      if (error instanceof InvalidEnvironmentError) {
+        stoUI.showToast(`Ground alias error: ${error.message}`, 'error')
+        return
+      } else {
+        stoUI.showToast('Failed to generate ground alias', 'error')
+        console.error('Error generating ground alias:', error)
+        return
+      }
     }
+
+    if (!spaceAlias && !groundAlias) {
+      stoUI.showToast(
+        'No effects selected. Please select at least one effect to generate aliases.',
+        'warning'
+      )
+      return
+    }
+
+    const currentProfile = this.getCurrentProfile()
+    if (!currentProfile) {
+      stoUI.showToast('No profile selected', 'error')
+      return
+    }
+
+    // Get the root profile object (not the build-specific view)
+    const rootProfile = stoStorage.getProfile(this.currentProfile)
+    if (!rootProfile) {
+      stoUI.showToast('No profile found', 'error')
+      return
+    }
+
+    let addedCount = 0
+
+    // Ensure aliases structure exists at profile level (not build-specific)
+    if (!rootProfile.aliases) {
+      rootProfile.aliases = {}
+    }
+
+    // Add space alias if effects are selected
+    if (spaceAlias) {
+      const spaceAliasName = 'dynFxSetFXExlusionList_Space'
+      // Extract commands from the full alias (remove the alias name and brackets)
+      // spaceAlias format: 'alias aliasName <& commands&>'
+      const match = spaceAlias.match(/alias\s+\w+\s+<&\s+(.+?)&>/)
+      const spaceCommands = match ? match[1] : ''
+
+      rootProfile.aliases[spaceAliasName] = {
+        name: spaceAliasName,
+        description: 'VFX - Disable Space Visual Effects',
+        commands: spaceCommands,
+        created: new Date().toISOString(),
+        lastModified: new Date().toISOString(),
+      }
+      addedCount++
+    }
+
+    // Add ground alias if effects are selected
+    if (groundAlias) {
+      const groundAliasName = 'dynFxSetFXExlusionList_Ground'
+      // Extract commands from the full alias (remove the alias name and brackets)
+      // groundAlias format: 'alias aliasName <& commands&>'
+      const match = groundAlias.match(/alias\s+\w+\s+<&\s+(.+?)&>/)
+      const groundCommands = match ? match[1] : ''
+
+      rootProfile.aliases[groundAliasName] = {
+        name: groundAliasName,
+        description: 'VFX - Disable Ground Visual Effects',
+        commands: groundCommands,
+        created: new Date().toISOString(),
+        lastModified: new Date().toISOString(),
+      }
+      addedCount++
+    }
+
+    // Save current state to root profile so it persists (commit the transaction)
+    vertigoManager.saveState(rootProfile)
+
+    // Save the root profile to storage
+    stoStorage.saveProfile(this.currentProfile, rootProfile)
+
+    // Save the changes - follow the same pattern as aliases.js
+    this.saveProfile()
+    this.setModified(true)
+
+    // Update the command library to show the new VFX aliases
+    if (typeof stoAliases !== 'undefined' && stoAliases.updateCommandLibrary) {
+      stoAliases.updateCommandLibrary()
+    }
+
+    // Update the stored initial state to the new saved state
+    this.vertigoInitialState = {
+      selectedEffects: {
+        space: new Set(vertigoManager.selectedEffects.space),
+        ground: new Set(vertigoManager.selectedEffects.ground),
+      },
+      showPlayerSay: vertigoManager.showPlayerSay,
+    }
+
+    // Set flag to indicate we're saving (not canceling)
+    this.vertigoSaving = true
+
+    // Close modal and show success message
+    modalManager.hide('vertigoModal')
+    stoUI.showToast(
+      `Generated ${addedCount} Vertigo alias${addedCount > 1 ? 'es' : ''}! Check the Alias Manager to bind them to keys.`,
+      'success'
+    )
+  }
+
+  // Theme Management
+  applyTheme() {
+    const settings = stoStorage.getSettings()
+    const theme = settings.theme || 'default'
+
+    if (theme === 'dark') {
+      document.documentElement.setAttribute('data-theme', 'dark')
+    } else {
+      document.documentElement.removeAttribute('data-theme')
+    }
+
+    this.updateThemeToggleButton(theme)
+  }
+
+  toggleTheme() {
+    const settings = stoStorage.getSettings()
+    const currentTheme = settings.theme || 'default'
+    const newTheme = currentTheme === 'dark' ? 'default' : 'dark'
+
+    settings.theme = newTheme
+    stoStorage.saveSettings(settings)
+
+    this.applyTheme()
+
+    const themeName = newTheme === 'dark' ? 'Dark Mode' : 'Light Mode'
+    stoUI.showToast(`Switched to ${themeName}`, 'success')
+  }
+
+  updateThemeToggleButton(theme) {
+    const themeToggleBtn = document.getElementById('themeToggleBtn')
+    const themeToggleText = document.getElementById('themeToggleText')
+    const themeIcon = themeToggleBtn?.querySelector('i')
+
+    if (themeToggleBtn && themeToggleText && themeIcon) {
+      if (theme === 'dark') {
+        themeIcon.className = 'fas fa-sun'
+        themeToggleText.textContent = 'Light Mode'
+      } else {
+        themeIcon.className = 'fas fa-moon'
+        themeToggleText.textContent = 'Dark Mode'
+      }
+    }
+  }
 }
 
 // Initialize application
-

--- a/src/js/commands.js
+++ b/src/js/commands.js
@@ -2,376 +2,453 @@
 // Handles command building, editing, and validation
 
 export default class STOCommandManager {
-    constructor() {
-        this.currentCommand = null;
-        this.commandBuilders = new Map();
-        this.init();
-    }
+  constructor() {
+    this.currentCommand = null
+    this.commandBuilders = new Map()
+    this.init()
+  }
 
-    init() {
-        this.setupCommandBuilders();
-        this.setupEventListeners();
-    }
+  init() {
+    this.setupCommandBuilders()
+    this.setupEventListeners()
+  }
 
-    // Command Builder Setup
-    setupCommandBuilders() {
-        // Targeting commands
-        this.commandBuilders.set('targeting', {
-            build: (commandId, params = {}) => {
-                const cmd = STO_DATA.commands.targeting.commands[commandId];
-                if (!cmd) return null;
-                
-                return {
-                    command: cmd.command,
-                    type: 'targeting',
-                    icon: cmd.icon,
-                    text: cmd.name,
-                    description: cmd.description
-                };
+  // Command Builder Setup
+  setupCommandBuilders() {
+    // Targeting commands
+    this.commandBuilders.set('targeting', {
+      build: (commandId, params = {}) => {
+        const cmd = STO_DATA.commands.targeting.commands[commandId]
+        if (!cmd) return null
+
+        return {
+          command: cmd.command,
+          type: 'targeting',
+          icon: cmd.icon,
+          text: cmd.name,
+          description: cmd.description,
+        }
+      },
+      getUI: () => this.createTargetingUI(),
+    })
+
+    // Combat commands
+    this.commandBuilders.set('combat', {
+      build: (commandId, params = {}) => {
+        const cmd = STO_DATA.commands.combat.commands[commandId]
+        if (!cmd) return null
+
+        return {
+          command: cmd.command,
+          type: 'combat',
+          icon: cmd.icon,
+          text: cmd.name,
+          description: cmd.description,
+        }
+      },
+      getUI: () => this.createCombatUI(),
+    })
+
+    // Tray execution commands
+    this.commandBuilders.set('tray', {
+      build: (commandId, params = {}) => {
+        const tray = params.tray || 0
+        const slot = params.slot || 0
+
+        // Handle backup tray commands
+        if (commandId === 'tray_with_backup') {
+          const backupTray = params.backup_tray || 0
+          const backupSlot = params.backup_slot || 0
+          const active = params.active || 'on'
+
+          return {
+            command: `TrayExecByTrayWithBackup ${tray} ${slot} ${backupTray} ${backupSlot} ${active === 'on' ? 1 : 0}`,
+            type: 'tray',
+            icon: '⚡',
+            text: `Execute Tray ${tray + 1} Slot ${slot + 1} (with backup)`,
+            description: `Execute ability in tray ${tray + 1}, slot ${slot + 1} with backup in tray ${backupTray + 1}, slot ${backupSlot + 1}`,
+            parameters: {
+              tray,
+              slot,
+              backup_tray: backupTray,
+              backup_slot: backupSlot,
+              active,
             },
-            getUI: () => this.createTargetingUI()
-        });
+          }
+        }
 
-        // Combat commands
-        this.commandBuilders.set('combat', {
-            build: (commandId, params = {}) => {
-                const cmd = STO_DATA.commands.combat.commands[commandId];
-                if (!cmd) return null;
-                
-                return {
-                    command: cmd.command,
-                    type: 'combat',
-                    icon: cmd.icon,
-                    text: cmd.name,
-                    description: cmd.description
-                };
-            },
-            getUI: () => this.createCombatUI()
-        });
+        // Handle tray range commands
+        if (commandId === 'tray_range') {
+          const startTray = params.start_tray || 0
+          const startSlot = params.start_slot || 0
+          const endTray = params.end_tray || 0
+          const endSlot = params.end_slot || 0
+          const commandType = params.command_type || 'STOTrayExecByTray'
 
-        // Tray execution commands
-        this.commandBuilders.set('tray', {
-            build: (commandId, params = {}) => {
-                const tray = params.tray || 0;
-                const slot = params.slot || 0;
-                
-                // Handle backup tray commands
-                if (commandId === 'tray_with_backup') {
-                    const backupTray = params.backup_tray || 0;
-                    const backupSlot = params.backup_slot || 0;
-                    const active = params.active || 'on';
-                    
-                    return {
-                        command: `TrayExecByTrayWithBackup ${tray} ${slot} ${backupTray} ${backupSlot} ${active === 'on' ? 1 : 0}`,
-                        type: 'tray',
-                        icon: '⚡',
-                        text: `Execute Tray ${tray + 1} Slot ${slot + 1} (with backup)`,
-                        description: `Execute ability in tray ${tray + 1}, slot ${slot + 1} with backup in tray ${backupTray + 1}, slot ${backupSlot + 1}`,
-                        parameters: { tray, slot, backup_tray: backupTray, backup_slot: backupSlot, active }
-                    };
-                }
-                
-                // Handle tray range commands
-                if (commandId === 'tray_range') {
-                    const startTray = params.start_tray || 0;
-                    const startSlot = params.start_slot || 0;
-                    const endTray = params.end_tray || 0;
-                    const endSlot = params.end_slot || 0;
-                    const commandType = params.command_type || 'STOTrayExecByTray';
-                    
-                    const commands = this.generateTrayRangeCommands(startTray, startSlot, endTray, endSlot, commandType);
-                    
-                    // Return an array of individual command objects instead of a single command with $$
-                    return commands.map((cmd, index) => ({
-                        command: cmd,
-                        type: 'tray',
-                        icon: '⚡',
-                        text: index === 0 ? `Execute Range: Tray ${startTray + 1} Slot ${startSlot + 1} to Tray ${endTray + 1} Slot ${endSlot + 1}` : cmd,
-                        description: index === 0 ? `Execute abilities from tray ${startTray + 1} slot ${startSlot + 1} to tray ${endTray + 1} slot ${endSlot + 1}` : cmd,
-                        parameters: index === 0 ? { start_tray: startTray, start_slot: startSlot, end_tray: endTray, end_slot: endSlot, command_type: commandType } : undefined
-                    }));
-                }
-                
-                // Handle tray range with backup commands
-                if (commandId === 'tray_range_with_backup') {
-                    const active = params.active || 1;
-                    const startTray = params.start_tray || 0;
-                    const startSlot = params.start_slot || 0;
-                    const endTray = params.end_tray || 0;
-                    const endSlot = params.end_slot || 0;
-                    const backupStartTray = params.backup_start_tray || 0;
-                    const backupStartSlot = params.backup_start_slot || 0;
-                    const backupEndTray = params.backup_end_tray || 0;
-                    const backupEndSlot = params.backup_end_slot || 0;
-                    
-                    const commands = this.generateTrayRangeWithBackupCommands(
-                        active, startTray, startSlot, endTray, endSlot,
-                        backupStartTray, backupStartSlot, backupEndTray, backupEndSlot
-                    );
-                    
-                    // Return an array of individual command objects instead of a single command with $$
-                    return commands.map((cmd, index) => ({
-                        command: cmd,
-                        type: 'tray',
-                        icon: '⚡',
-                        text: index === 0 ? `Execute Range with Backup: Tray ${startTray + 1}-${endTray + 1}` : cmd,
-                        description: index === 0 ? `Execute abilities from tray ${startTray + 1} to ${endTray + 1} with backup range` : cmd,
-                        parameters: index === 0 ? { 
-                            active, start_tray: startTray, start_slot: startSlot, end_tray: endTray, end_slot: endSlot,
-                            backup_start_tray: backupStartTray, backup_start_slot: backupStartSlot,
-                            backup_end_tray: backupEndTray, backup_end_slot: backupEndSlot
-                        } : undefined
-                    }));
-                }
-                
-                // Handle whole tray commands
-                if (commandId === 'whole_tray') {
-                    const commandType = params.command_type || 'STOTrayExecByTray';
-                    const commands = this.generateWholeTrayCommands(tray, commandType);
-                    
-                    // Return an array of individual command objects instead of a single command with $$
-                    return commands.map((cmd, index) => ({
-                        command: cmd,
-                        type: 'tray',
-                        icon: '⚡',
-                        text: index === 0 ? `Execute Whole Tray ${tray + 1}` : cmd,
-                        description: index === 0 ? `Execute all abilities in tray ${tray + 1}` : cmd,
-                        parameters: index === 0 ? { tray, command_type: commandType } : undefined
-                    }));
-                }
-                
-                // Handle whole tray with backup commands
-                if (commandId === 'whole_tray_with_backup') {
-                    const active = params.active || 1;
-                    const backupTray = params.backup_tray || 0;
-                    
-                    const commands = this.generateWholeTrayWithBackupCommands(active, tray, backupTray);
-                    
-                    // Return an array of individual command objects instead of a single command with $$
-                    return commands.map((cmd, index) => ({
-                        command: cmd,
-                        type: 'tray',
-                        icon: '⚡',
-                        text: index === 0 ? `Execute Whole Tray ${tray + 1} (with backup Tray ${backupTray + 1})` : cmd,
-                        description: index === 0 ? `Execute all abilities in tray ${tray + 1} with backup from tray ${backupTray + 1}` : cmd,
-                        parameters: index === 0 ? { active, tray, backup_tray: backupTray } : undefined
-                    }));
-                }
-                
-                // Regular tray command
-                const commandType = params.command_type || 'STOTrayExecByTray';
-                const prefix = '+';
-                
-                return {
-                    command: `${prefix}${commandType} ${tray} ${slot}`,
-                    type: 'tray',
-                    icon: '⚡',
-                    text: `Execute Tray ${tray + 1} Slot ${slot + 1}`,
-                    description: `Execute ability in tray ${tray + 1}, slot ${slot + 1}`,
-                    parameters: { tray, slot, command_type: commandType }
-                };
-            },
-            getUI: () => this.createTrayUI()
-        });
+          const commands = this.generateTrayRangeCommands(
+            startTray,
+            startSlot,
+            endTray,
+            endSlot,
+            commandType
+          )
 
-        // Shield management commands
-        this.commandBuilders.set('power', {
-            build: (commandId, params = {}) => {
-                const cmd = STO_DATA.commands.power.commands[commandId];
-                if (!cmd) return null;
-                
-                return {
-                    command: cmd.command,
-                    type: 'power',
-                    icon: cmd.icon,
-                    text: cmd.name,
-                    description: cmd.description
-                };
-            },
-            getUI: () => this.createPowerUI()
-        });
+          // Return an array of individual command objects instead of a single command with $$
+          return commands.map((cmd, index) => ({
+            command: cmd,
+            type: 'tray',
+            icon: '⚡',
+            text:
+              index === 0
+                ? `Execute Range: Tray ${startTray + 1} Slot ${startSlot + 1} to Tray ${endTray + 1} Slot ${endSlot + 1}`
+                : cmd,
+            description:
+              index === 0
+                ? `Execute abilities from tray ${startTray + 1} slot ${startSlot + 1} to tray ${endTray + 1} slot ${endSlot + 1}`
+                : cmd,
+            parameters:
+              index === 0
+                ? {
+                    start_tray: startTray,
+                    start_slot: startSlot,
+                    end_tray: endTray,
+                    end_slot: endSlot,
+                    command_type: commandType,
+                  }
+                : undefined,
+          }))
+        }
 
-        // Movement commands
-        this.commandBuilders.set('movement', {
-            build: (commandId, params = {}) => {
-                const cmd = STO_DATA.commands.movement.commands[commandId];
-                if (!cmd) return null;
-                
-                let command = cmd.command;
-                
-                // Handle parameterized movement commands
-                if (cmd.customizable && params) {
-                    if (commandId === 'throttle_adjust' && params.amount !== undefined) {
-                        command = `${cmd.command} ${params.amount}`;
-                    } else if (commandId === 'throttle_set' && params.position !== undefined) {
-                        command = `${cmd.command} ${params.position}`;
-                    }
-                }
-                
-                return {
-                    command: command,
-                    type: 'movement',
-                    icon: cmd.icon,
-                    text: cmd.name,
-                    description: cmd.description
-                };
-            },
-            getUI: () => this.createMovementUI()
-        });
+        // Handle tray range with backup commands
+        if (commandId === 'tray_range_with_backup') {
+          const active = params.active || 1
+          const startTray = params.start_tray || 0
+          const startSlot = params.start_slot || 0
+          const endTray = params.end_tray || 0
+          const endSlot = params.end_slot || 0
+          const backupStartTray = params.backup_start_tray || 0
+          const backupStartSlot = params.backup_start_slot || 0
+          const backupEndTray = params.backup_end_tray || 0
+          const backupEndSlot = params.backup_end_slot || 0
 
-        // Camera commands
-        this.commandBuilders.set('camera', {
-            build: (commandId, params = {}) => {
-                const cmd = STO_DATA.commands.camera.commands[commandId];
-                if (!cmd) return null;
-                
-                let command = cmd.command;
-                
-                // Handle parameterized camera commands
-                if (cmd.customizable && params) {
-                    if (commandId === 'cam_distance' && params.distance !== undefined) {
-                        command = `${cmd.command} ${params.distance}`;
-                    }
-                }
-                
-                return {
-                    command: command,
-                    type: 'camera',
-                    icon: cmd.icon,
-                    text: cmd.name,
-                    description: cmd.description
-                };
-            },
-            getUI: () => this.createCameraUI()
-        });
+          const commands = this.generateTrayRangeWithBackupCommands(
+            active,
+            startTray,
+            startSlot,
+            endTray,
+            endSlot,
+            backupStartTray,
+            backupStartSlot,
+            backupEndTray,
+            backupEndSlot
+          )
 
-        // Communication commands
-        this.commandBuilders.set('communication', {
-            build: (commandId, params = {}) => {
-                const cmd = STO_DATA.commands.communication.commands[commandId];
-                if (!cmd) return null;
-                
-                const message = params.message || 'Message text here';
-                
-                return {
-                    command: `${cmd.command} ${message}`,
-                    type: 'communication',
-                    icon: cmd.icon,
-                    text: `${cmd.name}: ${message}`,
-                    description: cmd.description,
-                    parameters: { message }
-                };
-            },
-            getUI: () => this.createCommunicationUI()
-        });
+          // Return an array of individual command objects instead of a single command with $$
+          return commands.map((cmd, index) => ({
+            command: cmd,
+            type: 'tray',
+            icon: '⚡',
+            text:
+              index === 0
+                ? `Execute Range with Backup: Tray ${startTray + 1}-${endTray + 1}`
+                : cmd,
+            description:
+              index === 0
+                ? `Execute abilities from tray ${startTray + 1} to ${endTray + 1} with backup range`
+                : cmd,
+            parameters:
+              index === 0
+                ? {
+                    active,
+                    start_tray: startTray,
+                    start_slot: startSlot,
+                    end_tray: endTray,
+                    end_slot: endSlot,
+                    backup_start_tray: backupStartTray,
+                    backup_start_slot: backupStartSlot,
+                    backup_end_tray: backupEndTray,
+                    backup_end_slot: backupEndSlot,
+                  }
+                : undefined,
+          }))
+        }
 
-        // System commands
-        this.commandBuilders.set('system', {
-            build: (commandId, params = {}) => {
-                const cmd = STO_DATA.commands.system.commands[commandId];
-                if (!cmd) return null;
-                
-                let command = cmd.command;
-                
-                // Handle parameterized system commands
-                if (cmd.customizable && params) {
-                    if ((commandId === 'bind_save_file' || commandId === 'bind_load_file') && params.filename) {
-                        command = `${cmd.command} ${params.filename}`;
-                    } else if (commandId === 'combat_log' && params.state !== undefined) {
-                        command = `${cmd.command} ${params.state}`;
-                    }
-                }
-                
-                return {
-                    command: command,
-                    type: 'system',
-                    icon: cmd.icon,
-                    text: cmd.name,
-                    description: cmd.description
-                };
-            },
-            getUI: () => this.createSystemUI()
-        });
+        // Handle whole tray commands
+        if (commandId === 'whole_tray') {
+          const commandType = params.command_type || 'STOTrayExecByTray'
+          const commands = this.generateWholeTrayCommands(tray, commandType)
 
-        // Alias commands
-        this.commandBuilders.set('alias', {
-            build: (commandId, params = {}) => {
-                const aliasName = params.alias_name || '';
-                
-                if (!aliasName.trim()) {
-                    return null;
-                }
-                
-                return {
-                    command: aliasName,
-                    type: 'alias',
-                    icon: '📝',
-                    text: `Alias: ${aliasName}`,
-                    description: 'Execute custom alias',
-                    parameters: { alias_name: aliasName }
-                };
-            },
-            getUI: () => this.createAliasUI()
-        });
+          // Return an array of individual command objects instead of a single command with $$
+          return commands.map((cmd, index) => ({
+            command: cmd,
+            type: 'tray',
+            icon: '⚡',
+            text: index === 0 ? `Execute Whole Tray ${tray + 1}` : cmd,
+            description:
+              index === 0 ? `Execute all abilities in tray ${tray + 1}` : cmd,
+            parameters:
+              index === 0 ? { tray, command_type: commandType } : undefined,
+          }))
+        }
 
-        // Custom commands
-        this.commandBuilders.set('custom', {
-            build: (commandId, params = {}) => {
-                const command = params.command || '';
-                const text = params.text || 'Custom Command';
-                
-                return {
-                    command: command,
-                    type: 'custom',
-                    icon: '⚙️',
-                    text: text,
-                    description: 'Custom command',
-                    parameters: { command, text }
-                };
-            },
-            getUI: () => this.createCustomUI()
-        });
-    }
+        // Handle whole tray with backup commands
+        if (commandId === 'whole_tray_with_backup') {
+          const active = params.active || 1
+          const backupTray = params.backup_tray || 0
 
-    // UI Builders for different command types
-    createTargetingUI() {
-        const commands = STO_DATA.commands.targeting.commands;
-        
-        return `
+          const commands = this.generateWholeTrayWithBackupCommands(
+            active,
+            tray,
+            backupTray
+          )
+
+          // Return an array of individual command objects instead of a single command with $$
+          return commands.map((cmd, index) => ({
+            command: cmd,
+            type: 'tray',
+            icon: '⚡',
+            text:
+              index === 0
+                ? `Execute Whole Tray ${tray + 1} (with backup Tray ${backupTray + 1})`
+                : cmd,
+            description:
+              index === 0
+                ? `Execute all abilities in tray ${tray + 1} with backup from tray ${backupTray + 1}`
+                : cmd,
+            parameters:
+              index === 0
+                ? { active, tray, backup_tray: backupTray }
+                : undefined,
+          }))
+        }
+
+        // Regular tray command
+        const commandType = params.command_type || 'STOTrayExecByTray'
+        const prefix = '+'
+
+        return {
+          command: `${prefix}${commandType} ${tray} ${slot}`,
+          type: 'tray',
+          icon: '⚡',
+          text: `Execute Tray ${tray + 1} Slot ${slot + 1}`,
+          description: `Execute ability in tray ${tray + 1}, slot ${slot + 1}`,
+          parameters: { tray, slot, command_type: commandType },
+        }
+      },
+      getUI: () => this.createTrayUI(),
+    })
+
+    // Shield management commands
+    this.commandBuilders.set('power', {
+      build: (commandId, params = {}) => {
+        const cmd = STO_DATA.commands.power.commands[commandId]
+        if (!cmd) return null
+
+        return {
+          command: cmd.command,
+          type: 'power',
+          icon: cmd.icon,
+          text: cmd.name,
+          description: cmd.description,
+        }
+      },
+      getUI: () => this.createPowerUI(),
+    })
+
+    // Movement commands
+    this.commandBuilders.set('movement', {
+      build: (commandId, params = {}) => {
+        const cmd = STO_DATA.commands.movement.commands[commandId]
+        if (!cmd) return null
+
+        let command = cmd.command
+
+        // Handle parameterized movement commands
+        if (cmd.customizable && params) {
+          if (commandId === 'throttle_adjust' && params.amount !== undefined) {
+            command = `${cmd.command} ${params.amount}`
+          } else if (
+            commandId === 'throttle_set' &&
+            params.position !== undefined
+          ) {
+            command = `${cmd.command} ${params.position}`
+          }
+        }
+
+        return {
+          command: command,
+          type: 'movement',
+          icon: cmd.icon,
+          text: cmd.name,
+          description: cmd.description,
+        }
+      },
+      getUI: () => this.createMovementUI(),
+    })
+
+    // Camera commands
+    this.commandBuilders.set('camera', {
+      build: (commandId, params = {}) => {
+        const cmd = STO_DATA.commands.camera.commands[commandId]
+        if (!cmd) return null
+
+        let command = cmd.command
+
+        // Handle parameterized camera commands
+        if (cmd.customizable && params) {
+          if (commandId === 'cam_distance' && params.distance !== undefined) {
+            command = `${cmd.command} ${params.distance}`
+          }
+        }
+
+        return {
+          command: command,
+          type: 'camera',
+          icon: cmd.icon,
+          text: cmd.name,
+          description: cmd.description,
+        }
+      },
+      getUI: () => this.createCameraUI(),
+    })
+
+    // Communication commands
+    this.commandBuilders.set('communication', {
+      build: (commandId, params = {}) => {
+        const cmd = STO_DATA.commands.communication.commands[commandId]
+        if (!cmd) return null
+
+        const message = params.message || 'Message text here'
+
+        return {
+          command: `${cmd.command} ${message}`,
+          type: 'communication',
+          icon: cmd.icon,
+          text: `${cmd.name}: ${message}`,
+          description: cmd.description,
+          parameters: { message },
+        }
+      },
+      getUI: () => this.createCommunicationUI(),
+    })
+
+    // System commands
+    this.commandBuilders.set('system', {
+      build: (commandId, params = {}) => {
+        const cmd = STO_DATA.commands.system.commands[commandId]
+        if (!cmd) return null
+
+        let command = cmd.command
+
+        // Handle parameterized system commands
+        if (cmd.customizable && params) {
+          if (
+            (commandId === 'bind_save_file' ||
+              commandId === 'bind_load_file') &&
+            params.filename
+          ) {
+            command = `${cmd.command} ${params.filename}`
+          } else if (commandId === 'combat_log' && params.state !== undefined) {
+            command = `${cmd.command} ${params.state}`
+          }
+        }
+
+        return {
+          command: command,
+          type: 'system',
+          icon: cmd.icon,
+          text: cmd.name,
+          description: cmd.description,
+        }
+      },
+      getUI: () => this.createSystemUI(),
+    })
+
+    // Alias commands
+    this.commandBuilders.set('alias', {
+      build: (commandId, params = {}) => {
+        const aliasName = params.alias_name || ''
+
+        if (!aliasName.trim()) {
+          return null
+        }
+
+        return {
+          command: aliasName,
+          type: 'alias',
+          icon: '📝',
+          text: `Alias: ${aliasName}`,
+          description: 'Execute custom alias',
+          parameters: { alias_name: aliasName },
+        }
+      },
+      getUI: () => this.createAliasUI(),
+    })
+
+    // Custom commands
+    this.commandBuilders.set('custom', {
+      build: (commandId, params = {}) => {
+        const command = params.command || ''
+        const text = params.text || 'Custom Command'
+
+        return {
+          command: command,
+          type: 'custom',
+          icon: '⚙️',
+          text: text,
+          description: 'Custom command',
+          parameters: { command, text },
+        }
+      },
+      getUI: () => this.createCustomUI(),
+    })
+  }
+
+  // UI Builders for different command types
+  createTargetingUI() {
+    const commands = STO_DATA.commands.targeting.commands
+
+    return `
             <div class="command-selector">
                 <label for="targetingCommand">Targeting Command:</label>
                 <select id="targetingCommand">
                     <option value="">Select targeting command...</option>
-                    ${Object.entries(commands).map(([id, cmd]) => 
-                        `<option value="${id}">${cmd.name}</option>`
-                    ).join('')}
+                    ${Object.entries(commands)
+                      .map(
+                        ([id, cmd]) =>
+                          `<option value="${id}">${cmd.name}</option>`
+                      )
+                      .join('')}
                 </select>
             </div>
-        `;
-    }
+        `
+  }
 
-    createCombatUI() {
-        const commands = STO_DATA.commands.combat.commands;
-        
-        return `
+  createCombatUI() {
+    const commands = STO_DATA.commands.combat.commands
+
+    return `
             <div class="command-selector">
                 <label for="combatCommand">Combat Command:</label>
                 <select id="combatCommand">
                     <option value="">Select combat command...</option>
-                    ${Object.entries(commands).map(([id, cmd]) => 
-                        `<option value="${id}">${cmd.name}</option>`
-                    ).join('')}
+                    ${Object.entries(commands)
+                      .map(
+                        ([id, cmd]) =>
+                          `<option value="${id}">${cmd.name}</option>`
+                      )
+                      .join('')}
                 </select>
                 <div id="combatCommandWarning" class="command-warning" style="display: none;">
                     <i class="fas fa-exclamation-triangle"></i>
                     <span id="combatWarningText"></span>
                 </div>
             </div>
-        `;
-    }
+        `
+  }
 
-    createTrayUI() {
-        return `
+  createTrayUI() {
+    return `
             <div class="tray-builder">
                 <div class="form-group">
                     <label for="trayCommandType">Command Type:</label>
@@ -391,7 +468,9 @@ export default class STOCommandManager {
                         <div class="form-group">
                             <label for="trayNumber">Tray Number:</label>
                             <select id="trayNumber">
-                                ${Array.from({length: 10}, (_, i) => 
+                                ${Array.from(
+                                  { length: 10 },
+                                  (_, i) =>
                                     `<option value="${i}">Tray ${i + 1}</option>`
                                 ).join('')}
                             </select>
@@ -399,7 +478,9 @@ export default class STOCommandManager {
                         <div class="form-group">
                             <label for="slotNumber">Slot Number:</label>
                             <select id="slotNumber">
-                                ${Array.from({length: 10}, (_, i) => 
+                                ${Array.from(
+                                  { length: 10 },
+                                  (_, i) =>
                                     `<option value="${i}">Slot ${i + 1}</option>`
                                 ).join('')}
                             </select>
@@ -414,7 +495,9 @@ export default class STOCommandManager {
                         <div class="form-group">
                             <label for="backupTrayNumber">Backup Tray:</label>
                             <select id="backupTrayNumber">
-                                ${Array.from({length: 10}, (_, i) => 
+                                ${Array.from(
+                                  { length: 10 },
+                                  (_, i) =>
                                     `<option value="${i}">Tray ${i + 1}</option>`
                                 ).join('')}
                             </select>
@@ -422,7 +505,9 @@ export default class STOCommandManager {
                         <div class="form-group">
                             <label for="backupSlotNumber">Backup Slot:</label>
                             <select id="backupSlotNumber">
-                                ${Array.from({length: 10}, (_, i) => 
+                                ${Array.from(
+                                  { length: 10 },
+                                  (_, i) =>
                                     `<option value="${i}">Slot ${i + 1}</option>`
                                 ).join('')}
                             </select>
@@ -444,7 +529,9 @@ export default class STOCommandManager {
                         <div class="form-group">
                             <label for="startTrayNumber">Start Tray:</label>
                             <select id="startTrayNumber">
-                                ${Array.from({length: 10}, (_, i) => 
+                                ${Array.from(
+                                  { length: 10 },
+                                  (_, i) =>
                                     `<option value="${i}">Tray ${i + 1}</option>`
                                 ).join('')}
                             </select>
@@ -452,7 +539,9 @@ export default class STOCommandManager {
                         <div class="form-group">
                             <label for="startSlotNumber">Start Slot:</label>
                             <select id="startSlotNumber">
-                                ${Array.from({length: 10}, (_, i) => 
+                                ${Array.from(
+                                  { length: 10 },
+                                  (_, i) =>
                                     `<option value="${i}">Slot ${i + 1}</option>`
                                 ).join('')}
                             </select>
@@ -462,7 +551,9 @@ export default class STOCommandManager {
                         <div class="form-group">
                             <label for="endTrayNumber">End Tray:</label>
                             <select id="endTrayNumber">
-                                ${Array.from({length: 10}, (_, i) => 
+                                ${Array.from(
+                                  { length: 10 },
+                                  (_, i) =>
                                     `<option value="${i}">Tray ${i + 1}</option>`
                                 ).join('')}
                             </select>
@@ -470,7 +561,9 @@ export default class STOCommandManager {
                         <div class="form-group">
                             <label for="endSlotNumber">End Slot:</label>
                             <select id="endSlotNumber">
-                                ${Array.from({length: 10}, (_, i) => 
+                                ${Array.from(
+                                  { length: 10 },
+                                  (_, i) =>
                                     `<option value="${i}">Slot ${i + 1}</option>`
                                 ).join('')}
                             </select>
@@ -485,7 +578,9 @@ export default class STOCommandManager {
                         <div class="form-group">
                             <label for="backupStartTrayNumber">Backup Start Tray:</label>
                             <select id="backupStartTrayNumber">
-                                ${Array.from({length: 10}, (_, i) => 
+                                ${Array.from(
+                                  { length: 10 },
+                                  (_, i) =>
                                     `<option value="${i}">Tray ${i + 1}</option>`
                                 ).join('')}
                             </select>
@@ -493,7 +588,9 @@ export default class STOCommandManager {
                         <div class="form-group">
                             <label for="backupStartSlotNumber">Backup Start Slot:</label>
                             <select id="backupStartSlotNumber">
-                                ${Array.from({length: 10}, (_, i) => 
+                                ${Array.from(
+                                  { length: 10 },
+                                  (_, i) =>
                                     `<option value="${i}">Slot ${i + 1}</option>`
                                 ).join('')}
                             </select>
@@ -503,7 +600,9 @@ export default class STOCommandManager {
                         <div class="form-group">
                             <label for="backupEndTrayNumber">Backup End Tray:</label>
                             <select id="backupEndTrayNumber">
-                                ${Array.from({length: 10}, (_, i) => 
+                                ${Array.from(
+                                  { length: 10 },
+                                  (_, i) =>
                                     `<option value="${i}">Tray ${i + 1}</option>`
                                 ).join('')}
                             </select>
@@ -511,7 +610,9 @@ export default class STOCommandManager {
                         <div class="form-group">
                             <label for="backupEndSlotNumber">Backup End Slot:</label>
                             <select id="backupEndSlotNumber">
-                                ${Array.from({length: 10}, (_, i) => 
+                                ${Array.from(
+                                  { length: 10 },
+                                  (_, i) =>
                                     `<option value="${i}">Slot ${i + 1}</option>`
                                 ).join('')}
                             </select>
@@ -534,40 +635,46 @@ export default class STOCommandManager {
                     <!-- Visual tray representation will be generated here -->
                 </div>
             </div>
-        `;
-    }
+        `
+  }
 
-    createPowerUI() {
-        const commands = STO_DATA.commands.power.commands;
-        
-        return `
+  createPowerUI() {
+    const commands = STO_DATA.commands.power.commands
+
+    return `
             <div class="command-selector">
                 <label for="powerCommand">Shield Command:</label>
                 <select id="powerCommand">
                     <option value="">Select shield command...</option>
-                    ${Object.entries(commands).map(([id, cmd]) => 
-                        `<option value="${id}">${cmd.name}</option>`
-                    ).join('')}
+                    ${Object.entries(commands)
+                      .map(
+                        ([id, cmd]) =>
+                          `<option value="${id}">${cmd.name}</option>`
+                      )
+                      .join('')}
                 </select>
                 <div id="powerCommandWarning" class="command-warning" style="display: none;">
                     <i class="fas fa-exclamation-triangle"></i>
                     <span id="powerWarningText"></span>
                 </div>
             </div>
-        `;
-    }
+        `
+  }
 
-    createMovementUI() {
-        const commands = STO_DATA.commands.movement.commands;
-        
-        return `
+  createMovementUI() {
+    const commands = STO_DATA.commands.movement.commands
+
+    return `
             <div class="command-selector">
                 <label for="movementCommand">Movement Command:</label>
                 <select id="movementCommand">
                     <option value="">Select movement command...</option>
-                    ${Object.entries(commands).map(([id, cmd]) => 
-                        `<option value="${id}">${cmd.name}</option>`
-                    ).join('')}
+                    ${Object.entries(commands)
+                      .map(
+                        ([id, cmd]) =>
+                          `<option value="${id}">${cmd.name}</option>`
+                      )
+                      .join('')}
                 </select>
                 <div id="movementParams" style="display: none;">
                     <div class="form-group">
@@ -580,21 +687,24 @@ export default class STOCommandManager {
                     </div>
                 </div>
             </div>
-        `;
-    }
+        `
+  }
 
-    createCommunicationUI() {
-        const commands = STO_DATA.commands.communication.commands;
-        
-        return `
+  createCommunicationUI() {
+    const commands = STO_DATA.commands.communication.commands
+
+    return `
             <div class="communication-builder">
                 <div class="form-group">
                     <label for="commCommand">Communication Type:</label>
                     <select id="commCommand">
                         <option value="">Select communication type...</option>
-                        ${Object.entries(commands).map(([id, cmd]) => 
-                            `<option value="${id}">${cmd.name}</option>`
-                        ).join('')}
+                        ${Object.entries(commands)
+                          .map(
+                            ([id, cmd]) =>
+                              `<option value="${id}">${cmd.name}</option>`
+                          )
+                          .join('')}
                     </select>
                 </div>
                 <div class="form-group">
@@ -615,20 +725,23 @@ export default class STOCommandManager {
                     </div>
                 </div>
             </div>
-        `;
-    }
+        `
+  }
 
-    createCameraUI() {
-        const commands = STO_DATA.commands.camera.commands;
-        
-        return `
+  createCameraUI() {
+    const commands = STO_DATA.commands.camera.commands
+
+    return `
             <div class="command-selector">
                 <label for="cameraCommand">Camera Command:</label>
                 <select id="cameraCommand">
                     <option value="">Select camera command...</option>
-                    ${Object.entries(commands).map(([id, cmd]) => 
-                        `<option value="${id}">${cmd.name}</option>`
-                    ).join('')}
+                    ${Object.entries(commands)
+                      .map(
+                        ([id, cmd]) =>
+                          `<option value="${id}">${cmd.name}</option>`
+                      )
+                      .join('')}
                 </select>
                 <div id="cameraParams" style="display: none;">
                     <div class="form-group">
@@ -637,20 +750,23 @@ export default class STOCommandManager {
                     </div>
                 </div>
             </div>
-        `;
-    }
+        `
+  }
 
-    createSystemUI() {
-        const commands = STO_DATA.commands.system.commands;
-        
-        return `
+  createSystemUI() {
+    const commands = STO_DATA.commands.system.commands
+
+    return `
             <div class="command-selector">
                 <label for="systemCommand">System Command:</label>
                 <select id="systemCommand">
                     <option value="">Select system command...</option>
-                    ${Object.entries(commands).map(([id, cmd]) => 
-                        `<option value="${id}">${cmd.name}</option>`
-                    ).join('')}
+                    ${Object.entries(commands)
+                      .map(
+                        ([id, cmd]) =>
+                          `<option value="${id}">${cmd.name}</option>`
+                      )
+                      .join('')}
                 </select>
                 <div id="systemParams" style="display: none;">
                     <div class="form-group">
@@ -663,17 +779,17 @@ export default class STOCommandManager {
                     </div>
                 </div>
             </div>
-        `;
-    }
+        `
+  }
 
-    createAliasUI() {
-        // Get available aliases from current profile
-        const profile = app?.getCurrentProfile();
-        const aliases = profile?.aliases || {};
-        const aliasEntries = Object.entries(aliases);
-        
-        if (aliasEntries.length === 0) {
-            return `
+  createAliasUI() {
+    // Get available aliases from current profile
+    const profile = app?.getCurrentProfile()
+    const aliases = profile?.aliases || {}
+    const aliasEntries = Object.entries(aliases)
+
+    if (aliasEntries.length === 0) {
+      return `
                 <div class="alias-builder">
                     <div class="empty-state">
                         <i class="fas fa-mask"></i>
@@ -684,18 +800,21 @@ export default class STOCommandManager {
                         </button>
                     </div>
                 </div>
-            `;
-        }
-        
-        return `
+            `
+    }
+
+    return `
             <div class="alias-builder">
                 <div class="form-group">
                     <label for="aliasSelect">Available Aliases:</label>
                     <select id="aliasSelect">
                         <option value="">Select an alias...</option>
-                        ${aliasEntries.map(([name, alias]) => 
-                            `<option value="${name}">${name}${alias.description ? ' - ' + alias.description : ''}</option>`
-                        ).join('')}
+                        ${aliasEntries
+                          .map(
+                            ([name, alias]) =>
+                              `<option value="${name}">${name}${alias.description ? ' - ' + alias.description : ''}</option>`
+                          )
+                          .join('')}
                     </select>
                 </div>
                 <div id="aliasPreviewSection" style="display: none;">
@@ -705,11 +824,11 @@ export default class STOCommandManager {
                     </div>
                 </div>
             </div>
-        `;
-    }
+        `
+  }
 
-    createCustomUI() {
-        return `
+  createCustomUI() {
+    return `
             <div class="custom-builder">
                 <div class="form-group">
                     <label for="customCommand">Command:</label>
@@ -743,815 +862,995 @@ export default class STOCommandManager {
                     </div>
                 </div>
             </div>
-        `;
-    }
+        `
+  }
 
-    // Event Listeners
-    setupEventListeners() {
-        // Command type change handler
-        document.addEventListener('change', (e) => {
-            if (e.target.id === 'commandType') {
-                this.handleCommandTypeChange(e.target.value);
-            }
-        });
+  // Event Listeners
+  setupEventListeners() {
+    // Command type change handler
+    document.addEventListener('change', (e) => {
+      if (e.target.id === 'commandType') {
+        this.handleCommandTypeChange(e.target.value)
+      }
+    })
 
-        // Tray visual updates
-        document.addEventListener('change', (e) => {
-            if (e.target.id === 'trayNumber' || e.target.id === 'slotNumber') {
-                this.updateTrayVisual();
-                this.updateCommandPreview();
-            }
-        });
+    // Tray visual updates
+    document.addEventListener('change', (e) => {
+      if (e.target.id === 'trayNumber' || e.target.id === 'slotNumber') {
+        this.updateTrayVisual()
+        this.updateCommandPreview()
+      }
+    })
 
-        // Communication message updates
-        document.addEventListener('input', (e) => {
-            if (e.target.id === 'commMessage') {
-                this.updateCommandPreview();
-            }
-        });
+    // Communication message updates
+    document.addEventListener('input', (e) => {
+      if (e.target.id === 'commMessage') {
+        this.updateCommandPreview()
+      }
+    })
 
-        // Custom command updates
-        document.addEventListener('input', (e) => {
-            if (e.target.id === 'customCommand' || e.target.id === 'customText') {
-                this.updateCommandPreview();
-            }
-        });
+    // Custom command updates
+    document.addEventListener('input', (e) => {
+      if (e.target.id === 'customCommand' || e.target.id === 'customText') {
+        this.updateCommandPreview()
+      }
+    })
 
-        // Example command buttons
-        document.addEventListener('click', (e) => {
-            if (e.target.classList.contains('example-cmd')) {
-                const cmd = e.target.dataset.cmd;
-                const input = document.getElementById('customCommand');
-                if (input) {
-                    input.value = cmd;
-                    this.updateCommandPreview();
-                }
-            }
-        });
-
-        // Insert $Target variable buttons
-        document.addEventListener('click', (e) => {
-            if (e.target.classList.contains('insert-target-btn') || e.target.closest('.insert-target-btn')) {
-                e.preventDefault();
-                const button = e.target.classList.contains('insert-target-btn') ? e.target : e.target.closest('.insert-target-btn');
-                const inputContainer = button.closest('.input-with-button');
-                const input = inputContainer ? inputContainer.querySelector('input') : null;
-                
-                if (input) {
-                    this.insertTargetVariable(input);
-                }
-            }
-        });
-
-        // Command selection changes
-        document.addEventListener('change', (e) => {
-            const commandSelectors = [
-                'targetingCommand', 'combatCommand', 'powerCommand', 
-                'movementCommand', 'cameraCommand', 'systemCommand', 'commCommand', 'aliasSelect'
-            ];
-            
-            if (commandSelectors.includes(e.target.id)) {
-                this.updateCommandPreview();
-            }
-        });
-    }
-
-    // Command Type Change Handler
-    handleCommandTypeChange(type) {
-        const builder = document.getElementById('commandBuilder');
-        const preview = document.getElementById('modalCommandPreview');
-        const saveBtn = document.getElementById('saveCommandBtn');
-        
-        if (!builder) return;
-        
-        if (type && this.commandBuilders.has(type)) {
-            const ui = this.commandBuilders.get(type).getUI();
-            builder.innerHTML = ui;
-            
-            // Setup specific event listeners for this type
-            this.setupTypeSpecificListeners(type);
-            
-            // Enable save button
-            if (saveBtn) saveBtn.disabled = false;
-            
-            // Update preview
-            this.updateCommandPreview();
-        } else {
-            builder.innerHTML = '<p class="text-muted">Select a command type to configure options.</p>';
-            if (preview) preview.textContent = 'Select a command type to see preview';
-            if (saveBtn) saveBtn.disabled = true;
+    // Example command buttons
+    document.addEventListener('click', (e) => {
+      if (e.target.classList.contains('example-cmd')) {
+        const cmd = e.target.dataset.cmd
+        const input = document.getElementById('customCommand')
+        if (input) {
+          input.value = cmd
+          this.updateCommandPreview()
         }
+      }
+    })
+
+    // Insert $Target variable buttons
+    document.addEventListener('click', (e) => {
+      if (
+        e.target.classList.contains('insert-target-btn') ||
+        e.target.closest('.insert-target-btn')
+      ) {
+        e.preventDefault()
+        const button = e.target.classList.contains('insert-target-btn')
+          ? e.target
+          : e.target.closest('.insert-target-btn')
+        const inputContainer = button.closest('.input-with-button')
+        const input = inputContainer
+          ? inputContainer.querySelector('input')
+          : null
+
+        if (input) {
+          this.insertTargetVariable(input)
+        }
+      }
+    })
+
+    // Command selection changes
+    document.addEventListener('change', (e) => {
+      const commandSelectors = [
+        'targetingCommand',
+        'combatCommand',
+        'powerCommand',
+        'movementCommand',
+        'cameraCommand',
+        'systemCommand',
+        'commCommand',
+        'aliasSelect',
+      ]
+
+      if (commandSelectors.includes(e.target.id)) {
+        this.updateCommandPreview()
+      }
+    })
+  }
+
+  // Command Type Change Handler
+  handleCommandTypeChange(type) {
+    const builder = document.getElementById('commandBuilder')
+    const preview = document.getElementById('modalCommandPreview')
+    const saveBtn = document.getElementById('saveCommandBtn')
+
+    if (!builder) return
+
+    if (type && this.commandBuilders.has(type)) {
+      const ui = this.commandBuilders.get(type).getUI()
+      builder.innerHTML = ui
+
+      // Setup specific event listeners for this type
+      this.setupTypeSpecificListeners(type)
+
+      // Enable save button
+      if (saveBtn) saveBtn.disabled = false
+
+      // Update preview
+      this.updateCommandPreview()
+    } else {
+      builder.innerHTML =
+        '<p class="text-muted">Select a command type to configure options.</p>'
+      if (preview) preview.textContent = 'Select a command type to see preview'
+      if (saveBtn) saveBtn.disabled = true
+    }
+  }
+
+  setupTypeSpecificListeners(type) {
+    if (type === 'tray') {
+      this.updateTrayVisual()
+
+      // Add listener for tray command type selection
+      const trayCommandType = document.getElementById('trayCommandType')
+      if (trayCommandType) {
+        trayCommandType.addEventListener('change', () => {
+          this.updateTrayConfigSections(trayCommandType.value)
+          this.updateCommandPreview()
+        })
+
+        // Initialize with default selection
+        this.updateTrayConfigSections(trayCommandType.value)
+      }
+
+      // Add listeners for all tray configuration inputs
+      const inputs = [
+        'trayNumber',
+        'slotNumber',
+        'backupTrayNumber',
+        'backupSlotNumber',
+        'activeState',
+        'startTrayNumber',
+        'startSlotNumber',
+        'endTrayNumber',
+        'endSlotNumber',
+        'backupStartTrayNumber',
+        'backupStartSlotNumber',
+        'backupEndTrayNumber',
+        'backupEndSlotNumber',
+        'trayCommandVariant',
+      ]
+
+      inputs.forEach((inputId) => {
+        const input = document.getElementById(inputId)
+        if (input) {
+          input.addEventListener('change', () => {
+            this.updateTrayVisual()
+            this.updateCommandPreview()
+          })
+        }
+      })
+    } else if (type === 'power') {
+      // Add power command change listener for warnings
+      const powerSelect = document.getElementById('powerCommand')
+      if (powerSelect) {
+        powerSelect.addEventListener('change', () => {
+          this.showPowerWarning(powerSelect.value)
+        })
+      }
+    } else if (type === 'combat') {
+      // Add combat command change listener for warnings
+      const combatSelect = document.getElementById('combatCommand')
+      if (combatSelect) {
+        combatSelect.addEventListener('change', () => {
+          this.showCombatWarning(combatSelect.value)
+        })
+      }
+    } else if (type === 'alias') {
+      // Add alias selection listener
+      const aliasSelect = document.getElementById('aliasSelect')
+      if (aliasSelect) {
+        aliasSelect.addEventListener('change', () => {
+          this.updateAliasPreview(aliasSelect.value)
+          this.updateCommandPreview()
+        })
+      }
+
+      // Add create alias button listener
+      const createBtn = document.getElementById('openAliasManager')
+      if (createBtn) {
+        createBtn.addEventListener('click', () => {
+          if (
+            typeof stoAliases !== 'undefined' &&
+            stoAliases.showAliasManager
+          ) {
+            stoAliases.showAliasManager()
+          } else {
+            stoUI.hideModal('addCommandModal')
+            stoUI.showModal('aliasManagerModal')
+          }
+        })
+      }
+    }
+  }
+
+  // Update tray configuration sections based on selected command type
+  updateTrayConfigSections(commandType) {
+    const sections = {
+      singleTrayConfig: document.getElementById('singleTrayConfig'),
+      backupConfig: document.getElementById('backupConfig'),
+      rangeConfig: document.getElementById('rangeConfig'),
+      backupRangeConfig: document.getElementById('backupRangeConfig'),
+      commandTypeConfig: document.getElementById('commandTypeConfig'),
     }
 
-    setupTypeSpecificListeners(type) {
-        if (type === 'tray') {
-            this.updateTrayVisual();
-            
-            // Add listener for tray command type selection
-            const trayCommandType = document.getElementById('trayCommandType');
-            if (trayCommandType) {
-                trayCommandType.addEventListener('change', () => {
-                    this.updateTrayConfigSections(trayCommandType.value);
-                    this.updateCommandPreview();
-                });
-                
-                // Initialize with default selection
-                this.updateTrayConfigSections(trayCommandType.value);
-            }
-            
-            // Add listeners for all tray configuration inputs
-            const inputs = [
-                'trayNumber', 'slotNumber', 'backupTrayNumber', 'backupSlotNumber', 'activeState',
-                'startTrayNumber', 'startSlotNumber', 'endTrayNumber', 'endSlotNumber',
-                'backupStartTrayNumber', 'backupStartSlotNumber', 'backupEndTrayNumber', 'backupEndSlotNumber',
-                'trayCommandVariant'
-            ];
-            
-            inputs.forEach(inputId => {
-                const input = document.getElementById(inputId);
-                if (input) {
-                    input.addEventListener('change', () => {
-                        this.updateTrayVisual();
-                        this.updateCommandPreview();
-                    });
-                }
-            });
-        } else if (type === 'power') {
-            // Add power command change listener for warnings
-            const powerSelect = document.getElementById('powerCommand');
-            if (powerSelect) {
-                powerSelect.addEventListener('change', () => {
-                    this.showPowerWarning(powerSelect.value);
-                });
-            }
-        } else if (type === 'combat') {
-            // Add combat command change listener for warnings
-            const combatSelect = document.getElementById('combatCommand');
-            if (combatSelect) {
-                combatSelect.addEventListener('change', () => {
-                    this.showCombatWarning(combatSelect.value);
-                });
-            }
-        } else if (type === 'alias') {
-            // Add alias selection listener
-            const aliasSelect = document.getElementById('aliasSelect');
-            if (aliasSelect) {
-                aliasSelect.addEventListener('change', () => {
-                    this.updateAliasPreview(aliasSelect.value);
-                    this.updateCommandPreview();
-                });
-            }
-            
-            // Add create alias button listener
-            const createBtn = document.getElementById('openAliasManager');
-            if (createBtn) {
-                createBtn.addEventListener('click', () => {
-                    if (typeof stoAliases !== 'undefined' && stoAliases.showAliasManager) {
-                        stoAliases.showAliasManager();
-                    } else {
-                        stoUI.hideModal('addCommandModal');
-                        stoUI.showModal('aliasManagerModal');
-                    }
-                });
-            }
-        }
+    // Hide all sections first
+    Object.values(sections).forEach((section) => {
+      if (section) section.style.display = 'none'
+    })
+
+    // Show relevant sections based on command type
+    switch (commandType) {
+      case 'custom_tray':
+        if (sections.singleTrayConfig)
+          sections.singleTrayConfig.style.display = 'block'
+        if (sections.commandTypeConfig)
+          sections.commandTypeConfig.style.display = 'block'
+        break
+
+      case 'tray_with_backup':
+        if (sections.singleTrayConfig)
+          sections.singleTrayConfig.style.display = 'block'
+        if (sections.backupConfig) sections.backupConfig.style.display = 'block'
+        break
+
+      case 'tray_range':
+        if (sections.rangeConfig) sections.rangeConfig.style.display = 'block'
+        if (sections.commandTypeConfig)
+          sections.commandTypeConfig.style.display = 'block'
+        break
+
+      case 'tray_range_with_backup':
+        if (sections.rangeConfig) sections.rangeConfig.style.display = 'block'
+        if (sections.backupRangeConfig)
+          sections.backupRangeConfig.style.display = 'block'
+        if (sections.backupConfig) sections.backupConfig.style.display = 'block'
+        break
+
+      case 'whole_tray':
+        if (sections.singleTrayConfig)
+          sections.singleTrayConfig.style.display = 'block'
+        if (sections.commandTypeConfig)
+          sections.commandTypeConfig.style.display = 'block'
+        break
+
+      case 'whole_tray_with_backup':
+        if (sections.singleTrayConfig)
+          sections.singleTrayConfig.style.display = 'block'
+        if (sections.backupConfig) sections.backupConfig.style.display = 'block'
+        break
+    }
+  }
+
+  // Show warning for specific power commands
+  showPowerWarning(commandId) {
+    const warningDiv = document.getElementById('powerCommandWarning')
+    const warningText = document.getElementById('powerWarningText')
+
+    if (!warningDiv || !warningText) return
+
+    if (commandId && STO_DATA.commands.power.commands[commandId]) {
+      const command = STO_DATA.commands.power.commands[commandId]
+      if (command.warning) {
+        warningText.textContent = command.warning
+        warningDiv.style.display = 'block'
+        return
+      }
     }
 
-    // Update tray configuration sections based on selected command type
-    updateTrayConfigSections(commandType) {
-        const sections = {
-            singleTrayConfig: document.getElementById('singleTrayConfig'),
-            backupConfig: document.getElementById('backupConfig'),
-            rangeConfig: document.getElementById('rangeConfig'),
-            backupRangeConfig: document.getElementById('backupRangeConfig'),
-            commandTypeConfig: document.getElementById('commandTypeConfig')
-        };
-        
-        // Hide all sections first
-        Object.values(sections).forEach(section => {
-            if (section) section.style.display = 'none';
-        });
-        
-        // Show relevant sections based on command type
-        switch (commandType) {
-            case 'custom_tray':
-                if (sections.singleTrayConfig) sections.singleTrayConfig.style.display = 'block';
-                if (sections.commandTypeConfig) sections.commandTypeConfig.style.display = 'block';
-                break;
-                
-            case 'tray_with_backup':
-                if (sections.singleTrayConfig) sections.singleTrayConfig.style.display = 'block';
-                if (sections.backupConfig) sections.backupConfig.style.display = 'block';
-                break;
-                
-            case 'tray_range':
-                if (sections.rangeConfig) sections.rangeConfig.style.display = 'block';
-                if (sections.commandTypeConfig) sections.commandTypeConfig.style.display = 'block';
-                break;
-                
-            case 'tray_range_with_backup':
-                if (sections.rangeConfig) sections.rangeConfig.style.display = 'block';
-                if (sections.backupRangeConfig) sections.backupRangeConfig.style.display = 'block';
-                if (sections.backupConfig) sections.backupConfig.style.display = 'block';
-                break;
-                
-            case 'whole_tray':
-                if (sections.singleTrayConfig) sections.singleTrayConfig.style.display = 'block';
-                if (sections.commandTypeConfig) sections.commandTypeConfig.style.display = 'block';
-                break;
-                
-            case 'whole_tray_with_backup':
-                if (sections.singleTrayConfig) sections.singleTrayConfig.style.display = 'block';
-                if (sections.backupConfig) sections.backupConfig.style.display = 'block';
-                break;
-        }
+    // Hide warning if no warning for this command
+    warningDiv.style.display = 'none'
+  }
+
+  // Show warning for specific combat commands
+  showCombatWarning(commandId) {
+    const warningDiv = document.getElementById('combatCommandWarning')
+    const warningText = document.getElementById('combatWarningText')
+
+    if (!warningDiv || !warningText) return
+
+    if (commandId && STO_DATA.commands.combat.commands[commandId]) {
+      const command = STO_DATA.commands.combat.commands[commandId]
+      if (command.warning) {
+        warningText.textContent = command.warning
+        warningDiv.style.display = 'block'
+        return
+      }
     }
 
-    // Show warning for specific power commands
-    showPowerWarning(commandId) {
-        const warningDiv = document.getElementById('powerCommandWarning');
-        const warningText = document.getElementById('powerWarningText');
-        
-        if (!warningDiv || !warningText) return;
-        
-        if (commandId && STO_DATA.commands.power.commands[commandId]) {
-            const command = STO_DATA.commands.power.commands[commandId];
-            if (command.warning) {
-                warningText.textContent = command.warning;
-                warningDiv.style.display = 'block';
-                return;
+    // Hide warning if no warning for this command
+    warningDiv.style.display = 'none'
+  }
+
+  updateAliasPreview(aliasName) {
+    const previewSection = document.getElementById('aliasPreviewSection')
+    const preview = document.getElementById('selectedAliasPreview')
+
+    if (!previewSection || !preview) return
+
+    if (aliasName) {
+      const profile = app?.getCurrentProfile()
+      const alias = profile?.aliases?.[aliasName]
+
+      if (alias) {
+        preview.textContent = alias.commands
+        previewSection.style.display = 'block'
+      } else {
+        previewSection.style.display = 'none'
+      }
+    } else {
+      previewSection.style.display = 'none'
+    }
+  }
+
+  // Update command preview in modal
+  updateCommandPreview() {
+    const preview = document.getElementById('modalCommandPreview')
+    if (!preview) {
+      console.log('DEBUG: modalCommandPreview element not found')
+      return
+    }
+
+    const command = this.buildCurrentCommand()
+    console.log('DEBUG: buildCurrentCommand returned:', command)
+
+    if (command) {
+      // Handle both single commands and arrays of commands
+      if (Array.isArray(command)) {
+        console.log('DEBUG: Command is array with length:', command.length)
+        const commandStrings = command.map((cmd) => cmd.command)
+        console.log('DEBUG: Command strings:', commandStrings)
+        preview.textContent = commandStrings.join(' $$ ')
+      } else {
+        console.log('DEBUG: Command is single object:', command.command)
+        preview.textContent = command.command
+      }
+      preview.className = 'command-preview valid'
+    } else {
+      console.log('DEBUG: No command returned, showing default message')
+      preview.textContent = 'Configure command options to see preview'
+      preview.className = 'command-preview'
+    }
+  }
+
+  // Build command from current modal state
+  buildCurrentCommand() {
+    const typeSelect = document.getElementById('commandType')
+    if (!typeSelect || !typeSelect.value) return null
+
+    const type = typeSelect.value
+    const builder = this.commandBuilders.get(type)
+    if (!builder) return null
+
+    let commandId = null
+    let params = {}
+
+    switch (type) {
+      case 'targeting':
+        commandId = document.getElementById('targetingCommand')?.value
+        break
+
+      case 'combat':
+        commandId = document.getElementById('combatCommand')?.value
+        break
+
+      case 'tray':
+        commandId =
+          document.getElementById('trayCommandType')?.value || 'custom_tray'
+
+        switch (commandId) {
+          case 'custom_tray':
+            params = {
+              tray: parseInt(document.getElementById('trayNumber')?.value || 0),
+              slot: parseInt(document.getElementById('slotNumber')?.value || 0),
+              command_type:
+                document.getElementById('trayCommandVariant')?.value ||
+                'STOTrayExecByTray',
             }
-        }
-        
-        // Hide warning if no warning for this command
-        warningDiv.style.display = 'none';
-    }
+            break
 
-    // Show warning for specific combat commands
-    showCombatWarning(commandId) {
-        const warningDiv = document.getElementById('combatCommandWarning');
-        const warningText = document.getElementById('combatWarningText');
-        
-        if (!warningDiv || !warningText) return;
-        
-        if (commandId && STO_DATA.commands.combat.commands[commandId]) {
-            const command = STO_DATA.commands.combat.commands[commandId];
-            if (command.warning) {
-                warningText.textContent = command.warning;
-                warningDiv.style.display = 'block';
-                return;
+          case 'tray_with_backup':
+            params = {
+              tray: parseInt(document.getElementById('trayNumber')?.value || 0),
+              slot: parseInt(document.getElementById('slotNumber')?.value || 0),
+              backup_tray: parseInt(
+                document.getElementById('backupTrayNumber')?.value || 0
+              ),
+              backup_slot: parseInt(
+                document.getElementById('backupSlotNumber')?.value || 0
+              ),
+              active: parseInt(
+                document.getElementById('activeState')?.value || 1
+              ),
             }
-        }
-        
-        // Hide warning if no warning for this command
-        warningDiv.style.display = 'none';
-    }
+            break
 
-    updateAliasPreview(aliasName) {
-        const previewSection = document.getElementById('aliasPreviewSection');
-        const preview = document.getElementById('selectedAliasPreview');
-        
-        if (!previewSection || !preview) return;
-        
-        if (aliasName) {
-            const profile = app?.getCurrentProfile();
-            const alias = profile?.aliases?.[aliasName];
-            
-            if (alias) {
-                preview.textContent = alias.commands;
-                previewSection.style.display = 'block';
-            } else {
-                previewSection.style.display = 'none';
+          case 'tray_range':
+            params = {
+              start_tray: parseInt(
+                document.getElementById('startTrayNumber')?.value || 0
+              ),
+              start_slot: parseInt(
+                document.getElementById('startSlotNumber')?.value || 0
+              ),
+              end_tray: parseInt(
+                document.getElementById('endTrayNumber')?.value || 0
+              ),
+              end_slot: parseInt(
+                document.getElementById('endSlotNumber')?.value || 0
+              ),
+              command_type:
+                document.getElementById('trayCommandVariant')?.value ||
+                'STOTrayExecByTray',
             }
-        } else {
-            previewSection.style.display = 'none';
-        }
-    }
+            break
 
-    // Update command preview in modal
-    updateCommandPreview() {
-        const preview = document.getElementById('modalCommandPreview');
-        if (!preview) {
-            console.log('DEBUG: modalCommandPreview element not found');
-            return;
-        }
-        
-        const command = this.buildCurrentCommand();
-        console.log('DEBUG: buildCurrentCommand returned:', command);
-        
-        if (command) {
-            // Handle both single commands and arrays of commands
-            if (Array.isArray(command)) {
-                console.log('DEBUG: Command is array with length:', command.length);
-                const commandStrings = command.map(cmd => cmd.command);
-                console.log('DEBUG: Command strings:', commandStrings);
-                preview.textContent = commandStrings.join(' $$ ');
-            } else {
-                console.log('DEBUG: Command is single object:', command.command);
-                preview.textContent = command.command;
+          case 'tray_range_with_backup':
+            params = {
+              active: parseInt(
+                document.getElementById('activeState')?.value || 1
+              ),
+              start_tray: parseInt(
+                document.getElementById('startTrayNumber')?.value || 0
+              ),
+              start_slot: parseInt(
+                document.getElementById('startSlotNumber')?.value || 0
+              ),
+              end_tray: parseInt(
+                document.getElementById('endTrayNumber')?.value || 0
+              ),
+              end_slot: parseInt(
+                document.getElementById('endSlotNumber')?.value || 0
+              ),
+              backup_start_tray: parseInt(
+                document.getElementById('backupStartTrayNumber')?.value || 0
+              ),
+              backup_start_slot: parseInt(
+                document.getElementById('backupStartSlotNumber')?.value || 0
+              ),
+              backup_end_tray: parseInt(
+                document.getElementById('backupEndTrayNumber')?.value || 0
+              ),
+              backup_end_slot: parseInt(
+                document.getElementById('backupEndSlotNumber')?.value || 0
+              ),
             }
-            preview.className = 'command-preview valid';
-        } else {
-            console.log('DEBUG: No command returned, showing default message');
-            preview.textContent = 'Configure command options to see preview';
-            preview.className = 'command-preview';
+            break
+
+          case 'whole_tray':
+            params = {
+              tray: parseInt(document.getElementById('trayNumber')?.value || 0),
+              command_type:
+                document.getElementById('trayCommandVariant')?.value ||
+                'STOTrayExecByTray',
+            }
+            break
+
+          case 'whole_tray_with_backup':
+            params = {
+              active: parseInt(
+                document.getElementById('activeState')?.value || 1
+              ),
+              tray: parseInt(document.getElementById('trayNumber')?.value || 0),
+              backup_tray: parseInt(
+                document.getElementById('backupTrayNumber')?.value || 0
+              ),
+            }
+            break
         }
+        break
+
+      case 'power':
+        commandId = document.getElementById('powerCommand')?.value
+        break
+
+      case 'movement':
+        commandId = document.getElementById('movementCommand')?.value
+        if (commandId === 'throttle_adjust') {
+          params.amount = parseFloat(
+            document.getElementById('movementAmount')?.value || 0.25
+          )
+        } else if (commandId === 'throttle_set') {
+          params.position = parseFloat(
+            document.getElementById('movementPosition')?.value || 1
+          )
+        }
+        break
+
+      case 'camera':
+        commandId = document.getElementById('cameraCommand')?.value
+        if (commandId === 'cam_distance') {
+          params.distance = parseInt(
+            document.getElementById('cameraDistance')?.value || 50
+          )
+        }
+        break
+
+      case 'communication':
+        commandId = document.getElementById('commCommand')?.value
+        params = {
+          message:
+            document.getElementById('commMessage')?.value ||
+            'Message text here',
+        }
+        break
+
+      case 'system':
+        commandId = document.getElementById('systemCommand')?.value
+        if (commandId === 'bind_save_file' || commandId === 'bind_load_file') {
+          params.filename =
+            document.getElementById('systemFilename')?.value || 'my_binds.txt'
+        } else if (commandId === 'combat_log') {
+          params.state = parseInt(
+            document.getElementById('systemState')?.value || 1
+          )
+        }
+        break
+
+      case 'alias':
+        commandId = 'alias'
+        params = {
+          alias_name: document.getElementById('aliasSelect')?.value || '',
+        }
+        break
+
+      case 'custom':
+        commandId = 'custom'
+        params = {
+          command: document.getElementById('customCommand')?.value || '',
+          text:
+            document.getElementById('customText')?.value || 'Custom Command',
+        }
+        break
     }
 
-    // Build command from current modal state
-    buildCurrentCommand() {
-        const typeSelect = document.getElementById('commandType');
-        if (!typeSelect || !typeSelect.value) return null;
-        
-        const type = typeSelect.value;
-        const builder = this.commandBuilders.get(type);
-        if (!builder) return null;
-        
-        let commandId = null;
-        let params = {};
-        
-        switch (type) {
-            case 'targeting':
-                commandId = document.getElementById('targetingCommand')?.value;
-                break;
-                
-            case 'combat':
-                commandId = document.getElementById('combatCommand')?.value;
-                break;
-                
-            case 'tray':
-                commandId = document.getElementById('trayCommandType')?.value || 'custom_tray';
-                
-                switch (commandId) {
-                    case 'custom_tray':
-                        params = {
-                            tray: parseInt(document.getElementById('trayNumber')?.value || 0),
-                            slot: parseInt(document.getElementById('slotNumber')?.value || 0),
-                            command_type: document.getElementById('trayCommandVariant')?.value || 'STOTrayExecByTray'
-                        };
-                        break;
-                        
-                    case 'tray_with_backup':
-                        params = {
-                            tray: parseInt(document.getElementById('trayNumber')?.value || 0),
-                            slot: parseInt(document.getElementById('slotNumber')?.value || 0),
-                            backup_tray: parseInt(document.getElementById('backupTrayNumber')?.value || 0),
-                            backup_slot: parseInt(document.getElementById('backupSlotNumber')?.value || 0),
-                            active: parseInt(document.getElementById('activeState')?.value || 1)
-                        };
-                        break;
-                        
-                    case 'tray_range':
-                        params = {
-                            start_tray: parseInt(document.getElementById('startTrayNumber')?.value || 0),
-                            start_slot: parseInt(document.getElementById('startSlotNumber')?.value || 0),
-                            end_tray: parseInt(document.getElementById('endTrayNumber')?.value || 0),
-                            end_slot: parseInt(document.getElementById('endSlotNumber')?.value || 0),
-                            command_type: document.getElementById('trayCommandVariant')?.value || 'STOTrayExecByTray'
-                        };
-                        break;
-                        
-                    case 'tray_range_with_backup':
-                        params = {
-                            active: parseInt(document.getElementById('activeState')?.value || 1),
-                            start_tray: parseInt(document.getElementById('startTrayNumber')?.value || 0),
-                            start_slot: parseInt(document.getElementById('startSlotNumber')?.value || 0),
-                            end_tray: parseInt(document.getElementById('endTrayNumber')?.value || 0),
-                            end_slot: parseInt(document.getElementById('endSlotNumber')?.value || 0),
-                            backup_start_tray: parseInt(document.getElementById('backupStartTrayNumber')?.value || 0),
-                            backup_start_slot: parseInt(document.getElementById('backupStartSlotNumber')?.value || 0),
-                            backup_end_tray: parseInt(document.getElementById('backupEndTrayNumber')?.value || 0),
-                            backup_end_slot: parseInt(document.getElementById('backupEndSlotNumber')?.value || 0)
-                        };
-                        break;
-                        
-                    case 'whole_tray':
-                        params = {
-                            tray: parseInt(document.getElementById('trayNumber')?.value || 0),
-                            command_type: document.getElementById('trayCommandVariant')?.value || 'STOTrayExecByTray'
-                        };
-                        break;
-                        
-                    case 'whole_tray_with_backup':
-                        params = {
-                            active: parseInt(document.getElementById('activeState')?.value || 1),
-                            tray: parseInt(document.getElementById('trayNumber')?.value || 0),
-                            backup_tray: parseInt(document.getElementById('backupTrayNumber')?.value || 0)
-                        };
-                        break;
-                }
-                break;
-                
-            case 'power':
-                commandId = document.getElementById('powerCommand')?.value;
-                break;
-                
-            case 'movement':
-                commandId = document.getElementById('movementCommand')?.value;
-                if (commandId === 'throttle_adjust') {
-                    params.amount = parseFloat(document.getElementById('movementAmount')?.value || 0.25);
-                } else if (commandId === 'throttle_set') {
-                    params.position = parseFloat(document.getElementById('movementPosition')?.value || 1);
-                }
-                break;
-                
-            case 'camera':
-                commandId = document.getElementById('cameraCommand')?.value;
-                if (commandId === 'cam_distance') {
-                    params.distance = parseInt(document.getElementById('cameraDistance')?.value || 50);
-                }
-                break;
-                
-            case 'communication':
-                commandId = document.getElementById('commCommand')?.value;
-                params = {
-                    message: document.getElementById('commMessage')?.value || 'Message text here'
-                };
-                break;
-                
-            case 'system':
-                commandId = document.getElementById('systemCommand')?.value;
-                if (commandId === 'bind_save_file' || commandId === 'bind_load_file') {
-                    params.filename = document.getElementById('systemFilename')?.value || 'my_binds.txt';
-                } else if (commandId === 'combat_log') {
-                    params.state = parseInt(document.getElementById('systemState')?.value || 1);
-                }
-                break;
-                
-            case 'alias':
-                commandId = 'alias';
-                params = {
-                    alias_name: document.getElementById('aliasSelect')?.value || ''
-                };
-                break;
-                
-            case 'custom':
-                commandId = 'custom';
-                params = {
-                    command: document.getElementById('customCommand')?.value || '',
-                    text: document.getElementById('customText')?.value || 'Custom Command'
-                };
-                break;
-        }
-        
-        if (!commandId && type !== 'custom') return null;
-        
-        return builder.build(commandId, params);
-    }
+    if (!commandId && type !== 'custom') return null
 
-    // Update tray visual representation
-    updateTrayVisual() {
-        const visual = document.getElementById('trayVisual');
-        const trayNum = document.getElementById('trayNumber')?.value || 0;
-        const slotNum = document.getElementById('slotNumber')?.value || 0;
-        
-        if (!visual) return;
-        
-        visual.innerHTML = `
+    return builder.build(commandId, params)
+  }
+
+  // Update tray visual representation
+  updateTrayVisual() {
+    const visual = document.getElementById('trayVisual')
+    const trayNum = document.getElementById('trayNumber')?.value || 0
+    const slotNum = document.getElementById('slotNumber')?.value || 0
+
+    if (!visual) return
+
+    visual.innerHTML = `
             <div class="tray-grid">
                 <div class="tray-label">Tray ${parseInt(trayNum) + 1}</div>
                 <div class="slot-grid">
-                    ${Array.from({length: 10}, (_, i) => `
+                    ${Array.from(
+                      { length: 10 },
+                      (_, i) => `
                         <div class="slot ${i == slotNum ? 'selected' : ''}" data-slot="${i}">
                             ${i + 1}
                         </div>
-                    `).join('')}
+                    `
+                    ).join('')}
                 </div>
             </div>
-        `;
-        
-        // Add click handlers for slots
-        visual.querySelectorAll('.slot').forEach(slot => {
-            slot.addEventListener('click', () => {
-                const slotSelect = document.getElementById('slotNumber');
-                if (slotSelect) {
-                    slotSelect.value = slot.dataset.slot;
-                    this.updateTrayVisual();
-                    this.updateCommandPreview();
-                }
-            });
-        });
-    }
+        `
 
-    // Helper method to generate tray range commands
-    generateTrayRangeCommands(startTray, startSlot, endTray, endSlot, commandType) {
-        const commands = [];
-        const prefix = commandType === 'STOTrayExecByTray' ? '+' : '';
-        
-        // If same tray, iterate through slots
-        if (startTray === endTray) {
-            for (let slot = startSlot; slot <= endSlot; slot++) {
-                commands.push(`${prefix}${commandType} ${startTray} ${slot}`);
-            }
-        } else {
-            // Multi-tray range
-            // First tray: from startSlot to end of tray (slot 9)
-            for (let slot = startSlot; slot <= 9; slot++) {
-                commands.push(`${prefix}${commandType} ${startTray} ${slot}`);
-            }
-            
-            // Middle trays: all slots (0-9)
-            for (let tray = startTray + 1; tray < endTray; tray++) {
-                for (let slot = 0; slot <= 9; slot++) {
-                    commands.push(`${prefix}${commandType} ${tray} ${slot}`);
-                }
-            }
-            
-            // Last tray: from slot 0 to endSlot
-            if (endTray > startTray) {
-                for (let slot = 0; slot <= endSlot; slot++) {
-                    commands.push(`${prefix}${commandType} ${endTray} ${slot}`);
-                }
-            }
+    // Add click handlers for slots
+    visual.querySelectorAll('.slot').forEach((slot) => {
+      slot.addEventListener('click', () => {
+        const slotSelect = document.getElementById('slotNumber')
+        if (slotSelect) {
+          slotSelect.value = slot.dataset.slot
+          this.updateTrayVisual()
+          this.updateCommandPreview()
         }
-        
-        return commands;
-    }
+      })
+    })
+  }
 
-    // Helper method to generate tray range with backup commands
-    generateTrayRangeWithBackupCommands(active, startTray, startSlot, endTray, endSlot, backupStartTray, backupStartSlot, backupEndTray, backupEndSlot) {
-        const commands = [];
-        const primarySlots = this.generateTraySlotList(startTray, startSlot, endTray, endSlot);
-        const backupSlots = this.generateTraySlotList(backupStartTray, backupStartSlot, backupEndTray, backupEndSlot);
-        
-        // Pair primary and backup slots
-        for (let i = 0; i < Math.max(primarySlots.length, backupSlots.length); i++) {
-            const primary = primarySlots[i] || primarySlots[primarySlots.length - 1];
-            const backup = backupSlots[i] || backupSlots[backupSlots.length - 1];
-            
-            commands.push(`TrayExecByTrayWithBackup ${active} ${primary.tray} ${primary.slot} ${backup.tray} ${backup.slot}`);
-        }
-        
-        return commands;
-    }
+  // Helper method to generate tray range commands
+  generateTrayRangeCommands(
+    startTray,
+    startSlot,
+    endTray,
+    endSlot,
+    commandType
+  ) {
+    const commands = []
+    const prefix = commandType === 'STOTrayExecByTray' ? '+' : ''
 
-    // Helper method to generate whole tray commands
-    generateWholeTrayCommands(tray, commandType) {
-        const commands = [];
-        const prefix = commandType === 'STOTrayExecByTray' ? '+' : '';
-        
+    // If same tray, iterate through slots
+    if (startTray === endTray) {
+      for (let slot = startSlot; slot <= endSlot; slot++) {
+        commands.push(`${prefix}${commandType} ${startTray} ${slot}`)
+      }
+    } else {
+      // Multi-tray range
+      // First tray: from startSlot to end of tray (slot 9)
+      for (let slot = startSlot; slot <= 9; slot++) {
+        commands.push(`${prefix}${commandType} ${startTray} ${slot}`)
+      }
+
+      // Middle trays: all slots (0-9)
+      for (let tray = startTray + 1; tray < endTray; tray++) {
         for (let slot = 0; slot <= 9; slot++) {
-            commands.push(`${prefix}${commandType} ${tray} ${slot}`);
+          commands.push(`${prefix}${commandType} ${tray} ${slot}`)
         }
-        
-        return commands;
+      }
+
+      // Last tray: from slot 0 to endSlot
+      if (endTray > startTray) {
+        for (let slot = 0; slot <= endSlot; slot++) {
+          commands.push(`${prefix}${commandType} ${endTray} ${slot}`)
+        }
+      }
     }
 
-    // Helper method to generate whole tray with backup commands
-    generateWholeTrayWithBackupCommands(active, tray, backupTray) {
-        const commands = [];
-        
+    return commands
+  }
+
+  // Helper method to generate tray range with backup commands
+  generateTrayRangeWithBackupCommands(
+    active,
+    startTray,
+    startSlot,
+    endTray,
+    endSlot,
+    backupStartTray,
+    backupStartSlot,
+    backupEndTray,
+    backupEndSlot
+  ) {
+    const commands = []
+    const primarySlots = this.generateTraySlotList(
+      startTray,
+      startSlot,
+      endTray,
+      endSlot
+    )
+    const backupSlots = this.generateTraySlotList(
+      backupStartTray,
+      backupStartSlot,
+      backupEndTray,
+      backupEndSlot
+    )
+
+    // Pair primary and backup slots
+    for (
+      let i = 0;
+      i < Math.max(primarySlots.length, backupSlots.length);
+      i++
+    ) {
+      const primary = primarySlots[i] || primarySlots[primarySlots.length - 1]
+      const backup = backupSlots[i] || backupSlots[backupSlots.length - 1]
+
+      commands.push(
+        `TrayExecByTrayWithBackup ${active} ${primary.tray} ${primary.slot} ${backup.tray} ${backup.slot}`
+      )
+    }
+
+    return commands
+  }
+
+  // Helper method to generate whole tray commands
+  generateWholeTrayCommands(tray, commandType) {
+    const commands = []
+    const prefix = commandType === 'STOTrayExecByTray' ? '+' : ''
+
+    for (let slot = 0; slot <= 9; slot++) {
+      commands.push(`${prefix}${commandType} ${tray} ${slot}`)
+    }
+
+    return commands
+  }
+
+  // Helper method to generate whole tray with backup commands
+  generateWholeTrayWithBackupCommands(active, tray, backupTray) {
+    const commands = []
+
+    for (let slot = 0; slot <= 9; slot++) {
+      commands.push(
+        `TrayExecByTrayWithBackup ${active} ${tray} ${slot} ${backupTray} ${slot}`
+      )
+    }
+
+    return commands
+  }
+
+  // Helper method to generate list of tray slots from range
+  generateTraySlotList(startTray, startSlot, endTray, endSlot) {
+    const slots = []
+
+    if (startTray === endTray) {
+      for (let slot = startSlot; slot <= endSlot; slot++) {
+        slots.push({ tray: startTray, slot })
+      }
+    } else {
+      // First tray
+      for (let slot = startSlot; slot <= 9; slot++) {
+        slots.push({ tray: startTray, slot })
+      }
+
+      // Middle trays
+      for (let tray = startTray + 1; tray < endTray; tray++) {
         for (let slot = 0; slot <= 9; slot++) {
-            commands.push(`TrayExecByTrayWithBackup ${active} ${tray} ${slot} ${backupTray} ${slot}`);
+          slots.push({ tray, slot })
         }
-        
-        return commands;
+      }
+
+      // Last tray
+      if (endTray > startTray) {
+        for (let slot = 0; slot <= endSlot; slot++) {
+          slots.push({ tray: endTray, slot })
+        }
+      }
     }
 
-    // Helper method to generate list of tray slots from range
-    generateTraySlotList(startTray, startSlot, endTray, endSlot) {
-        const slots = [];
-        
-        if (startTray === endTray) {
-            for (let slot = startSlot; slot <= endSlot; slot++) {
-                slots.push({ tray: startTray, slot });
-            }
-        } else {
-            // First tray
-            for (let slot = startSlot; slot <= 9; slot++) {
-                slots.push({ tray: startTray, slot });
-            }
-            
-            // Middle trays
-            for (let tray = startTray + 1; tray < endTray; tray++) {
-                for (let slot = 0; slot <= 9; slot++) {
-                    slots.push({ tray, slot });
-                }
-            }
-            
-            // Last tray
-            if (endTray > startTray) {
-                for (let slot = 0; slot <= endSlot; slot++) {
-                    slots.push({ tray: endTray, slot });
-                }
-            }
+    return slots
+  }
+
+  // Get current command for saving
+  getCurrentCommand() {
+    return this.buildCurrentCommand()
+  }
+
+  // Validate command
+  validateCommand(command) {
+    // Handle arrays of commands (for tray ranges)
+    if (Array.isArray(command)) {
+      // Validate each command in the array
+      for (let i = 0; i < command.length; i++) {
+        const validation = this.validateCommand(command[i])
+        if (!validation.valid) {
+          return {
+            valid: false,
+            error: `Command ${i + 1}: ${validation.error}`,
+          }
         }
-        
-        return slots;
+      }
+      return { valid: true }
     }
 
-    // Get current command for saving
-    getCurrentCommand() {
-        return this.buildCurrentCommand();
+    // Handle both string and object inputs
+    let cmdString
+    if (typeof command === 'string') {
+      cmdString = command
+    } else if (command && command.command) {
+      cmdString = command.command
+    } else {
+      return { valid: false, error: 'No command provided' }
     }
 
-    // Validate command
-    validateCommand(command) {
-        // Handle arrays of commands (for tray ranges)
-        if (Array.isArray(command)) {
-            // Validate each command in the array
-            for (let i = 0; i < command.length; i++) {
-                const validation = this.validateCommand(command[i]);
-                if (!validation.valid) {
-                    return { valid: false, error: `Command ${i + 1}: ${validation.error}` };
-                }
-            }
-            return { valid: true };
-        }
-        
-        // Handle both string and object inputs
-        let cmdString;
-        if (typeof command === 'string') {
-            cmdString = command;
-        } else if (command && command.command) {
-            cmdString = command.command;
-        } else {
-            return { valid: false, error: 'No command provided' };
-        }
-        
-        if (!cmdString || cmdString.trim().length === 0) {
-            return { valid: false, error: 'Command cannot be empty' };
-        }
-        
-        // Basic STO command validation
-        const cmd = cmdString.trim();
-        
-        // Check for dangerous commands
-        const dangerousCommands = ['quit', 'exit', 'shutdown'];
-        if (dangerousCommands.some(dangerous => cmd.toLowerCase().includes(dangerous))) {
-            return { valid: false, error: 'Dangerous command not allowed' };
-        }
-        
-        // Check for invalid characters that could break STO
-        // Note: $$ is valid as it's the STO command separator for chaining commands
-        // Note: | is invalid UNLESS it's inside quoted strings (for communication commands)
-        if (this.hasUnquotedPipeCharacter(cmd)) {
-            return { valid: false, error: 'Invalid characters in command (|)' };
-        }
-        
-        return { valid: true };
+    if (!cmdString || cmdString.trim().length === 0) {
+      return { valid: false, error: 'Command cannot be empty' }
     }
 
-    // Helper method to check for pipe characters outside of quoted strings
-    hasUnquotedPipeCharacter(cmd) {
-        let inQuotes = false;
-        let quoteChar = null;
-        
-        for (let i = 0; i < cmd.length; i++) {
-            const char = cmd[i];
-            
-            if (!inQuotes && (char === '"' || char === "'")) {
-                // Starting a quoted section
-                inQuotes = true;
-                quoteChar = char;
-            } else if (inQuotes && char === quoteChar) {
-                // Check if this quote is escaped
-                let backslashCount = 0;
-                for (let j = i - 1; j >= 0 && cmd[j] === '\\'; j--) {
-                    backslashCount++;
-                }
-                // If even number of backslashes (including 0), the quote is not escaped
-                if (backslashCount % 2 === 0) {
-                    inQuotes = false;
-                    quoteChar = null;
-                }
-            } else if (!inQuotes && char === '|') {
-                // Found unquoted pipe character
-                return true;
-            }
+    // Basic STO command validation
+    const cmd = cmdString.trim()
+
+    // Check for dangerous commands
+    const dangerousCommands = ['quit', 'exit', 'shutdown']
+    if (
+      dangerousCommands.some((dangerous) =>
+        cmd.toLowerCase().includes(dangerous)
+      )
+    ) {
+      return { valid: false, error: 'Dangerous command not allowed' }
+    }
+
+    // Check for invalid characters that could break STO
+    // Note: $$ is valid as it's the STO command separator for chaining commands
+    // Note: | is invalid UNLESS it's inside quoted strings (for communication commands)
+    if (this.hasUnquotedPipeCharacter(cmd)) {
+      return { valid: false, error: 'Invalid characters in command (|)' }
+    }
+
+    return { valid: true }
+  }
+
+  // Helper method to check for pipe characters outside of quoted strings
+  hasUnquotedPipeCharacter(cmd) {
+    let inQuotes = false
+    let quoteChar = null
+
+    for (let i = 0; i < cmd.length; i++) {
+      const char = cmd[i]
+
+      if (!inQuotes && (char === '"' || char === "'")) {
+        // Starting a quoted section
+        inQuotes = true
+        quoteChar = char
+      } else if (inQuotes && char === quoteChar) {
+        // Check if this quote is escaped
+        let backslashCount = 0
+        for (let j = i - 1; j >= 0 && cmd[j] === '\\'; j--) {
+          backslashCount++
         }
-        
-        return false;
-    }
-
-    // Command templates
-    getTemplateCommands(category) {
-        if (!STO_DATA.templates) return [];
-        
-        const templates = [];
-        
-        // Search through all template scenarios for templates containing commands of the specified category
-        Object.entries(STO_DATA.templates).forEach(([scenarioId, scenario]) => {
-            Object.entries(scenario).forEach(([templateId, template]) => {
-                // Check if this template contains commands of the specified category
-                const hasCategory = template.commands.some(cmd => {
-                    const cmdType = this.detectCommandType(cmd);
-                    return cmdType === category;
-                });
-                
-                if (hasCategory) {
-                    templates.push({
-                        id: `${scenarioId}_${templateId}`,
-                        name: template.name,
-                        description: template.description,
-                        scenario: scenarioId,
-                        commands: template.commands.map(cmd => ({
-                            command: cmd,
-                            type: this.detectCommandType(cmd),
-                            icon: this.getCommandIcon(cmd),
-                            text: this.getCommandText(cmd)
-                        }))
-                    });
-                }
-            });
-        });
-        
-        return templates;
-    }
-
-    // Utility methods
-    detectCommandType(command) {
-        if (!command || typeof command !== 'string') return 'custom';
-        
-        const cmd = command.toLowerCase().trim();
-        
-        // Tray commands
-        if (cmd.includes('+stotrayexecbytray')) return 'tray';
-        
-        // Communication commands
-        if (cmd.startsWith('say ') || cmd.startsWith('team ') || cmd.startsWith('zone ') || 
-            cmd.startsWith('tell ') || cmd.includes('"')) return 'communication';
-        
-        // Shield management commands
-        if (cmd.includes('+power_exec') || cmd.includes('distribute_shields') || 
-            cmd.includes('reroute_shields')) return 'power';
-        
-        // Movement commands
-        if (cmd.includes('+fullimpulse') || cmd.includes('+reverse') || 
-            cmd.includes('throttle') || cmd.includes('+turn') || cmd.includes('+up') || 
-            cmd.includes('+down') || cmd.includes('+left') || cmd.includes('+right') ||
-            cmd.includes('+forward') || cmd.includes('+backward') || cmd.includes('follow')) return 'movement';
-        
-        // Camera commands
-        if (cmd.includes('cam') || cmd.includes('look') || cmd.includes('zoom')) return 'camera';
-        
-        // Combat commands
-        if (cmd.includes('fire') || cmd.includes('attack') || cmd === 'fireall' ||
-            cmd === 'firephasers' || cmd === 'firetorps' || cmd === 'firephaserstorps') return 'combat';
-        
-        // Targeting commands
-        if (cmd.includes('target') || cmd === 'target_enemy_near' || cmd === 'target_self' ||
-            cmd === 'target_friend_near' || cmd === 'target_clear') return 'targeting';
-        
-        // System commands
-        if (cmd.includes('+gentoggle') || cmd === 'screenshot' || cmd.includes('hud') || 
-            cmd === 'interactwindow') return 'system';
-        
-        // Default to custom for unknown commands
-        return 'custom';
-    }
-
-    getCommandIcon(command) {
-        const type = this.detectCommandType(command);
-        const iconMap = {
-            targeting: '🎯',
-            combat: '🔥',
-            tray: '⚡',
-            power: '🔋',
-            communication: '💬',
-            movement: '🚀',
-            camera: '📹',
-            system: '⚙️'
-        };
-        return iconMap[type] || '⚙️';
-    }
-
-    getCommandText(command) {
-        // Handle tray commands specially
-        if (command.includes('+STOTrayExecByTray')) {
-            const match = command.match(/\+STOTrayExecByTray\s+(\d+)\s+(\d+)/);
-            if (match) {
-                const tray = parseInt(match[1]) + 1; // Convert to 1-based
-                const slot = parseInt(match[2]) + 1; // Convert to 1-based
-                return `Execute Tray ${tray} Slot ${slot}`;
-            }
+        // If even number of backslashes (including 0), the quote is not escaped
+        if (backslashCount % 2 === 0) {
+          inQuotes = false
+          quoteChar = null
         }
-        
-        // Try to find a friendly name for the command
-        for (const [categoryId, category] of Object.entries(STO_DATA.commands)) {
-            for (const [cmdId, cmd] of Object.entries(category.commands)) {
-                if (cmd.command === command) {
-                    return cmd.name;
-                }
-            }
-        }
-        
-        // Generate a friendly name from the command
-        return command.replace(/[_+]/g, ' ').replace(/([A-Z])/g, ' $1').trim();
+      } else if (!inQuotes && char === '|') {
+        // Found unquoted pipe character
+        return true
+      }
     }
 
-    insertTargetVariable(input) {
-        const targetVar = '$Target';
-        const cursorPosition = input.selectionStart;
-        const value = input.value;
-        const newValue = value.slice(0, cursorPosition) + targetVar + value.slice(cursorPosition);
-        input.value = newValue;
-        input.setSelectionRange(cursorPosition + targetVar.length, cursorPosition + targetVar.length);
-        input.focus();
-        
-        // Trigger input event to update preview
-        input.dispatchEvent(new Event('input', { bubbles: true }));
+    return false
+  }
+
+  // Command templates
+  getTemplateCommands(category) {
+    if (!STO_DATA.templates) return []
+
+    const templates = []
+
+    // Search through all template scenarios for templates containing commands of the specified category
+    Object.entries(STO_DATA.templates).forEach(([scenarioId, scenario]) => {
+      Object.entries(scenario).forEach(([templateId, template]) => {
+        // Check if this template contains commands of the specified category
+        const hasCategory = template.commands.some((cmd) => {
+          const cmdType = this.detectCommandType(cmd)
+          return cmdType === category
+        })
+
+        if (hasCategory) {
+          templates.push({
+            id: `${scenarioId}_${templateId}`,
+            name: template.name,
+            description: template.description,
+            scenario: scenarioId,
+            commands: template.commands.map((cmd) => ({
+              command: cmd,
+              type: this.detectCommandType(cmd),
+              icon: this.getCommandIcon(cmd),
+              text: this.getCommandText(cmd),
+            })),
+          })
+        }
+      })
+    })
+
+    return templates
+  }
+
+  // Utility methods
+  detectCommandType(command) {
+    if (!command || typeof command !== 'string') return 'custom'
+
+    const cmd = command.toLowerCase().trim()
+
+    // Tray commands
+    if (cmd.includes('+stotrayexecbytray')) return 'tray'
+
+    // Communication commands
+    if (
+      cmd.startsWith('say ') ||
+      cmd.startsWith('team ') ||
+      cmd.startsWith('zone ') ||
+      cmd.startsWith('tell ') ||
+      cmd.includes('"')
+    )
+      return 'communication'
+
+    // Shield management commands
+    if (
+      cmd.includes('+power_exec') ||
+      cmd.includes('distribute_shields') ||
+      cmd.includes('reroute_shields')
+    )
+      return 'power'
+
+    // Movement commands
+    if (
+      cmd.includes('+fullimpulse') ||
+      cmd.includes('+reverse') ||
+      cmd.includes('throttle') ||
+      cmd.includes('+turn') ||
+      cmd.includes('+up') ||
+      cmd.includes('+down') ||
+      cmd.includes('+left') ||
+      cmd.includes('+right') ||
+      cmd.includes('+forward') ||
+      cmd.includes('+backward') ||
+      cmd.includes('follow')
+    )
+      return 'movement'
+
+    // Camera commands
+    if (cmd.includes('cam') || cmd.includes('look') || cmd.includes('zoom'))
+      return 'camera'
+
+    // Combat commands
+    if (
+      cmd.includes('fire') ||
+      cmd.includes('attack') ||
+      cmd === 'fireall' ||
+      cmd === 'firephasers' ||
+      cmd === 'firetorps' ||
+      cmd === 'firephaserstorps'
+    )
+      return 'combat'
+
+    // Targeting commands
+    if (
+      cmd.includes('target') ||
+      cmd === 'target_enemy_near' ||
+      cmd === 'target_self' ||
+      cmd === 'target_friend_near' ||
+      cmd === 'target_clear'
+    )
+      return 'targeting'
+
+    // System commands
+    if (
+      cmd.includes('+gentoggle') ||
+      cmd === 'screenshot' ||
+      cmd.includes('hud') ||
+      cmd === 'interactwindow'
+    )
+      return 'system'
+
+    // Default to custom for unknown commands
+    return 'custom'
+  }
+
+  getCommandIcon(command) {
+    const type = this.detectCommandType(command)
+    const iconMap = {
+      targeting: '🎯',
+      combat: '🔥',
+      tray: '⚡',
+      power: '🔋',
+      communication: '💬',
+      movement: '🚀',
+      camera: '📹',
+      system: '⚙️',
     }
+    return iconMap[type] || '⚙️'
+  }
+
+  getCommandText(command) {
+    // Handle tray commands specially
+    if (command.includes('+STOTrayExecByTray')) {
+      const match = command.match(/\+STOTrayExecByTray\s+(\d+)\s+(\d+)/)
+      if (match) {
+        const tray = parseInt(match[1]) + 1 // Convert to 1-based
+        const slot = parseInt(match[2]) + 1 // Convert to 1-based
+        return `Execute Tray ${tray} Slot ${slot}`
+      }
+    }
+
+    // Try to find a friendly name for the command
+    for (const [categoryId, category] of Object.entries(STO_DATA.commands)) {
+      for (const [cmdId, cmd] of Object.entries(category.commands)) {
+        if (cmd.command === command) {
+          return cmd.name
+        }
+      }
+    }
+
+    // Generate a friendly name from the command
+    return command
+      .replace(/[_+]/g, ' ')
+      .replace(/([A-Z])/g, ' $1')
+      .trim()
+  }
+
+  insertTargetVariable(input) {
+    const targetVar = '$Target'
+    const cursorPosition = input.selectionStart
+    const value = input.value
+    const newValue =
+      value.slice(0, cursorPosition) + targetVar + value.slice(cursorPosition)
+    input.value = newValue
+    input.setSelectionRange(
+      cursorPosition + targetVar.length,
+      cursorPosition + targetVar.length
+    )
+    input.focus()
+
+    // Trigger input event to update preview
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  }
 }
 
 // Global command manager instance

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -3,7 +3,7 @@
  */
 
 // Current application version
-export const APP_VERSION = '2025.06.20-preview-1';
+export const APP_VERSION = '2025.06.20-preview-1'
 
 // Display version with 'v' prefix for UI
-export const DISPLAY_VERSION = `v${APP_VERSION}`;
+export const DISPLAY_VERSION = `v${APP_VERSION}`

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -2,1271 +2,1304 @@
 // Contains all command definitions, templates, and default configurations
 
 const STO_DATA = {
-    // Command categories and definitions
-    commands: {
-        targeting: {
-            name: "Targeting",
-            icon: "fas fa-crosshairs",
-            description: "Target selection and management",
-            commands: {
-                target: {
-                    name: "Target by Name",
-                    command: "Target",
-                    description: "Target entity by name (requires quotes)",
-                    syntax: "Target \"EntityName\"",
-                    icon: "🎯",
-                    customizable: true,
-                    parameters: {
-                        entityName: { type: "text", default: "EntityName", placeholder: "Enter entity name" }
-                    }
-                },
-                target_enemy_near: {
-                    name: "Target Nearest Enemy",
-                    command: "Target_Enemy_Near",
-                    description: "Target the nearest enemy in view",
-                    syntax: "Target_Enemy_Near",
-                    icon: "🎯"
-                },
-                target_friend_near: {
-                    name: "Target Nearest Friend",
-                    command: "Target_Friend_Near", 
-                    description: "Target the nearest friendly entity",
-                    syntax: "Target_Friend_Near",
-                    icon: "🤝"
-                },
-                target_self: {
-                    name: "Target Self",
-                    command: "Target_Self",
-                    description: "Target your own ship/character",
-                    syntax: "Target_Self",
-                    icon: "👤"
-                },
-                target_clear: {
-                    name: "Clear Target",
-                    command: "Target_Clear",
-                    description: "Remove current target lock",
-                    syntax: "Target_Clear",
-                    icon: "❌"
-                },
-                target_teammate_1: {
-                    name: "Target Teammate 1",
-                    command: "Target_Teammate 1",
-                    description: "Target first team member",
-                    syntax: "Target_Teammate 1",
-                    icon: "👥"
-                },
-                target_teammate_2: {
-                    name: "Target Teammate 2", 
-                    command: "Target_Teammate 2",
-                    description: "Target second team member",
-                    syntax: "Target_Teammate 2",
-                    icon: "👥"
-                },
-                target_teammate_3: {
-                    name: "Target Teammate 3",
-                    command: "Target_Teammate 3", 
-                    description: "Target third team member",
-                    syntax: "Target_Teammate 3",
-                    icon: "👥"
-                },
-                target_teammate_4: {
-                    name: "Target Teammate 4",
-                    command: "Target_Teammate 4",
-                    description: "Target fourth team member",
-                    syntax: "Target_Teammate 4", 
-                    icon: "👥"
-                }
-            }
-        },
-
-        combat: {
-            name: "Combat",
-            icon: "fas fa-fire",
-            description: "Weapon firing and combat actions",
-            commands: {
-                fire_all: {
-                    name: "Fire All Weapons",
-                    command: "FireAll",
-                    description: "Fire all weapons",
-                    syntax: "FireAll",
-                    environment: "space",
-                    icon: "🔥",
-                    warning: "Not recommended on spam bars as it interferes with firing cycles"
-                },
-                fire_phasers: {
-                    name: "Fire Energy Weapons",
-                    command: "FirePhasers",
-                    description: "Fire all Energy Weapons",
-                    syntax: "FirePhasers",
-                    environment: "space",
-                    icon: "⚡",
-                    warning: "Not recommended on spam bars as it interferes with firing cycles"
-                },
-                fire_torps: {
-                    name: "Fire Torpedoes",
-                    command: "FireTorps", 
-                    description: "Fire all Torpedos",
-                    syntax: "FireTorps",
-                    environment: "space",
-                    icon: "🚀",
-                    warning: "Not recommended on spam bars as it interferes with firing cycles"
-                },
-                fire_mines: {
-                    name: "Fire Mines",
-                    command: "FireMines",
-                    description: "Fire all Mines",
-                    syntax: "FireMines",
-                    environment: "space",
-                    icon: "💣",
-                    warning: "Not recommended on spam bars as it interferes with firing cycles"
-                },
-                fire_phasers_torps: {
-                    name: "Fire Phasers & Torpedoes",
-                    command: "FirePhasersTorps",
-                    description: "Fire phasers & torpedos",
-                    syntax: "FirePhasersTorps",
-                    environment: "space",
-                    icon: "💥",
-                    warning: "Not recommended on spam bars as it interferes with firing cycles"
-                },
-                fire_projectiles: {
-                    name: "Fire Projectiles",
-                    command: "FireProjectiles",
-                    description: "Fire torpedos & mines",
-                    syntax: "FireProjectiles",
-                    environment: "space",
-                    icon: "🎯",
-                    warning: "Not recommended on spam bars as it interferes with firing cycles"
-                }
-            }
-        },
-
-        tray: {
-            name: "Tray Execution",
-            icon: "fas fa-th",
-            description: "Execute abilities from action trays",
-            commands: {
-                custom_tray: {
-                    name: "Tray Execution",
-                    command: "+STOTrayExecByTray 0 0",
-                    description: "Execute specific tray slot",
-                    syntax: "+STOTrayExecByTray <tray> <slot>",
-                    icon: "⚡",
-                    customizable: true,
-                    parameters: {
-                        tray: { type: "number", min: 0, max: 9, default: 0 },
-                        slot: { type: "number", min: 0, max: 9, default: 0 },
-                        command_type: { type: "select", options: ["STOTrayExecByTray", "TrayExecByTray"], default: "STOTrayExecByTray" }
-                    }
-                },
-                tray_with_backup: {
-                    name: "Tray Execution with Backup",
-                    command: "TrayExecByTrayWithBackup 1 0 0 0 0",
-                    description: "Execute specific tray slot with backup ability",
-                    syntax: "TrayExecByTrayWithBackup <active> <tray> <slot> <backup_tray> <backup_slot>",
-                    icon: "⚡",
-                    customizable: true,
-                    parameters: {
-                        active: { type: "number", min: 0, max: 1, default: 1 },
-                        tray: { type: "number", min: 0, max: 9, default: 0 },
-                        slot: { type: "number", min: 0, max: 9, default: 0 },
-                        backup_tray: { type: "number", min: 0, max: 9, default: 0 },
-                        backup_slot: { type: "number", min: 0, max: 9, default: 0 }
-                    }
-                },
-                tray_range: {
-                    name: "Tray Range Execution",
-                    command: "+STOTrayExecByTray 0 0",
-                    description: "Execute a range of tray slots",
-                    syntax: "+STOTrayExecByTray <tray> <slot> $$ ... (range)",
-                    icon: "⚡",
-                    customizable: true,
-                    parameters: {
-                        start_tray: { type: "number", min: 0, max: 9, default: 0 },
-                        start_slot: { type: "number", min: 0, max: 9, default: 0 },
-                        end_tray: { type: "number", min: 0, max: 9, default: 0 },
-                        end_slot: { type: "number", min: 0, max: 9, default: 0 },
-                        command_type: { type: "select", options: ["STOTrayExecByTray", "TrayExecByTray"], default: "STOTrayExecByTray" }
-                    }
-                },
-                tray_range_with_backup: {
-                    name: "Tray Range with Backup",
-                    command: "TrayExecByTrayWithBackup 1 0 0 0 0",
-                    description: "Execute a range of tray slots with backup abilities",
-                    syntax: "TrayExecByTrayWithBackup <active> <tray> <slot> <backup_tray> <backup_slot> $$ ... (range)",
-                    icon: "⚡",
-                    customizable: true,
-                    parameters: {
-                        active: { type: "number", min: 0, max: 1, default: 1 },
-                        start_tray: { type: "number", min: 0, max: 9, default: 0 },
-                        start_slot: { type: "number", min: 0, max: 9, default: 0 },
-                        end_tray: { type: "number", min: 0, max: 9, default: 0 },
-                        end_slot: { type: "number", min: 0, max: 9, default: 0 },
-                        backup_start_tray: { type: "number", min: 0, max: 9, default: 0 },
-                        backup_start_slot: { type: "number", min: 0, max: 9, default: 0 },
-                        backup_end_tray: { type: "number", min: 0, max: 9, default: 0 },
-                        backup_end_slot: { type: "number", min: 0, max: 9, default: 0 }
-                    }
-                },
-                whole_tray: {
-                    name: "Whole Tray Execution",
-                    command: "+STOTrayExecByTray 0 0",
-                    description: "Execute all slots in a tray",
-                    syntax: "+STOTrayExecByTray <tray> <slot> $$ ... (all slots)",
-                    icon: "⚡",
-                    customizable: true,
-                    parameters: {
-                        tray: { type: "number", min: 0, max: 9, default: 0 },
-                        command_type: { type: "select", options: ["STOTrayExecByTray", "TrayExecByTray"], default: "STOTrayExecByTray" }
-                    }
-                },
-                whole_tray_with_backup: {
-                    name: "Whole Tray with Backup",
-                    command: "TrayExecByTrayWithBackup 1 0 0 0 0",
-                    description: "Execute all slots in a tray with backup tray",
-                    syntax: "TrayExecByTrayWithBackup <active> <tray> <slot> <backup_tray> <backup_slot> $$ ... (all slots)",
-                    icon: "⚡",
-                    customizable: true,
-                    parameters: {
-                        active: { type: "number", min: 0, max: 1, default: 1 },
-                        tray: { type: "number", min: 0, max: 9, default: 0 },
-                        backup_tray: { type: "number", min: 0, max: 9, default: 0 }
-                    }
-                }
-            }
-        },
-
-        power: {
-            name: "Shield Management", 
-            icon: "fas fa-shield-alt",
-            description: "Shield power and distribution management",
-            commands: {
-                distribute_shields: {
-                    name: "Distribute Shields",
-                    command: "+power_exec Distribute_Shields",
-                    description: "Evenly distributes shields as if clicking in the middle of the ship and shields icon",
-                    syntax: "+power_exec Distribute_Shields",
-                    environment: "space",
-                    icon: "🛡️",
-                    warning: "Not recommended on spam bars as it interferes with firing cycles"
-                },
-                reroute_shields_rear: {
-                    name: "Reroute Shields Rear",
-                    command: "+power_exec reroute_shields_rear",
-                    description: "Route shield power to rear facing",
-                    syntax: "+power_exec reroute_shields_rear",
-                    environment: "space",
-                    icon: "🛡️"
-                },
-                reroute_shields_left: {
-                    name: "Reroute Shields Left",
-                    command: "+power_exec reroute_shields_left",
-                    description: "Route shield power to left side",
-                    syntax: "+power_exec reroute_shields_left",
-                    environment: "space",
-                    icon: "🛡️"
-                },
-                reroute_shields_right: {
-                    name: "Reroute Shields Right",
-                    command: "+power_exec reroute_shields_right",
-                    description: "Route shield power to right side",
-                    syntax: "+power_exec reroute_shields_right",
-                    environment: "space",
-                    icon: "🛡️"
-                },
-                reroute_shields_forward: {
-                    name: "Reroute Shields Forward",
-                    command: "+power_exec reroute_shields_forward",
-                    description: "Route shield power to forward facing",
-                    syntax: "+power_exec reroute_shields_forward",
-                    environment: "space",
-                    icon: "🛡️"
-                }
-            }
-        },
-
-        movement: {
-            name: "Movement",
-            icon: "fas fa-arrows-alt",
-            description: "Ship movement and navigation",
-            commands: {
-                full_impulse: {
-                    name: "Full Impulse",
-                    command: "+fullimpulse",
-                    description: "Engage full impulse drive",
-                    syntax: "+fullimpulse",
-                    environment: "space",
-                    icon: "🚀"
-                },
-                reverse: {
-                    name: "Reverse",
-                    command: "+reverse",
-                    description: "Reverse engines",
-                    syntax: "+reverse",
-                    icon: "⬅️"
-                },
-                throttle_adjust: {
-                    name: "Throttle Adjust",
-                    command: "ThrottleAdjust",
-                    description: "Increase or decrease the throttle by amount",
-                    syntax: "ThrottleAdjust <amount>",
-                    icon: "⚡",
-                    customizable: true,
-                    parameters: {
-                        amount: { type: "number", min: -1, max: 1, default: 0.25, step: 0.05 }
-                    }
-                },
-                throttle_set: {
-                    name: "Throttle Set",
-                    command: "ThrottleSet",
-                    description: "Set the throttle to a specific position (negative = reverse, 0 = stop)",
-                    syntax: "ThrottleSet <position>",
-                    icon: "🎛️",
-                    customizable: true,
-                    parameters: {
-                        position: { type: "number", min: -1, max: 1, default: 1, step: 0.1 }
-                    }
-                },
-                throttle_toggle: {
-                    name: "Throttle Toggle",
-                    command: "ThrottleToggle",
-                    description: "Alternates between full throttle and full stop",
-                    syntax: "ThrottleToggle",
-                    icon: "🔄"
-                },
-                turn_left: {
-                    name: "Turn Left",
-                    command: "+turnleft",
-                    description: "Turn ship left (continuous while held)",
-                    syntax: "+turnleft",
-                    icon: "↪️"
-                },
-                turn_right: {
-                    name: "Turn Right",
-                    command: "+turnright",
-                    description: "Turn ship right (continuous while held)",
-                    syntax: "+turnright",
-                    icon: "↩️"
-                },
-                pitch_up: {
-                    name: "Pitch Up",
-                    command: "+up",
-                    description: "Pitch ship nose up (space altitude change)",
-                    syntax: "+up",
-                    icon: "⬆️"
-                },
-                pitch_down: {
-                    name: "Pitch Down", 
-                    command: "+down",
-                    description: "Pitch ship nose down (space altitude change)",
-                    syntax: "+down",
-                    icon: "⬇️"
-                },
-                strafe_left: {
-                    name: "Strafe Left",
-                    command: "+left",
-                    description: "Strafe ship left",
-                    syntax: "+left",
-                    icon: "⬅️"
-                },
-                strafe_right: {
-                    name: "Strafe Right",
-                    command: "+right",
-                    description: "Strafe ship right",
-                    syntax: "+right",
-                    icon: "➡️"
-                },
-                forward: {
-                    name: "Forward",
-                    command: "+forward",
-                    description: "Move forward",
-                    syntax: "+forward",
-                    icon: "⬆️"
-                },
-                backward: {
-                    name: "Backward",
-                    command: "+backward",
-                    description: "Move backward",
-                    syntax: "+backward",
-                    icon: "⬇️"
-                },
-                auto_forward: {
-                    name: "Auto Forward",
-                    command: "autoForward",
-                    description: "Character moves forward until given new movement commands",
-                    syntax: "autoForward",
-                    environment: "ground",
-                    icon: "🏃"
-                },
-                follow: {
-                    name: "Follow Target",
-                    command: "Follow",
-                    description: "Follow the targeted entity",
-                    syntax: "Follow",
-                    icon: "👥"
-                },
-                follow_cancel: {
-                    name: "Cancel Follow",
-                    command: "Follow_Cancel",
-                    description: "Stop following and forget about the target",
-                    syntax: "Follow_Cancel",
-                    icon: "❌"
-                }
-            }
-        },
-
-        camera: {
-            name: "Camera",
-            icon: "fas fa-video",
-            description: "Camera control and view management",
-            commands: {
-                zoom_in: {
-                    name: "Zoom In",
-                    command: "Camzoomin",
-                    description: "Zoom the camera in",
-                    syntax: "Camzoomin",
-                    icon: "🔍"
-                },
-                zoom_out: {
-                    name: "Zoom Out",
-                    command: "Camzoomout",
-                    description: "Zoom the camera out",
-                    syntax: "Camzoomout",
-                    icon: "🔎"
-                },
-                zoom_in_small: {
-                    name: "Zoom In Small",
-                    command: "Camzoominsmall",
-                    description: "Zoom the camera in slightly",
-                    syntax: "Camzoominsmall",
-                    icon: "🔍"
-                },
-                zoom_out_small: {
-                    name: "Zoom Out Small",
-                    command: "Camzoomoutsmall",
-                    description: "Zoom the camera out slightly",
-                    syntax: "Camzoomoutsmall",
-                    icon: "🔎"
-                },
-                cam_distance: {
-                    name: "Set Camera Distance",
-                    command: "camdist",
-                    description: "Sets the camera distance from the player",
-                    syntax: "camdist <distance>",
-                    icon: "📏",
-                    customizable: true,
-                    parameters: {
-                        distance: { type: "number", min: 1, max: 500, default: 50 }
-                    }
-                },
-                cam_reset: {
-                    name: "Reset Camera",
-                    command: "CamReset",
-                    description: "Reset the camera position to default",
-                    syntax: "CamReset",
-                    icon: "🔄"
-                },
-                cam_target_lock: {
-                    name: "Lock Camera to Target",
-                    command: "Camsetlocktotarget",
-                    description: "Lock or unlock the camera to the target",
-                    syntax: "Camsetlocktotarget",
-                    icon: "🎯"
-                },
-                cam_cycle_distance: {
-                    name: "Cycle Camera Distance",
-                    command: "camCycleDist",
-                    description: "Cycle the camera distance between several preset values",
-                    syntax: "camCycleDist",
-                    icon: "🔄"
-                },
-                cam_mouse_look: {
-                    name: "Mouse Look",
-                    command: "+camMouseLook",
-                    description: "Enable mouse look camera control",
-                    syntax: "+camMouseLook",
-                    icon: "🖱️"
-                },
-                cam_turn_to_face: {
-                    name: "Turn to Face Camera",
-                    command: "+camTurnToFace",
-                    description: "Turn ship to face camera direction",
-                    syntax: "+camTurnToFace",
-                    icon: "↪️"
-                },
-                look_up: {
-                    name: "Look Up",
-                    command: "lookUp",
-                    description: "Change point of view to look straight up",
-                    syntax: "lookUp",
-                    icon: "⬆️"
-                },
-                look_down: {
-                    name: "Look Down",
-                    command: "lookDown",
-                    description: "Change point of view to look straight down",
-                    syntax: "lookDown",
-                    icon: "⬇️"
-                }
-            }
-        },
-
-        communication: {
-            name: "Communication",
-            icon: "fas fa-comments",
-            description: "Chat and team communication",
-            commands: {
-                team_message: {
-                    name: "Team Message",
-                    command: "team",
-                    description: "Send message to team",
-                    syntax: "team message",
-                    icon: "💬",
-                    customizable: true,
-                    parameters: {
-                        message: { type: "text", default: "Message text here" }
-                    }
-                },
-                local_message: {
-                    name: "Local Message",
-                    command: "say",
-                    description: "Send message to local area",
-                    syntax: "say message",
-                    icon: "📢",
-                    customizable: true,
-                    parameters: {
-                        message: { type: "text", default: "Message text here" }
-                    }
-                },
-                zone_message: {
-                    name: "Zone Message", 
-                    command: "zone",
-                    description: "Send message to zone",
-                    syntax: "zone message",
-                    icon: "📡",
-                    customizable: true,
-                    parameters: {
-                        message: { type: "text", default: "Message text here" }
-                    }
-                }
-            }
-        },
-
-        system: {
-            name: "System",
-            icon: "fas fa-cog",
-            description: "UI and system commands",
-            commands: {
-                toggle_hud: {
-                    name: "Toggle HUD",
-                    command: "+GenToggleHUD",
-                    description: "Toggle HUD visibility",
-                    syntax: "+GenToggleHUD",
-                    icon: "👁️"
-                },
-                screenshot: {
-                    name: "Screenshot",
-                    command: "screenshot",
-                    description: "Take a screenshot",
-                    syntax: "screenshot",
-                    icon: "📷"
-                },
-                screenshot_jpg: {
-                    name: "Screenshot JPG",
-                    command: "screenshot_jpg",
-                    description: "Save a screenshot as JPG",
-                    syntax: "screenshot_jpg",
-                    icon: "📷"
-                },
-                autofire_toggle: {
-                    name: "Toggle Autofire",
-                    command: "+GenToggleAutofire",
-                    description: "Toggle weapon autofire",
-                    syntax: "+GenToggleAutofire",
-                    icon: "🔁"
-                },
-                bind_save_file: {
-                    name: "Save Binds to File",
-                    command: "bind_save_file",
-                    description: "Save all your binds to a text file",
-                    syntax: "bind_save_file <filename>",
-                    icon: "💾",
-                    customizable: true,
-                    parameters: {
-                        filename: { type: "text", default: "my_binds.txt" }
-                    }
-                },
-                bind_load_file: {
-                    name: "Load Binds from File",
-                    command: "bind_load_file",
-                    description: "Load a bind file into the client",
-                    syntax: "bind_load_file <filename>",
-                    icon: "📁",
-                    customizable: true,
-                    parameters: {
-                        filename: { type: "text", default: "my_binds.txt" }
-                    }
-                },
-                combat_log: {
-                    name: "Toggle Combat Log",
-                    command: "CombatLog",
-                    description: "Turn combat log recording on/off (1=on, 0=off)",
-                    syntax: "CombatLog <1/0>",
-                    icon: "📊",
-                    customizable: true,
-                    parameters: {
-                        state: { type: "number", min: 0, max: 1, default: 1 }
-                    }
-                },
-                missions: {
-                    name: "Show/Hide Missions",
-                    command: "missions",
-                    description: "Show/hide the mission journal",
-                    syntax: "missions",
-                    icon: "📋"
-                },
-                inventory: {
-                    name: "Show/Hide Inventory",
-                    command: "Inventory",
-                    description: "Show/hide your inventory",
-                    syntax: "Inventory",
-                    icon: "🎒"
-                },
-                map: {
-                    name: "Show/Hide Map",
-                    command: "Map",
-                    description: "Show/hide the map window",
-                    syntax: "Map",
-                    icon: "🗺️"
-                }
-            }
-        }
-    },
-
-    // Command templates for common scenarios
-    templates: {
-        space_combat: {
-            basic_attack: {
-                name: "Basic Attack Sequence",
-                description: "Target enemy and fire all weapons",
-                commands: [
-                    "Target_Enemy_Near",
-                    "FireAll"
-                ]
-            },
-            defensive_sequence: {
-                name: "Defensive Sequence", 
-                description: "Target self and activate defensive abilities",
-                commands: [
-                    "Target_Self",
-                    "+power_exec Distribute_Shields"
-                ]
-            },
-            alpha_strike: {
-                name: "Alpha Strike",
-                description: "Full offensive sequence with buffs",
-                commands: [
-                    "Target_Enemy_Near",
-                    "FireAll"
-                ]
-            },
-            healing_sequence: {
-                name: "Emergency Healing",
-                description: "Self-healing and damage control",
-                commands: [
-                    "Target_Self",
-                    "+power_exec Distribute_Shields"
-                ]
-            }
-        },
-        ground_combat: {
-            basic_ground_attack: {
-                name: "Basic Ground Attack",
-                description: "Target and attack sequence for ground combat",
-                commands: [
-                    "Target_Enemy_Near",
-                    "+STOTrayExecByTray 0 0"
-                ]
-            }
-        }
-    },
-
-    // Default profiles
-    defaultProfiles: {
-        default_space: {
-            name: "Default Space",
-            description: "Basic space combat configuration",
-            currentEnvironment: "space",
-            builds: {
-                space: {
-                    keys: {
-                        Space: [
-                            {
-                                command: "Target_Enemy_Near",
-                                type: "targeting", 
-                                icon: "🎯",
-                                text: "Target nearest enemy",
-                                id: "cmd_1"
-                            },
-                            {
-                                command: "FireAll", 
-                                type: "combat",
-                                icon: "🔥",
-                                text: "Fire all weapons",
-                                id: "cmd_2"
-                            }
-                        ]
-                    },
-                    aliases: {
-                        AttackCall: {
-                            description: "Call out attack target to team",
-                            commands: 'team Attacking [$Target] - focus fire!'
-                        },
-                        TargetReport: {
-                            description: "Report current target to team",
-                            commands: 'team Current target: [$Target]'
-                        },
-                        HealCall: {
-                            description: "Request healing for target",
-                            commands: 'team Need healing on [$Target]!'
-                        }
-                    }
-                },
-                ground: {
-                    keys: {
-                        Space: [
-                            {
-                                command: "Target_Enemy_Near",
-                                type: "targeting",
-                                icon: "🎯", 
-                                text: "Target nearest enemy",
-                                id: "cmd_g1"
-                            },
-                            {
-                                command: "+STOTrayExecByTray 0 0",
-                                type: "tray",
-                                icon: "⚡",
-                                text: "Primary attack",
-                                id: "cmd_g2"
-                            }
-                        ]
-                    },
-                    aliases: {}
-                }
-            }
-        },
-        tactical_space: {
-            name: "Tactical Space",
-            description: "Aggressive DPS-focused space build",
-            currentEnvironment: "space",
-            builds: {
-                space: {
-                    keys: {
-                        Space: [
-                            {
-                                command: "Target_Enemy_Near",
-                                type: "targeting", 
-                                icon: "🎯",
-                                text: "Target nearest enemy",
-                                id: "cmd_1"
-                            },
-                            {
-                                command: "+STOTrayExecByTray 0 0",
-                                type: "tray",
-                                icon: "⚡", 
-                                text: "Execute Tray 1 Slot 1",
-                                id: "cmd_2"
-                            },
-                            {
-                                command: "FireAll",
-                                type: "combat",
-                                icon: "🔥",
-                                text: "Fire all weapons", 
-                                id: "cmd_3"
-                            },
-                            {
-                                command: "+power_exec Distribute_Shields",
-                                type: "power",
-                                icon: "🛡️",
-                                text: "Distribute shields",
-                                id: "cmd_4"
-                            }
-                        ],
-                        "1": [
-                            {
-                                command: "+STOTrayExecByTray 1 0",
-                                type: "tray",
-                                icon: "⚡",
-                                text: "Execute Tray 2 Slot 1",
-                                id: "cmd_5"
-                            }
-                        ],
-                        F1: [
-                            {
-                                command: "Target_Self",
-                                type: "targeting",
-                                icon: "👤", 
-                                text: "Target self",
-                                id: "cmd_6"
-                            },
-                            {
-                                command: "+STOTrayExecByTray 2 0",
-                                type: "tray",
-                                icon: "⚡",
-                                text: "Execute Tray 3 Slot 1",
-                                id: "cmd_7"
-                            }
-                        ]
-                    },
-                    aliases: {}
-                },
-                ground: {
-                    keys: {
-                        Space: [
-                            {
-                                command: "Target_Enemy_Near",
-                                type: "targeting",
-                                icon: "🎯",
-                                text: "Target nearest enemy",
-                                id: "cmd_g1"
-                            },
-                            {
-                                command: "+STOTrayExecByTray 0 0",
-                                type: "tray",
-                                icon: "⚡",
-                                text: "Primary attack",
-                                id: "cmd_g2"
-                            }
-                        ],
-                        "1": [
-                            {
-                                command: "+STOTrayExecByTray 0 1",
-                                type: "tray",
-                                icon: "⚡",
-                                text: "Secondary attack",
-                                id: "cmd_g3"
-                            }
-                        ],
-                        F1: [
-                            {
-                                command: "Target_Self",
-                                type: "targeting",
-                                icon: "👤",
-                                text: "Target self",
-                                id: "cmd_g4"
-                            },
-                            {
-                                command: "+STOTrayExecByTray 1 0",
-                                type: "tray",
-                                icon: "💊",
-                                text: "Heal self",
-                                id: "cmd_g5"
-                            }
-                        ]
-                    },
-                    aliases: {}
-                }
-            }
-        }
-    },
-
-    // Comprehensive key definitions organized by category
-    keys: {
-        common: {
-            name: "Common Keys",
-            description: "Most frequently used keys",
-            keys: [
-                { key: "Space", description: "Spacebar" },
-                { key: "1", description: "Number 1" },
-                { key: "2", description: "Number 2" },
-                { key: "3", description: "Number 3" },
-                { key: "4", description: "Number 4" },
-                { key: "5", description: "Number 5" },
-                { key: "F1", description: "Function Key 1" },
-                { key: "F2", description: "Function Key 2" },
-                { key: "F3", description: "Function Key 3" },
-                { key: "F4", description: "Function Key 4" },
-                { key: "Tab", description: "Tab" },
-                { key: "enter", description: "Main Enter Key" },
-                { key: "Shift", description: "Shift" },
-                { key: "Control", description: "Control" },
-                { key: "ALT", description: "Alt" }
-            ]
-        },
-        letters: {
-            name: "Letter Keys",
-            description: "A-Z keyboard letters",
-            keys: [
-                { key: "A", description: "Key A" },
-                { key: "B", description: "Key B" },
-                { key: "C", description: "Key C" },
-                { key: "D", description: "Key D" },
-                { key: "E", description: "Key E" },
-                { key: "F", description: "Key F" },
-                { key: "G", description: "Key G" },
-                { key: "H", description: "Key H" },
-                { key: "I", description: "Key I" },
-                { key: "J", description: "Key J" },
-                { key: "K", description: "Key K" },
-                { key: "L", description: "Key L" },
-                { key: "M", description: "Key M" },
-                { key: "N", description: "Key N" },
-                { key: "O", description: "Key O" },
-                { key: "P", description: "Key P" },
-                { key: "Q", description: "Key Q" },
-                { key: "R", description: "Key R" },
-                { key: "S", description: "Key S" },
-                { key: "T", description: "Key T" },
-                { key: "U", description: "Key U" },
-                { key: "V", description: "Key V" },
-                { key: "W", description: "Key W" },
-                { key: "X", description: "Key X" },
-                { key: "Y", description: "Key Y" },
-                { key: "Z", description: "Key Z" }
-            ]
-        },
-        numbers: {
-            name: "Number Keys",
-            description: "Number row and numpad",
-            keys: [
-                { key: "0", description: "Number 0" },
-                { key: "6", description: "Number 6" },
-                { key: "7", description: "Number 7" },
-                { key: "8", description: "Number 8" },
-                { key: "9", description: "Number 9" },
-                { key: "numpad0", description: "Numerical Keypad 0" },
-                { key: "numpad1", description: "Numerical Keypad 1" },
-                { key: "numpad2", description: "Numerical Keypad 2" },
-                { key: "numpad3", description: "Numerical Keypad 3" },
-                { key: "numpad4", description: "Numerical Keypad 4" },
-                { key: "numpad5", description: "Numerical Keypad 5" },
-                { key: "numpad6", description: "Numerical Keypad 6" },
-                { key: "numpad7", description: "Numerical Keypad 7" },
-                { key: "numpad8", description: "Numerical Keypad 8" },
-                { key: "numpad9", description: "Numerical Keypad 9" },
-                { key: "Decimal", description: "Numerical Keypad Decimal" },
-                { key: "Divide", description: "Numerical Keypad Divide" },
-                { key: "Multiply", description: "Multiply (*)" },
-                { key: "Subtract", description: "Subtract (-)" },
-                { key: "Add", description: "Add (+)" },
-                { key: "numpadenter", description: "Numerical Keypad Enter" }
-            ]
-        },
-        function: {
-            name: "Function Keys",
-            description: "F1-F24 function keys",
-            keys: [
-                { key: "F5", description: "Function Key 5" },
-                { key: "F6", description: "Function Key 6" },
-                { key: "F7", description: "Function Key 7" },
-                { key: "F8", description: "Function Key 8" },
-                { key: "F9", description: "Function Key 9" },
-                { key: "F10", description: "Function Key 10" },
-                { key: "F11", description: "Function Key 11" },
-                { key: "F12", description: "Function Key 12" },
-                { key: "F13", description: "Function Key 13" },
-                { key: "F14", description: "Function Key 14" },
-                { key: "F15", description: "Function Key 15" },
-                { key: "F16", description: "Function Key 16" },
-                { key: "F17", description: "Function Key 17" },
-                { key: "F18", description: "Function Key 18" },
-                { key: "F19", description: "Function Key 19" },
-                { key: "F20", description: "Function Key 20" },
-                { key: "F21", description: "Function Key 21" },
-                { key: "F22", description: "Function Key 22" },
-                { key: "F23", description: "Function Key 23" },
-                { key: "F24", description: "Function Key 24" }
-            ]
-        },
-        arrows: {
-            name: "Arrow & Navigation",
-            description: "Arrow keys and navigation",
-            keys: [
-                { key: "Up", description: "Arrow Key: Up" },
-                { key: "Down", description: "Arrow Key: Down" },
-                { key: "Left", description: "Arrow Key: Left" },
-                { key: "Right", description: "Arrow Key: Right" },
-                { key: "Home", description: "Home" },
-                { key: "End", description: "End" },
-                { key: "PageUp", description: "Page Up" },
-                { key: "PageDown", description: "Page Down" },
-                { key: "insert", description: "Insert" },
-                { key: "delete", description: "Delete" }
-            ]
-        },
-        modifiers: {
-            name: "Modifier Keys",
-            description: "Shift, Ctrl, Alt variations",
-            keys: [
-                { key: "LALT", description: "Alt (Left)" },
-                { key: "RALT", description: "Alt (Right)" },
-                { key: "LCTRL", description: "Control (Left)" },
-                { key: "RCTRL", description: "Control (Right)" }
-            ]
-        },
-        symbols: {
-            name: "Symbol Keys",
-            description: "Punctuation and symbols",
-            keys: [
-                { key: "[", description: "[" },
-                { key: "]", description: "]" },
-                { key: "\\", description: "\\" },
-                { key: ",", description: "Comma (,)" },
-                { key: ".", description: "Period (.)" },
-                { key: "/", description: "Divide (/)" },
-                { key: "`", description: "Tilda Key (~)" }
-            ]
-        },
-        mouse: {
-            name: "Mouse Controls",
-            description: "Mouse buttons and scroll",
-            keys: [
-                { key: "Lbutton", description: "Mouse Left Press" },
-                { key: "Rbutton", description: "Mouse Right Press" },
-                { key: "Middleclick", description: "Mouse Middle Click" },
-                { key: "Button1", description: "Mouse Button 1" },
-                { key: "Button2", description: "Mouse Button 2" },
-                { key: "Button3", description: "Mouse Button 3" },
-                { key: "Button4", description: "Mouse Button 4" },
-                { key: "Button5", description: "Mouse Button 5" },
-                { key: "Button6", description: "Mouse Button 6" },
-                { key: "Button7", description: "Mouse Button 7" },
-                { key: "Button8", description: "Mouse Button 8" },
-                { key: "Button9", description: "Mouse Button 9" },
-                { key: "Button10", description: "Mouse Button 10" },
-                { key: "Wheelplus", description: "Mouse Scroll Up" },
-                { key: "Wheelminus", description: "Mouse Scroll Down" }
-            ]
-        },
-        gamepad: {
-            name: "Xbox Controller",
-            description: "Xbox/Gamepad controls",
-            keys: [
-                { key: "Joy1", description: "XBOX Contr [Start]" },
-                { key: "Joy2", description: "XBOX Contr [Back]" },
-                { key: "Joy3", description: "XBOX Contr [L Thumb depress]" },
-                { key: "Joy4", description: "XBOX Contr [R Thumb depress]" },
-                { key: "Joy5", description: "XBOX Contr [Left Bumper]" },
-                { key: "Joy6", description: "XBOX Contr [Right Bumper]" },
-                { key: "Joy7", description: "XBOX Contr [Left Trigger]" },
-                { key: "Joy8", description: "XBOX Contr [Right Trigger]" },
-                { key: "Joy9", description: "XBOX Contr [A Button]" },
-                { key: "Joy10", description: "XBOX Contr [B Button]" },
-                { key: "Joy11", description: "XBOX Contr [X Button]" },
-                { key: "Joy12", description: "XBOX Contr [Y Button]" },
-                { key: "Joypad_up", description: "XBOX Contr [Pad up]" },
-                { key: "Joypad_down", description: "XBOX Contr [Pad down]" },
-                { key: "Joypad_left", description: "XBOX Contr [Pad left]" },
-                { key: "Joypad_right", description: "XBOX Contr [Pad right]" },
-                { key: "Lstick_up", description: "XBOX Contr [Left Stick up]" },
-                { key: "Lstick_down", description: "XBOX Contr [Left Stick down]" },
-                { key: "Lstick_left", description: "XBOX Contr [Left Stick left]" },
-                { key: "Lstick_right", description: "XBOX Contr [Left Stick right]" },
-                { key: "Rstick_up", description: "XBOX Contr [Right Stick up]" },
-                { key: "Rstick_down", description: "XBOX Contr [Right Stick down]" },
-                { key: "Rstick_left", description: "XBOX Contr [Right Stick left]" },
-                { key: "Rstick_right", description: "XBOX Contr [Right Stick right]" }
-            ]
-        }
-    },
-
-    // Validation rules
-    validation: {
-        keyNamePattern: /^[a-zA-Z0-9_+\-\s]+$/,
-        aliasNamePattern: /^[a-zA-Z_][a-zA-Z0-9_]*$/,
-        maxCommandsPerKey: 20,
-        maxKeysPerProfile: 100
-    },
-
-    // Application settings
-    settings: {
-        version: "1.0.0",
-        autoSave: true,
-        maxUndoSteps: 50,
-        defaultMode: "space"
-    },
-
-    // STO Variables that can be used in commands
-    variables: {
+  // Command categories and definitions
+  commands: {
+    targeting: {
+      name: 'Targeting',
+      icon: 'fas fa-crosshairs',
+      description: 'Target selection and management',
+      commands: {
         target: {
-            variable: "$Target",
-            description: "Replaced with the name of your current target",
-                                    example: 'team Target [$Target]',
-            usableIn: ["communication", "custom", "aliases"],
-            notes: "If your target's name is 'froggyMonster', this will output 'Target [froggyMonster]'"
-        }
-    }
-};
+          name: 'Target by Name',
+          command: 'Target',
+          description: 'Target entity by name (requires quotes)',
+          syntax: 'Target "EntityName"',
+          icon: '🎯',
+          customizable: true,
+          parameters: {
+            entityName: {
+              type: 'text',
+              default: 'EntityName',
+              placeholder: 'Enter entity name',
+            },
+          },
+        },
+        target_enemy_near: {
+          name: 'Target Nearest Enemy',
+          command: 'Target_Enemy_Near',
+          description: 'Target the nearest enemy in view',
+          syntax: 'Target_Enemy_Near',
+          icon: '🎯',
+        },
+        target_friend_near: {
+          name: 'Target Nearest Friend',
+          command: 'Target_Friend_Near',
+          description: 'Target the nearest friendly entity',
+          syntax: 'Target_Friend_Near',
+          icon: '🤝',
+        },
+        target_self: {
+          name: 'Target Self',
+          command: 'Target_Self',
+          description: 'Target your own ship/character',
+          syntax: 'Target_Self',
+          icon: '👤',
+        },
+        target_clear: {
+          name: 'Clear Target',
+          command: 'Target_Clear',
+          description: 'Remove current target lock',
+          syntax: 'Target_Clear',
+          icon: '❌',
+        },
+        target_teammate_1: {
+          name: 'Target Teammate 1',
+          command: 'Target_Teammate 1',
+          description: 'Target first team member',
+          syntax: 'Target_Teammate 1',
+          icon: '👥',
+        },
+        target_teammate_2: {
+          name: 'Target Teammate 2',
+          command: 'Target_Teammate 2',
+          description: 'Target second team member',
+          syntax: 'Target_Teammate 2',
+          icon: '👥',
+        },
+        target_teammate_3: {
+          name: 'Target Teammate 3',
+          command: 'Target_Teammate 3',
+          description: 'Target third team member',
+          syntax: 'Target_Teammate 3',
+          icon: '👥',
+        },
+        target_teammate_4: {
+          name: 'Target Teammate 4',
+          command: 'Target_Teammate 4',
+          description: 'Target fourth team member',
+          syntax: 'Target_Teammate 4',
+          icon: '👥',
+        },
+      },
+    },
+
+    combat: {
+      name: 'Combat',
+      icon: 'fas fa-fire',
+      description: 'Weapon firing and combat actions',
+      commands: {
+        fire_all: {
+          name: 'Fire All Weapons',
+          command: 'FireAll',
+          description: 'Fire all weapons',
+          syntax: 'FireAll',
+          environment: 'space',
+          icon: '🔥',
+          warning:
+            'Not recommended on spam bars as it interferes with firing cycles',
+        },
+        fire_phasers: {
+          name: 'Fire Energy Weapons',
+          command: 'FirePhasers',
+          description: 'Fire all Energy Weapons',
+          syntax: 'FirePhasers',
+          environment: 'space',
+          icon: '⚡',
+          warning:
+            'Not recommended on spam bars as it interferes with firing cycles',
+        },
+        fire_torps: {
+          name: 'Fire Torpedoes',
+          command: 'FireTorps',
+          description: 'Fire all Torpedos',
+          syntax: 'FireTorps',
+          environment: 'space',
+          icon: '🚀',
+          warning:
+            'Not recommended on spam bars as it interferes with firing cycles',
+        },
+        fire_mines: {
+          name: 'Fire Mines',
+          command: 'FireMines',
+          description: 'Fire all Mines',
+          syntax: 'FireMines',
+          environment: 'space',
+          icon: '💣',
+          warning:
+            'Not recommended on spam bars as it interferes with firing cycles',
+        },
+        fire_phasers_torps: {
+          name: 'Fire Phasers & Torpedoes',
+          command: 'FirePhasersTorps',
+          description: 'Fire phasers & torpedos',
+          syntax: 'FirePhasersTorps',
+          environment: 'space',
+          icon: '💥',
+          warning:
+            'Not recommended on spam bars as it interferes with firing cycles',
+        },
+        fire_projectiles: {
+          name: 'Fire Projectiles',
+          command: 'FireProjectiles',
+          description: 'Fire torpedos & mines',
+          syntax: 'FireProjectiles',
+          environment: 'space',
+          icon: '🎯',
+          warning:
+            'Not recommended on spam bars as it interferes with firing cycles',
+        },
+      },
+    },
+
+    tray: {
+      name: 'Tray Execution',
+      icon: 'fas fa-th',
+      description: 'Execute abilities from action trays',
+      commands: {
+        custom_tray: {
+          name: 'Tray Execution',
+          command: '+STOTrayExecByTray 0 0',
+          description: 'Execute specific tray slot',
+          syntax: '+STOTrayExecByTray <tray> <slot>',
+          icon: '⚡',
+          customizable: true,
+          parameters: {
+            tray: { type: 'number', min: 0, max: 9, default: 0 },
+            slot: { type: 'number', min: 0, max: 9, default: 0 },
+            command_type: {
+              type: 'select',
+              options: ['STOTrayExecByTray', 'TrayExecByTray'],
+              default: 'STOTrayExecByTray',
+            },
+          },
+        },
+        tray_with_backup: {
+          name: 'Tray Execution with Backup',
+          command: 'TrayExecByTrayWithBackup 1 0 0 0 0',
+          description: 'Execute specific tray slot with backup ability',
+          syntax:
+            'TrayExecByTrayWithBackup <active> <tray> <slot> <backup_tray> <backup_slot>',
+          icon: '⚡',
+          customizable: true,
+          parameters: {
+            active: { type: 'number', min: 0, max: 1, default: 1 },
+            tray: { type: 'number', min: 0, max: 9, default: 0 },
+            slot: { type: 'number', min: 0, max: 9, default: 0 },
+            backup_tray: { type: 'number', min: 0, max: 9, default: 0 },
+            backup_slot: { type: 'number', min: 0, max: 9, default: 0 },
+          },
+        },
+        tray_range: {
+          name: 'Tray Range Execution',
+          command: '+STOTrayExecByTray 0 0',
+          description: 'Execute a range of tray slots',
+          syntax: '+STOTrayExecByTray <tray> <slot> $$ ... (range)',
+          icon: '⚡',
+          customizable: true,
+          parameters: {
+            start_tray: { type: 'number', min: 0, max: 9, default: 0 },
+            start_slot: { type: 'number', min: 0, max: 9, default: 0 },
+            end_tray: { type: 'number', min: 0, max: 9, default: 0 },
+            end_slot: { type: 'number', min: 0, max: 9, default: 0 },
+            command_type: {
+              type: 'select',
+              options: ['STOTrayExecByTray', 'TrayExecByTray'],
+              default: 'STOTrayExecByTray',
+            },
+          },
+        },
+        tray_range_with_backup: {
+          name: 'Tray Range with Backup',
+          command: 'TrayExecByTrayWithBackup 1 0 0 0 0',
+          description: 'Execute a range of tray slots with backup abilities',
+          syntax:
+            'TrayExecByTrayWithBackup <active> <tray> <slot> <backup_tray> <backup_slot> $$ ... (range)',
+          icon: '⚡',
+          customizable: true,
+          parameters: {
+            active: { type: 'number', min: 0, max: 1, default: 1 },
+            start_tray: { type: 'number', min: 0, max: 9, default: 0 },
+            start_slot: { type: 'number', min: 0, max: 9, default: 0 },
+            end_tray: { type: 'number', min: 0, max: 9, default: 0 },
+            end_slot: { type: 'number', min: 0, max: 9, default: 0 },
+            backup_start_tray: { type: 'number', min: 0, max: 9, default: 0 },
+            backup_start_slot: { type: 'number', min: 0, max: 9, default: 0 },
+            backup_end_tray: { type: 'number', min: 0, max: 9, default: 0 },
+            backup_end_slot: { type: 'number', min: 0, max: 9, default: 0 },
+          },
+        },
+        whole_tray: {
+          name: 'Whole Tray Execution',
+          command: '+STOTrayExecByTray 0 0',
+          description: 'Execute all slots in a tray',
+          syntax: '+STOTrayExecByTray <tray> <slot> $$ ... (all slots)',
+          icon: '⚡',
+          customizable: true,
+          parameters: {
+            tray: { type: 'number', min: 0, max: 9, default: 0 },
+            command_type: {
+              type: 'select',
+              options: ['STOTrayExecByTray', 'TrayExecByTray'],
+              default: 'STOTrayExecByTray',
+            },
+          },
+        },
+        whole_tray_with_backup: {
+          name: 'Whole Tray with Backup',
+          command: 'TrayExecByTrayWithBackup 1 0 0 0 0',
+          description: 'Execute all slots in a tray with backup tray',
+          syntax:
+            'TrayExecByTrayWithBackup <active> <tray> <slot> <backup_tray> <backup_slot> $$ ... (all slots)',
+          icon: '⚡',
+          customizable: true,
+          parameters: {
+            active: { type: 'number', min: 0, max: 1, default: 1 },
+            tray: { type: 'number', min: 0, max: 9, default: 0 },
+            backup_tray: { type: 'number', min: 0, max: 9, default: 0 },
+          },
+        },
+      },
+    },
+
+    power: {
+      name: 'Shield Management',
+      icon: 'fas fa-shield-alt',
+      description: 'Shield power and distribution management',
+      commands: {
+        distribute_shields: {
+          name: 'Distribute Shields',
+          command: '+power_exec Distribute_Shields',
+          description:
+            'Evenly distributes shields as if clicking in the middle of the ship and shields icon',
+          syntax: '+power_exec Distribute_Shields',
+          environment: 'space',
+          icon: '🛡️',
+          warning:
+            'Not recommended on spam bars as it interferes with firing cycles',
+        },
+        reroute_shields_rear: {
+          name: 'Reroute Shields Rear',
+          command: '+power_exec reroute_shields_rear',
+          description: 'Route shield power to rear facing',
+          syntax: '+power_exec reroute_shields_rear',
+          environment: 'space',
+          icon: '🛡️',
+        },
+        reroute_shields_left: {
+          name: 'Reroute Shields Left',
+          command: '+power_exec reroute_shields_left',
+          description: 'Route shield power to left side',
+          syntax: '+power_exec reroute_shields_left',
+          environment: 'space',
+          icon: '🛡️',
+        },
+        reroute_shields_right: {
+          name: 'Reroute Shields Right',
+          command: '+power_exec reroute_shields_right',
+          description: 'Route shield power to right side',
+          syntax: '+power_exec reroute_shields_right',
+          environment: 'space',
+          icon: '🛡️',
+        },
+        reroute_shields_forward: {
+          name: 'Reroute Shields Forward',
+          command: '+power_exec reroute_shields_forward',
+          description: 'Route shield power to forward facing',
+          syntax: '+power_exec reroute_shields_forward',
+          environment: 'space',
+          icon: '🛡️',
+        },
+      },
+    },
+
+    movement: {
+      name: 'Movement',
+      icon: 'fas fa-arrows-alt',
+      description: 'Ship movement and navigation',
+      commands: {
+        full_impulse: {
+          name: 'Full Impulse',
+          command: '+fullimpulse',
+          description: 'Engage full impulse drive',
+          syntax: '+fullimpulse',
+          environment: 'space',
+          icon: '🚀',
+        },
+        reverse: {
+          name: 'Reverse',
+          command: '+reverse',
+          description: 'Reverse engines',
+          syntax: '+reverse',
+          icon: '⬅️',
+        },
+        throttle_adjust: {
+          name: 'Throttle Adjust',
+          command: 'ThrottleAdjust',
+          description: 'Increase or decrease the throttle by amount',
+          syntax: 'ThrottleAdjust <amount>',
+          icon: '⚡',
+          customizable: true,
+          parameters: {
+            amount: {
+              type: 'number',
+              min: -1,
+              max: 1,
+              default: 0.25,
+              step: 0.05,
+            },
+          },
+        },
+        throttle_set: {
+          name: 'Throttle Set',
+          command: 'ThrottleSet',
+          description:
+            'Set the throttle to a specific position (negative = reverse, 0 = stop)',
+          syntax: 'ThrottleSet <position>',
+          icon: '🎛️',
+          customizable: true,
+          parameters: {
+            position: {
+              type: 'number',
+              min: -1,
+              max: 1,
+              default: 1,
+              step: 0.1,
+            },
+          },
+        },
+        throttle_toggle: {
+          name: 'Throttle Toggle',
+          command: 'ThrottleToggle',
+          description: 'Alternates between full throttle and full stop',
+          syntax: 'ThrottleToggle',
+          icon: '🔄',
+        },
+        turn_left: {
+          name: 'Turn Left',
+          command: '+turnleft',
+          description: 'Turn ship left (continuous while held)',
+          syntax: '+turnleft',
+          icon: '↪️',
+        },
+        turn_right: {
+          name: 'Turn Right',
+          command: '+turnright',
+          description: 'Turn ship right (continuous while held)',
+          syntax: '+turnright',
+          icon: '↩️',
+        },
+        pitch_up: {
+          name: 'Pitch Up',
+          command: '+up',
+          description: 'Pitch ship nose up (space altitude change)',
+          syntax: '+up',
+          icon: '⬆️',
+        },
+        pitch_down: {
+          name: 'Pitch Down',
+          command: '+down',
+          description: 'Pitch ship nose down (space altitude change)',
+          syntax: '+down',
+          icon: '⬇️',
+        },
+        strafe_left: {
+          name: 'Strafe Left',
+          command: '+left',
+          description: 'Strafe ship left',
+          syntax: '+left',
+          icon: '⬅️',
+        },
+        strafe_right: {
+          name: 'Strafe Right',
+          command: '+right',
+          description: 'Strafe ship right',
+          syntax: '+right',
+          icon: '➡️',
+        },
+        forward: {
+          name: 'Forward',
+          command: '+forward',
+          description: 'Move forward',
+          syntax: '+forward',
+          icon: '⬆️',
+        },
+        backward: {
+          name: 'Backward',
+          command: '+backward',
+          description: 'Move backward',
+          syntax: '+backward',
+          icon: '⬇️',
+        },
+        auto_forward: {
+          name: 'Auto Forward',
+          command: 'autoForward',
+          description:
+            'Character moves forward until given new movement commands',
+          syntax: 'autoForward',
+          environment: 'ground',
+          icon: '🏃',
+        },
+        follow: {
+          name: 'Follow Target',
+          command: 'Follow',
+          description: 'Follow the targeted entity',
+          syntax: 'Follow',
+          icon: '👥',
+        },
+        follow_cancel: {
+          name: 'Cancel Follow',
+          command: 'Follow_Cancel',
+          description: 'Stop following and forget about the target',
+          syntax: 'Follow_Cancel',
+          icon: '❌',
+        },
+      },
+    },
+
+    camera: {
+      name: 'Camera',
+      icon: 'fas fa-video',
+      description: 'Camera control and view management',
+      commands: {
+        zoom_in: {
+          name: 'Zoom In',
+          command: 'Camzoomin',
+          description: 'Zoom the camera in',
+          syntax: 'Camzoomin',
+          icon: '🔍',
+        },
+        zoom_out: {
+          name: 'Zoom Out',
+          command: 'Camzoomout',
+          description: 'Zoom the camera out',
+          syntax: 'Camzoomout',
+          icon: '🔎',
+        },
+        zoom_in_small: {
+          name: 'Zoom In Small',
+          command: 'Camzoominsmall',
+          description: 'Zoom the camera in slightly',
+          syntax: 'Camzoominsmall',
+          icon: '🔍',
+        },
+        zoom_out_small: {
+          name: 'Zoom Out Small',
+          command: 'Camzoomoutsmall',
+          description: 'Zoom the camera out slightly',
+          syntax: 'Camzoomoutsmall',
+          icon: '🔎',
+        },
+        cam_distance: {
+          name: 'Set Camera Distance',
+          command: 'camdist',
+          description: 'Sets the camera distance from the player',
+          syntax: 'camdist <distance>',
+          icon: '📏',
+          customizable: true,
+          parameters: {
+            distance: { type: 'number', min: 1, max: 500, default: 50 },
+          },
+        },
+        cam_reset: {
+          name: 'Reset Camera',
+          command: 'CamReset',
+          description: 'Reset the camera position to default',
+          syntax: 'CamReset',
+          icon: '🔄',
+        },
+        cam_target_lock: {
+          name: 'Lock Camera to Target',
+          command: 'Camsetlocktotarget',
+          description: 'Lock or unlock the camera to the target',
+          syntax: 'Camsetlocktotarget',
+          icon: '🎯',
+        },
+        cam_cycle_distance: {
+          name: 'Cycle Camera Distance',
+          command: 'camCycleDist',
+          description:
+            'Cycle the camera distance between several preset values',
+          syntax: 'camCycleDist',
+          icon: '🔄',
+        },
+        cam_mouse_look: {
+          name: 'Mouse Look',
+          command: '+camMouseLook',
+          description: 'Enable mouse look camera control',
+          syntax: '+camMouseLook',
+          icon: '🖱️',
+        },
+        cam_turn_to_face: {
+          name: 'Turn to Face Camera',
+          command: '+camTurnToFace',
+          description: 'Turn ship to face camera direction',
+          syntax: '+camTurnToFace',
+          icon: '↪️',
+        },
+        look_up: {
+          name: 'Look Up',
+          command: 'lookUp',
+          description: 'Change point of view to look straight up',
+          syntax: 'lookUp',
+          icon: '⬆️',
+        },
+        look_down: {
+          name: 'Look Down',
+          command: 'lookDown',
+          description: 'Change point of view to look straight down',
+          syntax: 'lookDown',
+          icon: '⬇️',
+        },
+      },
+    },
+
+    communication: {
+      name: 'Communication',
+      icon: 'fas fa-comments',
+      description: 'Chat and team communication',
+      commands: {
+        team_message: {
+          name: 'Team Message',
+          command: 'team',
+          description: 'Send message to team',
+          syntax: 'team message',
+          icon: '💬',
+          customizable: true,
+          parameters: {
+            message: { type: 'text', default: 'Message text here' },
+          },
+        },
+        local_message: {
+          name: 'Local Message',
+          command: 'say',
+          description: 'Send message to local area',
+          syntax: 'say message',
+          icon: '📢',
+          customizable: true,
+          parameters: {
+            message: { type: 'text', default: 'Message text here' },
+          },
+        },
+        zone_message: {
+          name: 'Zone Message',
+          command: 'zone',
+          description: 'Send message to zone',
+          syntax: 'zone message',
+          icon: '📡',
+          customizable: true,
+          parameters: {
+            message: { type: 'text', default: 'Message text here' },
+          },
+        },
+      },
+    },
+
+    system: {
+      name: 'System',
+      icon: 'fas fa-cog',
+      description: 'UI and system commands',
+      commands: {
+        toggle_hud: {
+          name: 'Toggle HUD',
+          command: '+GenToggleHUD',
+          description: 'Toggle HUD visibility',
+          syntax: '+GenToggleHUD',
+          icon: '👁️',
+        },
+        screenshot: {
+          name: 'Screenshot',
+          command: 'screenshot',
+          description: 'Take a screenshot',
+          syntax: 'screenshot',
+          icon: '📷',
+        },
+        screenshot_jpg: {
+          name: 'Screenshot JPG',
+          command: 'screenshot_jpg',
+          description: 'Save a screenshot as JPG',
+          syntax: 'screenshot_jpg',
+          icon: '📷',
+        },
+        autofire_toggle: {
+          name: 'Toggle Autofire',
+          command: '+GenToggleAutofire',
+          description: 'Toggle weapon autofire',
+          syntax: '+GenToggleAutofire',
+          icon: '🔁',
+        },
+        bind_save_file: {
+          name: 'Save Binds to File',
+          command: 'bind_save_file',
+          description: 'Save all your binds to a text file',
+          syntax: 'bind_save_file <filename>',
+          icon: '💾',
+          customizable: true,
+          parameters: {
+            filename: { type: 'text', default: 'my_binds.txt' },
+          },
+        },
+        bind_load_file: {
+          name: 'Load Binds from File',
+          command: 'bind_load_file',
+          description: 'Load a bind file into the client',
+          syntax: 'bind_load_file <filename>',
+          icon: '📁',
+          customizable: true,
+          parameters: {
+            filename: { type: 'text', default: 'my_binds.txt' },
+          },
+        },
+        combat_log: {
+          name: 'Toggle Combat Log',
+          command: 'CombatLog',
+          description: 'Turn combat log recording on/off (1=on, 0=off)',
+          syntax: 'CombatLog <1/0>',
+          icon: '📊',
+          customizable: true,
+          parameters: {
+            state: { type: 'number', min: 0, max: 1, default: 1 },
+          },
+        },
+        missions: {
+          name: 'Show/Hide Missions',
+          command: 'missions',
+          description: 'Show/hide the mission journal',
+          syntax: 'missions',
+          icon: '📋',
+        },
+        inventory: {
+          name: 'Show/Hide Inventory',
+          command: 'Inventory',
+          description: 'Show/hide your inventory',
+          syntax: 'Inventory',
+          icon: '🎒',
+        },
+        map: {
+          name: 'Show/Hide Map',
+          command: 'Map',
+          description: 'Show/hide the map window',
+          syntax: 'Map',
+          icon: '🗺️',
+        },
+      },
+    },
+  },
+
+  // Command templates for common scenarios
+  templates: {
+    space_combat: {
+      basic_attack: {
+        name: 'Basic Attack Sequence',
+        description: 'Target enemy and fire all weapons',
+        commands: ['Target_Enemy_Near', 'FireAll'],
+      },
+      defensive_sequence: {
+        name: 'Defensive Sequence',
+        description: 'Target self and activate defensive abilities',
+        commands: ['Target_Self', '+power_exec Distribute_Shields'],
+      },
+      alpha_strike: {
+        name: 'Alpha Strike',
+        description: 'Full offensive sequence with buffs',
+        commands: ['Target_Enemy_Near', 'FireAll'],
+      },
+      healing_sequence: {
+        name: 'Emergency Healing',
+        description: 'Self-healing and damage control',
+        commands: ['Target_Self', '+power_exec Distribute_Shields'],
+      },
+    },
+    ground_combat: {
+      basic_ground_attack: {
+        name: 'Basic Ground Attack',
+        description: 'Target and attack sequence for ground combat',
+        commands: ['Target_Enemy_Near', '+STOTrayExecByTray 0 0'],
+      },
+    },
+  },
+
+  // Default profiles
+  defaultProfiles: {
+    default_space: {
+      name: 'Default Space',
+      description: 'Basic space combat configuration',
+      currentEnvironment: 'space',
+      builds: {
+        space: {
+          keys: {
+            Space: [
+              {
+                command: 'Target_Enemy_Near',
+                type: 'targeting',
+                icon: '🎯',
+                text: 'Target nearest enemy',
+                id: 'cmd_1',
+              },
+              {
+                command: 'FireAll',
+                type: 'combat',
+                icon: '🔥',
+                text: 'Fire all weapons',
+                id: 'cmd_2',
+              },
+            ],
+          },
+          aliases: {
+            AttackCall: {
+              description: 'Call out attack target to team',
+              commands: 'team Attacking [$Target] - focus fire!',
+            },
+            TargetReport: {
+              description: 'Report current target to team',
+              commands: 'team Current target: [$Target]',
+            },
+            HealCall: {
+              description: 'Request healing for target',
+              commands: 'team Need healing on [$Target]!',
+            },
+          },
+        },
+        ground: {
+          keys: {
+            Space: [
+              {
+                command: 'Target_Enemy_Near',
+                type: 'targeting',
+                icon: '🎯',
+                text: 'Target nearest enemy',
+                id: 'cmd_g1',
+              },
+              {
+                command: '+STOTrayExecByTray 0 0',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Primary attack',
+                id: 'cmd_g2',
+              },
+            ],
+          },
+          aliases: {},
+        },
+      },
+    },
+    tactical_space: {
+      name: 'Tactical Space',
+      description: 'Aggressive DPS-focused space build',
+      currentEnvironment: 'space',
+      builds: {
+        space: {
+          keys: {
+            Space: [
+              {
+                command: 'Target_Enemy_Near',
+                type: 'targeting',
+                icon: '🎯',
+                text: 'Target nearest enemy',
+                id: 'cmd_1',
+              },
+              {
+                command: '+STOTrayExecByTray 0 0',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Execute Tray 1 Slot 1',
+                id: 'cmd_2',
+              },
+              {
+                command: 'FireAll',
+                type: 'combat',
+                icon: '🔥',
+                text: 'Fire all weapons',
+                id: 'cmd_3',
+              },
+              {
+                command: '+power_exec Distribute_Shields',
+                type: 'power',
+                icon: '🛡️',
+                text: 'Distribute shields',
+                id: 'cmd_4',
+              },
+            ],
+            1: [
+              {
+                command: '+STOTrayExecByTray 1 0',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Execute Tray 2 Slot 1',
+                id: 'cmd_5',
+              },
+            ],
+            F1: [
+              {
+                command: 'Target_Self',
+                type: 'targeting',
+                icon: '👤',
+                text: 'Target self',
+                id: 'cmd_6',
+              },
+              {
+                command: '+STOTrayExecByTray 2 0',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Execute Tray 3 Slot 1',
+                id: 'cmd_7',
+              },
+            ],
+          },
+          aliases: {},
+        },
+        ground: {
+          keys: {
+            Space: [
+              {
+                command: 'Target_Enemy_Near',
+                type: 'targeting',
+                icon: '🎯',
+                text: 'Target nearest enemy',
+                id: 'cmd_g1',
+              },
+              {
+                command: '+STOTrayExecByTray 0 0',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Primary attack',
+                id: 'cmd_g2',
+              },
+            ],
+            1: [
+              {
+                command: '+STOTrayExecByTray 0 1',
+                type: 'tray',
+                icon: '⚡',
+                text: 'Secondary attack',
+                id: 'cmd_g3',
+              },
+            ],
+            F1: [
+              {
+                command: 'Target_Self',
+                type: 'targeting',
+                icon: '👤',
+                text: 'Target self',
+                id: 'cmd_g4',
+              },
+              {
+                command: '+STOTrayExecByTray 1 0',
+                type: 'tray',
+                icon: '💊',
+                text: 'Heal self',
+                id: 'cmd_g5',
+              },
+            ],
+          },
+          aliases: {},
+        },
+      },
+    },
+  },
+
+  // Comprehensive key definitions organized by category
+  keys: {
+    common: {
+      name: 'Common Keys',
+      description: 'Most frequently used keys',
+      keys: [
+        { key: 'Space', description: 'Spacebar' },
+        { key: '1', description: 'Number 1' },
+        { key: '2', description: 'Number 2' },
+        { key: '3', description: 'Number 3' },
+        { key: '4', description: 'Number 4' },
+        { key: '5', description: 'Number 5' },
+        { key: 'F1', description: 'Function Key 1' },
+        { key: 'F2', description: 'Function Key 2' },
+        { key: 'F3', description: 'Function Key 3' },
+        { key: 'F4', description: 'Function Key 4' },
+        { key: 'Tab', description: 'Tab' },
+        { key: 'enter', description: 'Main Enter Key' },
+        { key: 'Shift', description: 'Shift' },
+        { key: 'Control', description: 'Control' },
+        { key: 'ALT', description: 'Alt' },
+      ],
+    },
+    letters: {
+      name: 'Letter Keys',
+      description: 'A-Z keyboard letters',
+      keys: [
+        { key: 'A', description: 'Key A' },
+        { key: 'B', description: 'Key B' },
+        { key: 'C', description: 'Key C' },
+        { key: 'D', description: 'Key D' },
+        { key: 'E', description: 'Key E' },
+        { key: 'F', description: 'Key F' },
+        { key: 'G', description: 'Key G' },
+        { key: 'H', description: 'Key H' },
+        { key: 'I', description: 'Key I' },
+        { key: 'J', description: 'Key J' },
+        { key: 'K', description: 'Key K' },
+        { key: 'L', description: 'Key L' },
+        { key: 'M', description: 'Key M' },
+        { key: 'N', description: 'Key N' },
+        { key: 'O', description: 'Key O' },
+        { key: 'P', description: 'Key P' },
+        { key: 'Q', description: 'Key Q' },
+        { key: 'R', description: 'Key R' },
+        { key: 'S', description: 'Key S' },
+        { key: 'T', description: 'Key T' },
+        { key: 'U', description: 'Key U' },
+        { key: 'V', description: 'Key V' },
+        { key: 'W', description: 'Key W' },
+        { key: 'X', description: 'Key X' },
+        { key: 'Y', description: 'Key Y' },
+        { key: 'Z', description: 'Key Z' },
+      ],
+    },
+    numbers: {
+      name: 'Number Keys',
+      description: 'Number row and numpad',
+      keys: [
+        { key: '0', description: 'Number 0' },
+        { key: '6', description: 'Number 6' },
+        { key: '7', description: 'Number 7' },
+        { key: '8', description: 'Number 8' },
+        { key: '9', description: 'Number 9' },
+        { key: 'numpad0', description: 'Numerical Keypad 0' },
+        { key: 'numpad1', description: 'Numerical Keypad 1' },
+        { key: 'numpad2', description: 'Numerical Keypad 2' },
+        { key: 'numpad3', description: 'Numerical Keypad 3' },
+        { key: 'numpad4', description: 'Numerical Keypad 4' },
+        { key: 'numpad5', description: 'Numerical Keypad 5' },
+        { key: 'numpad6', description: 'Numerical Keypad 6' },
+        { key: 'numpad7', description: 'Numerical Keypad 7' },
+        { key: 'numpad8', description: 'Numerical Keypad 8' },
+        { key: 'numpad9', description: 'Numerical Keypad 9' },
+        { key: 'Decimal', description: 'Numerical Keypad Decimal' },
+        { key: 'Divide', description: 'Numerical Keypad Divide' },
+        { key: 'Multiply', description: 'Multiply (*)' },
+        { key: 'Subtract', description: 'Subtract (-)' },
+        { key: 'Add', description: 'Add (+)' },
+        { key: 'numpadenter', description: 'Numerical Keypad Enter' },
+      ],
+    },
+    function: {
+      name: 'Function Keys',
+      description: 'F1-F24 function keys',
+      keys: [
+        { key: 'F5', description: 'Function Key 5' },
+        { key: 'F6', description: 'Function Key 6' },
+        { key: 'F7', description: 'Function Key 7' },
+        { key: 'F8', description: 'Function Key 8' },
+        { key: 'F9', description: 'Function Key 9' },
+        { key: 'F10', description: 'Function Key 10' },
+        { key: 'F11', description: 'Function Key 11' },
+        { key: 'F12', description: 'Function Key 12' },
+        { key: 'F13', description: 'Function Key 13' },
+        { key: 'F14', description: 'Function Key 14' },
+        { key: 'F15', description: 'Function Key 15' },
+        { key: 'F16', description: 'Function Key 16' },
+        { key: 'F17', description: 'Function Key 17' },
+        { key: 'F18', description: 'Function Key 18' },
+        { key: 'F19', description: 'Function Key 19' },
+        { key: 'F20', description: 'Function Key 20' },
+        { key: 'F21', description: 'Function Key 21' },
+        { key: 'F22', description: 'Function Key 22' },
+        { key: 'F23', description: 'Function Key 23' },
+        { key: 'F24', description: 'Function Key 24' },
+      ],
+    },
+    arrows: {
+      name: 'Arrow & Navigation',
+      description: 'Arrow keys and navigation',
+      keys: [
+        { key: 'Up', description: 'Arrow Key: Up' },
+        { key: 'Down', description: 'Arrow Key: Down' },
+        { key: 'Left', description: 'Arrow Key: Left' },
+        { key: 'Right', description: 'Arrow Key: Right' },
+        { key: 'Home', description: 'Home' },
+        { key: 'End', description: 'End' },
+        { key: 'PageUp', description: 'Page Up' },
+        { key: 'PageDown', description: 'Page Down' },
+        { key: 'insert', description: 'Insert' },
+        { key: 'delete', description: 'Delete' },
+      ],
+    },
+    modifiers: {
+      name: 'Modifier Keys',
+      description: 'Shift, Ctrl, Alt variations',
+      keys: [
+        { key: 'LALT', description: 'Alt (Left)' },
+        { key: 'RALT', description: 'Alt (Right)' },
+        { key: 'LCTRL', description: 'Control (Left)' },
+        { key: 'RCTRL', description: 'Control (Right)' },
+      ],
+    },
+    symbols: {
+      name: 'Symbol Keys',
+      description: 'Punctuation and symbols',
+      keys: [
+        { key: '[', description: '[' },
+        { key: ']', description: ']' },
+        { key: '\\', description: '\\' },
+        { key: ',', description: 'Comma (,)' },
+        { key: '.', description: 'Period (.)' },
+        { key: '/', description: 'Divide (/)' },
+        { key: '`', description: 'Tilda Key (~)' },
+      ],
+    },
+    mouse: {
+      name: 'Mouse Controls',
+      description: 'Mouse buttons and scroll',
+      keys: [
+        { key: 'Lbutton', description: 'Mouse Left Press' },
+        { key: 'Rbutton', description: 'Mouse Right Press' },
+        { key: 'Middleclick', description: 'Mouse Middle Click' },
+        { key: 'Button1', description: 'Mouse Button 1' },
+        { key: 'Button2', description: 'Mouse Button 2' },
+        { key: 'Button3', description: 'Mouse Button 3' },
+        { key: 'Button4', description: 'Mouse Button 4' },
+        { key: 'Button5', description: 'Mouse Button 5' },
+        { key: 'Button6', description: 'Mouse Button 6' },
+        { key: 'Button7', description: 'Mouse Button 7' },
+        { key: 'Button8', description: 'Mouse Button 8' },
+        { key: 'Button9', description: 'Mouse Button 9' },
+        { key: 'Button10', description: 'Mouse Button 10' },
+        { key: 'Wheelplus', description: 'Mouse Scroll Up' },
+        { key: 'Wheelminus', description: 'Mouse Scroll Down' },
+      ],
+    },
+    gamepad: {
+      name: 'Xbox Controller',
+      description: 'Xbox/Gamepad controls',
+      keys: [
+        { key: 'Joy1', description: 'XBOX Contr [Start]' },
+        { key: 'Joy2', description: 'XBOX Contr [Back]' },
+        { key: 'Joy3', description: 'XBOX Contr [L Thumb depress]' },
+        { key: 'Joy4', description: 'XBOX Contr [R Thumb depress]' },
+        { key: 'Joy5', description: 'XBOX Contr [Left Bumper]' },
+        { key: 'Joy6', description: 'XBOX Contr [Right Bumper]' },
+        { key: 'Joy7', description: 'XBOX Contr [Left Trigger]' },
+        { key: 'Joy8', description: 'XBOX Contr [Right Trigger]' },
+        { key: 'Joy9', description: 'XBOX Contr [A Button]' },
+        { key: 'Joy10', description: 'XBOX Contr [B Button]' },
+        { key: 'Joy11', description: 'XBOX Contr [X Button]' },
+        { key: 'Joy12', description: 'XBOX Contr [Y Button]' },
+        { key: 'Joypad_up', description: 'XBOX Contr [Pad up]' },
+        { key: 'Joypad_down', description: 'XBOX Contr [Pad down]' },
+        { key: 'Joypad_left', description: 'XBOX Contr [Pad left]' },
+        { key: 'Joypad_right', description: 'XBOX Contr [Pad right]' },
+        { key: 'Lstick_up', description: 'XBOX Contr [Left Stick up]' },
+        { key: 'Lstick_down', description: 'XBOX Contr [Left Stick down]' },
+        { key: 'Lstick_left', description: 'XBOX Contr [Left Stick left]' },
+        { key: 'Lstick_right', description: 'XBOX Contr [Left Stick right]' },
+        { key: 'Rstick_up', description: 'XBOX Contr [Right Stick up]' },
+        { key: 'Rstick_down', description: 'XBOX Contr [Right Stick down]' },
+        { key: 'Rstick_left', description: 'XBOX Contr [Right Stick left]' },
+        { key: 'Rstick_right', description: 'XBOX Contr [Right Stick right]' },
+      ],
+    },
+  },
+
+  // Validation rules
+  validation: {
+    keyNamePattern: /^[a-zA-Z0-9_+\-\s]+$/,
+    aliasNamePattern: /^[a-zA-Z_][a-zA-Z0-9_]*$/,
+    maxCommandsPerKey: 20,
+    maxKeysPerProfile: 100,
+  },
+
+  // Application settings
+  settings: {
+    version: '1.0.0',
+    autoSave: true,
+    maxUndoSteps: 50,
+    defaultMode: 'space',
+  },
+
+  // STO Variables that can be used in commands
+  variables: {
+    target: {
+      variable: '$Target',
+      description: 'Replaced with the name of your current target',
+      example: 'team Target [$Target]',
+      usableIn: ['communication', 'custom', 'aliases'],
+      notes:
+        "If your target's name is 'froggyMonster', this will output 'Target [froggyMonster]'",
+    },
+  },
+}
 
 // Make available globally
-window.STO_DATA = STO_DATA;
+window.STO_DATA = STO_DATA
 
 // Create flattened data structures for backward compatibility and testing
-window.COMMAND_CATEGORIES = STO_DATA.commands;
+window.COMMAND_CATEGORIES = STO_DATA.commands
 
 // Flatten all commands into a single object
-window.COMMANDS = {};
+window.COMMANDS = {}
 Object.entries(STO_DATA.commands).forEach(([categoryKey, category]) => {
-    Object.entries(category.commands).forEach(([commandKey, command]) => {
-        window.COMMANDS[commandKey] = {
-            ...command,
-            category: categoryKey,
-            key: commandKey
-        };
-    });
-});
+  Object.entries(category.commands).forEach(([commandKey, command]) => {
+    window.COMMANDS[commandKey] = {
+      ...command,
+      category: categoryKey,
+      key: commandKey,
+    }
+  })
+})
 
 // Key layouts (if they exist in STO_DATA, otherwise create basic structure)
 window.KEY_LAYOUTS = STO_DATA.keyLayouts || {
-    qwerty: {
-        name: "QWERTY",
-        rows: [
-            [
-                { key: "Escape", display: "Esc" },
-                { key: "F1", display: "F1" },
-                { key: "F2", display: "F2" },
-                { key: "F3", display: "F3" },
-                { key: "F4", display: "F4" },
-                { key: "F5", display: "F5" },
-                { key: "F6", display: "F6" },
-                { key: "F7", display: "F7" },
-                { key: "F8", display: "F8" },
-                { key: "F9", display: "F9" },
-                { key: "F10", display: "F10" },
-                { key: "F11", display: "F11" },
-                { key: "F12", display: "F12" }
-            ],
-            [
-                { key: "`", display: "`" },
-                { key: "1", display: "1" },
-                { key: "2", display: "2" },
-                { key: "3", display: "3" },
-                { key: "4", display: "4" },
-                { key: "5", display: "5" },
-                { key: "6", display: "6" },
-                { key: "7", display: "7" },
-                { key: "8", display: "8" },
-                { key: "9", display: "9" },
-                { key: "0", display: "0" },
-                { key: "-", display: "-" },
-                { key: "=", display: "=" },
-                { key: "Backspace", display: "Backspace" }
-            ],
-            [
-                { key: "Tab", display: "Tab" },
-                { key: "Q", display: "Q" },
-                { key: "W", display: "W" },
-                { key: "E", display: "E" },
-                { key: "R", display: "R" },
-                { key: "T", display: "T" },
-                { key: "Y", display: "Y" },
-                { key: "U", display: "U" },
-                { key: "I", display: "I" },
-                { key: "O", display: "O" },
-                { key: "P", display: "P" },
-                { key: "[", display: "[" },
-                { key: "]", display: "]" },
-                { key: "\\", display: "\\" }
-            ],
-            [
-                { key: "CapsLock", display: "Caps" },
-                { key: "A", display: "A" },
-                { key: "S", display: "S" },
-                { key: "D", display: "D" },
-                { key: "F", display: "F" },
-                { key: "G", display: "G" },
-                { key: "H", display: "H" },
-                { key: "J", display: "J" },
-                { key: "K", display: "K" },
-                { key: "L", display: "L" },
-                { key: ";", display: ";" },
-                { key: "'", display: "'" },
-                { key: "Enter", display: "Enter" }
-            ],
-            [
-                { key: "Shift", display: "Shift" },
-                { key: "Z", display: "Z" },
-                { key: "X", display: "X" },
-                { key: "C", display: "C" },
-                { key: "V", display: "V" },
-                { key: "B", display: "B" },
-                { key: "N", display: "N" },
-                { key: "M", display: "M" },
-                { key: ",", display: "," },
-                { key: ".", display: "." },
-                { key: "/", display: "/" },
-                { key: "Shift", display: "Shift" }
-            ],
-            [
-                { key: "Ctrl", display: "Ctrl" },
-                { key: "Alt", display: "Alt" },
-                { key: "Space", display: "Space" },
-                { key: "Alt", display: "Alt" },
-                { key: "Ctrl", display: "Ctrl" }
-            ]
-        ]
-    }
-};
+  qwerty: {
+    name: 'QWERTY',
+    rows: [
+      [
+        { key: 'Escape', display: 'Esc' },
+        { key: 'F1', display: 'F1' },
+        { key: 'F2', display: 'F2' },
+        { key: 'F3', display: 'F3' },
+        { key: 'F4', display: 'F4' },
+        { key: 'F5', display: 'F5' },
+        { key: 'F6', display: 'F6' },
+        { key: 'F7', display: 'F7' },
+        { key: 'F8', display: 'F8' },
+        { key: 'F9', display: 'F9' },
+        { key: 'F10', display: 'F10' },
+        { key: 'F11', display: 'F11' },
+        { key: 'F12', display: 'F12' },
+      ],
+      [
+        { key: '`', display: '`' },
+        { key: '1', display: '1' },
+        { key: '2', display: '2' },
+        { key: '3', display: '3' },
+        { key: '4', display: '4' },
+        { key: '5', display: '5' },
+        { key: '6', display: '6' },
+        { key: '7', display: '7' },
+        { key: '8', display: '8' },
+        { key: '9', display: '9' },
+        { key: '0', display: '0' },
+        { key: '-', display: '-' },
+        { key: '=', display: '=' },
+        { key: 'Backspace', display: 'Backspace' },
+      ],
+      [
+        { key: 'Tab', display: 'Tab' },
+        { key: 'Q', display: 'Q' },
+        { key: 'W', display: 'W' },
+        { key: 'E', display: 'E' },
+        { key: 'R', display: 'R' },
+        { key: 'T', display: 'T' },
+        { key: 'Y', display: 'Y' },
+        { key: 'U', display: 'U' },
+        { key: 'I', display: 'I' },
+        { key: 'O', display: 'O' },
+        { key: 'P', display: 'P' },
+        { key: '[', display: '[' },
+        { key: ']', display: ']' },
+        { key: '\\', display: '\\' },
+      ],
+      [
+        { key: 'CapsLock', display: 'Caps' },
+        { key: 'A', display: 'A' },
+        { key: 'S', display: 'S' },
+        { key: 'D', display: 'D' },
+        { key: 'F', display: 'F' },
+        { key: 'G', display: 'G' },
+        { key: 'H', display: 'H' },
+        { key: 'J', display: 'J' },
+        { key: 'K', display: 'K' },
+        { key: 'L', display: 'L' },
+        { key: ';', display: ';' },
+        { key: "'", display: "'" },
+        { key: 'Enter', display: 'Enter' },
+      ],
+      [
+        { key: 'Shift', display: 'Shift' },
+        { key: 'Z', display: 'Z' },
+        { key: 'X', display: 'X' },
+        { key: 'C', display: 'C' },
+        { key: 'V', display: 'V' },
+        { key: 'B', display: 'B' },
+        { key: 'N', display: 'N' },
+        { key: 'M', display: 'M' },
+        { key: ',', display: ',' },
+        { key: '.', display: '.' },
+        { key: '/', display: '/' },
+        { key: 'Shift', display: 'Shift' },
+      ],
+      [
+        { key: 'Ctrl', display: 'Ctrl' },
+        { key: 'Alt', display: 'Alt' },
+        { key: 'Space', display: 'Space' },
+        { key: 'Alt', display: 'Alt' },
+        { key: 'Ctrl', display: 'Ctrl' },
+      ],
+    ],
+  },
+}
 
 // Default settings
 window.DEFAULT_SETTINGS = {
-    keyLayout: "qwerty",
-    autoSave: STO_DATA.settings?.autoSave || true,
-    showTooltips: true,
-    exportFormat: "txt",
-    maxUndoSteps: STO_DATA.settings?.maxUndoSteps || 50,
-    defaultMode: STO_DATA.settings?.defaultMode || "space"
-};
+  keyLayout: 'qwerty',
+  autoSave: STO_DATA.settings?.autoSave || true,
+  showTooltips: true,
+  exportFormat: 'txt',
+  maxUndoSteps: STO_DATA.settings?.maxUndoSteps || 50,
+  defaultMode: STO_DATA.settings?.defaultMode || 'space',
+}
 
 // Sample profiles
-window.SAMPLE_PROFILES = Object.values(STO_DATA.defaultProfiles).map(profile => ({
+window.SAMPLE_PROFILES = Object.values(STO_DATA.defaultProfiles).map(
+  (profile) => ({
     id: profile.name.toLowerCase().replace(/\s+/g, '_'),
     name: profile.name,
     description: profile.description,
     currentEnvironment: profile.currentEnvironment || 'space',
     builds: profile.builds || {
-        space: { keys: {} },
-        ground: { keys: {} }
+      space: { keys: {} },
+      ground: { keys: {} },
     },
     // Maintain backward compatibility
     mode: profile.currentEnvironment || 'space',
     keybinds: profile.builds?.space?.keys || {},
     aliases: profile.builds?.space?.aliases || {},
     created: new Date().toISOString(),
-    modified: new Date().toISOString()
-}));
+    modified: new Date().toISOString(),
+  })
+)
 
 // Sample aliases
 window.SAMPLE_ALIASES = {
-    attack_sequence: {
-        name: "Attack Sequence",
-        commands: ["Target_Enemy_Near", "FireAll"],
-        description: "Target and attack nearest enemy"
-    },
-    defensive_sequence: {
-        name: "Defensive Sequence", 
-        commands: ["Target_Self", "+power_exec Distribute_Shields"],
-        description: "Self-target and activate defensive abilities"
-    },
-    heal_sequence: {
-        name: "Healing Sequence",
-        commands: ["Target_Self", "+STOTrayExecByTray 3 0 $$ +STOTrayExecByTray 3 1"],
-        description: "Emergency healing and repair sequence"
-    }
-};
+  attack_sequence: {
+    name: 'Attack Sequence',
+    commands: ['Target_Enemy_Near', 'FireAll'],
+    description: 'Target and attack nearest enemy',
+  },
+  defensive_sequence: {
+    name: 'Defensive Sequence',
+    commands: ['Target_Self', '+power_exec Distribute_Shields'],
+    description: 'Self-target and activate defensive abilities',
+  },
+  heal_sequence: {
+    name: 'Healing Sequence',
+    commands: [
+      'Target_Self',
+      '+STOTrayExecByTray 3 0 $$ +STOTrayExecByTray 3 1',
+    ],
+    description: 'Emergency healing and repair sequence',
+  },
+}
 
 // Tray configuration
 window.TRAY_CONFIG = {
-    maxTrays: 10,
-    slotsPerTray: 10,
-    defaultTray: 0,
-    maxCommandsPerSlot: 1
-};
+  maxTrays: 10,
+  slotsPerTray: 10,
+  defaultTray: 0,
+  maxCommandsPerSlot: 1,
+}
 
 // Utility functions for data access
-window.getCommandsByCategory = function(category) {
-    if (!category || !STO_DATA.commands[category]) {
-        return [];
-    }
-    return Object.values(STO_DATA.commands[category].commands);
-};
+window.getCommandsByCategory = function (category) {
+  if (!category || !STO_DATA.commands[category]) {
+    return []
+  }
+  return Object.values(STO_DATA.commands[category].commands)
+}

--- a/src/js/errors.js
+++ b/src/js/errors.js
@@ -3,40 +3,46 @@
  */
 
 class STOError extends Error {
-    constructor(message, code = 'STO_ERROR') {
-        super(message);
-        this.name = 'STOError';
-        this.code = code;
-    }
+  constructor(message, code = 'STO_ERROR') {
+    super(message)
+    this.name = 'STOError'
+    this.code = code
+  }
 }
 
 class VertigoError extends STOError {
-    constructor(message, code = 'VFX_ERROR') {
-        super(message, code);
-        this.name = 'VertigoError';
-    }
+  constructor(message, code = 'VFX_ERROR') {
+    super(message, code)
+    this.name = 'VertigoError'
+  }
 }
 
 class InvalidEnvironmentError extends VertigoError {
-    constructor(environment) {
-        super(`Invalid environment '${environment}'. Valid environments are: space, ground`, 'INVALID_ENVIRONMENT');
-        this.environment = environment;
-    }
+  constructor(environment) {
+    super(
+      `Invalid environment '${environment}'. Valid environments are: space, ground`,
+      'INVALID_ENVIRONMENT'
+    )
+    this.environment = environment
+  }
 }
 
 class InvalidEffectError extends VertigoError {
-    constructor(effectName, environment) {
-        super(`Invalid effect '${effectName}' for environment '${environment}'`, 'INVALID_EFFECT');
-        this.effectName = effectName;
-        this.environment = environment;
-    }
+  constructor(effectName, environment) {
+    super(
+      `Invalid effect '${effectName}' for environment '${environment}'`,
+      'INVALID_EFFECT'
+    )
+    this.effectName = effectName
+    this.environment = environment
+  }
 }
 
-export { STOError, VertigoError, InvalidEnvironmentError, InvalidEffectError };
+export { STOError, VertigoError, InvalidEnvironmentError, InvalidEffectError }
 
 if (typeof window !== 'undefined') {
-    window.STOError = STOError;
-    window.VertigoError = VertigoError;
-    window.InvalidEnvironmentError = InvalidEnvironmentError;
-    window.InvalidEffectError = InvalidEffectError;
+  window.STOError = STOError
+  window.VertigoError = VertigoError
+  window.InvalidEnvironmentError = InvalidEnvironmentError
+  window.InvalidEffectError = InvalidEffectError
 }

--- a/src/js/eventBus.js
+++ b/src/js/eventBus.js
@@ -1,49 +1,49 @@
-const listeners = {};
+const listeners = {}
 
 function on(event, handler) {
   if (!listeners[event]) {
-    listeners[event] = new Set();
+    listeners[event] = new Set()
   }
-  listeners[event].add(handler);
+  listeners[event].add(handler)
 }
 
 function off(event, handler) {
   if (listeners[event]) {
-    listeners[event].delete(handler);
+    listeners[event].delete(handler)
   }
 }
 
 function emit(event, detail) {
-  if (!listeners[event]) return;
+  if (!listeners[event]) return
   for (const handler of listeners[event]) {
     try {
-      handler(detail);
+      handler(detail)
     } catch (err) {
-      console.error(err);
+      console.error(err)
     }
   }
 }
 
 function onDom(target, domEvent, busEvent, handler) {
   if (typeof target === 'string') {
-    target = document.getElementById(target);
+    target = document.getElementById(target)
   }
-  if (!target || !target.addEventListener) return () => {};
+  if (!target || !target.addEventListener) return () => {}
   if (typeof busEvent === 'function') {
-    handler = busEvent;
-    busEvent = domEvent;
+    handler = busEvent
+    busEvent = domEvent
   }
-  if (!busEvent) busEvent = domEvent;
+  if (!busEvent) busEvent = domEvent
 
-  const domHandler = (e) => emit(busEvent, e);
-  target.addEventListener(domEvent, domHandler);
+  const domHandler = (e) => emit(busEvent, e)
+  target.addEventListener(domEvent, domHandler)
 
-  if (handler) on(busEvent, handler);
+  if (handler) on(busEvent, handler)
 
   return () => {
-    target.removeEventListener(domEvent, domHandler);
-    if (handler) off(busEvent, handler);
-  };
+    target.removeEventListener(domEvent, domHandler)
+    if (handler) off(busEvent, handler)
+  }
 }
 
-export default { on, off, emit, onDom };
+export default { on, off, emit, onDom }

--- a/src/js/export.js
+++ b/src/js/export.js
@@ -3,103 +3,107 @@
 import eventBus from './eventBus.js'
 
 export default class STOExportManager {
-    constructor() {
-        this.exportFormats = {
-            sto_keybind: 'STO Keybind File (.txt)',
-            json_profile: 'JSON Profile (.json)',
-            json_project: 'Complete Project (.json)',
-            csv_data: 'CSV Data (.csv)',
-            html_report: 'HTML Report (.html)'
-        };
-        
-        // Don't initialize immediately - wait for app to be ready
+  constructor() {
+    this.exportFormats = {
+      sto_keybind: 'STO Keybind File (.txt)',
+      json_profile: 'JSON Profile (.json)',
+      json_project: 'Complete Project (.json)',
+      csv_data: 'CSV Data (.csv)',
+      html_report: 'HTML Report (.html)',
     }
 
-    init() {
-        this.setupEventListeners();
+    // Don't initialize immediately - wait for app to be ready
+  }
+
+  init() {
+    this.setupEventListeners()
+  }
+
+  setupEventListeners() {
+    // Main export button
+    eventBus.onDom('exportKeybindsBtn', 'click', 'exportKeybinds', () => {
+      this.showExportOptions()
+    })
+
+    // Copy command preview
+    eventBus.onDom('copyPreviewBtn', 'click', 'copyPreview', () => {
+      this.copyCommandPreview()
+    })
+  }
+
+  // Export Options Dialog
+  async showExportOptions() {
+    const profile = app.getCurrentProfile()
+    if (!profile) {
+      stoUI.showToast('No profile selected to export', 'warning')
+      return
     }
 
-    setupEventListeners() {
-        // Main export button
-        eventBus.onDom('exportKeybindsBtn', 'click', 'exportKeybinds', () => {
-            this.showExportOptions();
-        });
+    // For now, directly export as STO keybind file
+    // TODO: Add export options modal for different formats
+    this.exportSTOKeybindFile(profile)
+  }
 
-        // Copy command preview
-        eventBus.onDom('copyPreviewBtn', 'click', 'copyPreview', () => {
-            this.copyCommandPreview();
-        });
+  // STO Keybind File Export
+  exportSTOKeybindFile(profile) {
+    try {
+      const content = this.generateSTOKeybindFile(profile)
+      this.downloadFile(
+        content,
+        this.generateFileName(profile, 'txt'),
+        'text/plain'
+      )
+
+      stoUI.showToast('Keybind file exported successfully', 'success')
+    } catch (error) {
+      stoUI.showToast(
+        'Failed to export keybind file: ' + error.message,
+        'error'
+      )
+    }
+  }
+
+  generateSTOKeybindFile(profile, options = {}) {
+    let content = ''
+
+    // Header with metadata
+    content += this.generateFileHeader(profile)
+
+    // Export keybinds only (aliases are exported separately)
+    // Pass the profile and environment (if available) to the keybind section for per-key metadata access
+    content += this.generateKeybindSection(profile.keys, {
+      ...options,
+      profile,
+      // Support both explicit environment option or fallback to profile.mode/current environment string
+      environment: options.environment || profile.mode || 'space',
+    })
+
+    // Footer with usage instructions
+    content += this.generateFileFooter()
+
+    return content
+  }
+
+  generateFileHeader(profile) {
+    const timestamp = new Date().toLocaleString()
+
+    // Calculate stats locally if stoKeybinds is not available
+    let stats
+    if (typeof stoKeybinds !== 'undefined' && stoKeybinds.getProfileStats) {
+      stats = stoKeybinds.getProfileStats(profile)
+    } else {
+      // Calculate stats locally
+      stats = {
+        totalKeys: Object.keys(profile.keys || {}).length,
+        totalCommands: 0,
+      }
+
+      Object.values(profile.keys || {}).forEach((commands) => {
+        stats.totalCommands += commands.length
+      })
     }
 
-    // Export Options Dialog
-    async showExportOptions() {
-        const profile = app.getCurrentProfile();
-        if (!profile) {
-            stoUI.showToast('No profile selected to export', 'warning');
-            return;
-        }
-
-        // For now, directly export as STO keybind file
-        // TODO: Add export options modal for different formats
-        this.exportSTOKeybindFile(profile);
-    }
-
-    // STO Keybind File Export
-    exportSTOKeybindFile(profile) {
-        try {
-            const content = this.generateSTOKeybindFile(profile);
-            this.downloadFile(content, this.generateFileName(profile, 'txt'), 'text/plain');
-            
-            stoUI.showToast('Keybind file exported successfully', 'success');
-        } catch (error) {
-            stoUI.showToast('Failed to export keybind file: ' + error.message, 'error');
-        }
-    }
-
-    generateSTOKeybindFile(profile, options = {}) {
-        let content = '';
-        
-        // Header with metadata
-        content += this.generateFileHeader(profile);
-        
-        // Export keybinds only (aliases are exported separately)
-        // Pass the profile and environment (if available) to the keybind section for per-key metadata access
-        content += this.generateKeybindSection(
-            profile.keys,
-            {
-                ...options,
-                profile,
-                // Support both explicit environment option or fallback to profile.mode/current environment string
-                environment: options.environment || profile.mode || 'space'
-            }
-        );
-        
-        // Footer with usage instructions
-        content += this.generateFileFooter();
-        
-        return content;
-    }
-
-    generateFileHeader(profile) {
-        const timestamp = new Date().toLocaleString();
-        
-        // Calculate stats locally if stoKeybinds is not available
-        let stats;
-        if (typeof stoKeybinds !== 'undefined' && stoKeybinds.getProfileStats) {
-            stats = stoKeybinds.getProfileStats(profile);
-        } else {
-            // Calculate stats locally
-            stats = {
-                totalKeys: Object.keys(profile.keys || {}).length,
-                totalCommands: 0
-            };
-            
-            Object.values(profile.keys || {}).forEach(commands => {
-                stats.totalCommands += commands.length;
-            });
-        }
-        
-        return `; ================================================================
+    return `; ================================================================
 ; ${profile.name} - STO Keybind Configuration
 ; ================================================================
 ; Mode: ${profile.mode.toUpperCase()}
@@ -116,193 +120,208 @@ export default class STOExportManager {
 ; 2. In game, type: /bind_load_file ${this.generateFileName(profile, 'txt')}
 ; ================================================================
 
-`;
+`
+  }
+
+  generateAliasSection(aliases) {
+    if (!aliases || Object.keys(aliases).length === 0) {
+      return ''
     }
 
-    generateAliasSection(aliases) {
-        if (!aliases || Object.keys(aliases).length === 0) {
-            return '';
-        }
-
-        let content = `; Command Aliases
+    let content = `; Command Aliases
 ; ================================================================
 ; Aliases allow you to create custom commands that execute
 ; multiple commands in sequence. Use them in keybinds like any
 ; other command.
 ; ================================================================
 
-`;
+`
 
-        // Sort aliases alphabetically
-        const sortedAliases = Object.entries(aliases).sort(([a], [b]) => a.localeCompare(b));
-        
-        sortedAliases.forEach(([name, alias]) => {
-            if (alias.description) {
-                content += `; ${alias.description}\n`;
-            }
-            content += `alias ${name} <& ${alias.commands} &>\n\n`;
-        });
+    // Sort aliases alphabetically
+    const sortedAliases = Object.entries(aliases).sort(([a], [b]) =>
+      a.localeCompare(b)
+    )
 
-        return content;
+    sortedAliases.forEach(([name, alias]) => {
+      if (alias.description) {
+        content += `; ${alias.description}\n`
+      }
+      content += `alias ${name} <& ${alias.commands} &>\n\n`
+    })
+
+    return content
+  }
+
+  generateKeybindSection(keys, options = {}) {
+    if (!keys || Object.keys(keys).length === 0) {
+      return '; No keybinds defined\n\n'
     }
 
-    generateKeybindSection(keys, options = {}) {
-        if (!keys || Object.keys(keys).length === 0) {
-            return '; No keybinds defined\n\n';
-        }
-
-        let content = `; Keybind Commands
+    let content = `; Keybind Commands
 ; ================================================================
 ; Each line binds a key to one or more commands.
-; Multiple commands are separated by $$`;
-        
-        if (options.stabilizeExecutionOrder) {
-            content += `
+; Multiple commands are separated by $$`
+
+    if (options.stabilizeExecutionOrder) {
+      content += `
 ; EXECUTION ORDER STABILIZATION: ON
 ; Commands are mirrored to ensure consistent execution order
-; Phase 1: left-to-right, Phase 2: right-to-left`;
-        }
-        
-        content += `
+; Phase 1: left-to-right, Phase 2: right-to-left`
+    }
+
+    content += `
 ; ================================================================
 
-`;
+`
 
-        // Sort keys using the keybind manager's sorting logic if available, otherwise use local sorting
-        let sortedKeys;
-        if (typeof stoKeybinds !== 'undefined' && stoKeybinds.compareKeys) {
-            sortedKeys = Object.keys(keys).sort(stoKeybinds.compareKeys.bind(stoKeybinds));
-        } else {
-            // Local key sorting implementation
-            sortedKeys = Object.keys(keys).sort(this.compareKeys.bind(this));
-        }
-        
-        // Group keys by type for better organization
-        const keyGroups = this.groupKeysByType(sortedKeys, keys);
-        
-        Object.entries(keyGroups).forEach(([groupName, groupKeys]) => {
-            if (groupKeys.length === 0) return;
-            
-            content += `; ${groupName}\n`;
-            content += `; ${'-'.repeat(groupName.length)}\n`;
-            
-            groupKeys.forEach(key => {
-                const commands = keys[key];
-                if (commands && commands.length > 0) {
-                    let commandString;
-                    
-                    // Global stabilization (legacy – kept for backward-compatibility/tests)
-                    const globalStabilize = options.stabilizeExecutionOrder;
-
-                    // Environment-scoped per-key stabilization
-                    let perKeyStabilize = false;
-
-                    if (options.profile && options.profile.keybindMetadata) {
-                        if (options.environment && options.profile.keybindMetadata[options.environment]) {
-                            // New structure: keybindMetadata -> environment -> key
-                            const envMeta = options.profile.keybindMetadata[options.environment];
-                            perKeyStabilize = !!(envMeta && envMeta[key] && envMeta[key].stabilizeExecutionOrder);
-                        } else {
-                            // Legacy flat structure (no environment nesting)
-                            perKeyStabilize = !!(options.profile.keybindMetadata[key] && 
-                                                 options.profile.keybindMetadata[key].stabilizeExecutionOrder);
-                        }
-                    }
-
-                    const shouldStabilize = globalStabilize || perKeyStabilize;
-                    
-                    if (shouldStabilize && commands.length > 1) {
-                        // Use mirroring for stabilized execution order
-                        commandString = stoKeybinds ? stoKeybinds.generateMirroredCommandString(commands) 
-                                                    : commands.map(cmd => cmd.command).join(' $$ ');
-                    } else {
-                        commandString = commands.map(cmd => cmd.command).join(' $$ ');
-                    }
-                    content += `${key} "${commandString}"\n`;
-                }
-            });
-            
-            content += '\n';
-        });
-
-        return content;
+    // Sort keys using the keybind manager's sorting logic if available, otherwise use local sorting
+    let sortedKeys
+    if (typeof stoKeybinds !== 'undefined' && stoKeybinds.compareKeys) {
+      sortedKeys = Object.keys(keys).sort(
+        stoKeybinds.compareKeys.bind(stoKeybinds)
+      )
+    } else {
+      // Local key sorting implementation
+      sortedKeys = Object.keys(keys).sort(this.compareKeys.bind(this))
     }
 
-    // Local key comparison for sorting (fallback when stoKeybinds is not available)
-    compareKeys(a, b) {
-        // Function keys first
-        const aIsF = a.match(/^F(\d+)$/);
-        const bIsF = b.match(/^F(\d+)$/);
-        
-        if (aIsF && bIsF) {
-            return parseInt(aIsF[1]) - parseInt(bIsF[1]);
-        }
-        if (aIsF && !bIsF) return -1;
-        if (!aIsF && bIsF) return 1;
-        
-        // Numbers next
-        const aIsNum = /^\d+$/.test(a);
-        const bIsNum = /^\d+$/.test(b);
-        
-        if (aIsNum && bIsNum) {
-            return parseInt(a) - parseInt(b);
-        }
-        if (aIsNum && !bIsNum) return -1;
-        if (!aIsNum && bIsNum) return 1;
-        
-        // Letters
-        const aIsLetter = /^[A-Z]$/.test(a);
-        const bIsLetter = /^[A-Z]$/.test(b);
-        
-        if (aIsLetter && bIsLetter) {
-            return a.localeCompare(b);
-        }
-        if (aIsLetter && !bIsLetter) return -1;
-        if (!aIsLetter && bIsLetter) return 1;
-        
-        // Special keys
-        const specialOrder = ['Space', 'Tab', 'Enter', 'Escape'];
-        const aSpecial = specialOrder.indexOf(a);
-        const bSpecial = specialOrder.indexOf(b);
-        
-        if (aSpecial !== -1 && bSpecial !== -1) {
-            return aSpecial - bSpecial;
-        }
-        if (aSpecial !== -1 && bSpecial === -1) return -1;
-        if (aSpecial === -1 && bSpecial !== -1) return 1;
-        
-        // Default alphabetical
-        return a.localeCompare(b);
-    }
+    // Group keys by type for better organization
+    const keyGroups = this.groupKeysByType(sortedKeys, keys)
 
-    groupKeysByType(sortedKeys, keys) {
-        const groups = {
-            'Function Keys': [],
-            'Number Keys': [],
-            'Letter Keys': [],
-            'Special Keys': [],
-            'Modifier Combinations': []
-        };
+    Object.entries(keyGroups).forEach(([groupName, groupKeys]) => {
+      if (groupKeys.length === 0) return
 
-        sortedKeys.forEach(key => {
-            if (/^F\d+$/.test(key)) {
-                groups['Function Keys'].push(key);
-            } else if (/^\d+$/.test(key)) {
-                groups['Number Keys'].push(key);
-            } else if (/^[A-Z]$/.test(key)) {
-                groups['Letter Keys'].push(key);
-            } else if (key.includes('+')) {
-                groups['Modifier Combinations'].push(key);
+      content += `; ${groupName}\n`
+      content += `; ${'-'.repeat(groupName.length)}\n`
+
+      groupKeys.forEach((key) => {
+        const commands = keys[key]
+        if (commands && commands.length > 0) {
+          let commandString
+
+          // Global stabilization (legacy – kept for backward-compatibility/tests)
+          const globalStabilize = options.stabilizeExecutionOrder
+
+          // Environment-scoped per-key stabilization
+          let perKeyStabilize = false
+
+          if (options.profile && options.profile.keybindMetadata) {
+            if (
+              options.environment &&
+              options.profile.keybindMetadata[options.environment]
+            ) {
+              // New structure: keybindMetadata -> environment -> key
+              const envMeta =
+                options.profile.keybindMetadata[options.environment]
+              perKeyStabilize = !!(
+                envMeta &&
+                envMeta[key] &&
+                envMeta[key].stabilizeExecutionOrder
+              )
             } else {
-                groups['Special Keys'].push(key);
+              // Legacy flat structure (no environment nesting)
+              perKeyStabilize = !!(
+                options.profile.keybindMetadata[key] &&
+                options.profile.keybindMetadata[key].stabilizeExecutionOrder
+              )
             }
-        });
+          }
 
-        return groups;
+          const shouldStabilize = globalStabilize || perKeyStabilize
+
+          if (shouldStabilize && commands.length > 1) {
+            // Use mirroring for stabilized execution order
+            commandString = stoKeybinds
+              ? stoKeybinds.generateMirroredCommandString(commands)
+              : commands.map((cmd) => cmd.command).join(' $$ ')
+          } else {
+            commandString = commands.map((cmd) => cmd.command).join(' $$ ')
+          }
+          content += `${key} "${commandString}"\n`
+        }
+      })
+
+      content += '\n'
+    })
+
+    return content
+  }
+
+  // Local key comparison for sorting (fallback when stoKeybinds is not available)
+  compareKeys(a, b) {
+    // Function keys first
+    const aIsF = a.match(/^F(\d+)$/)
+    const bIsF = b.match(/^F(\d+)$/)
+
+    if (aIsF && bIsF) {
+      return parseInt(aIsF[1]) - parseInt(bIsF[1])
+    }
+    if (aIsF && !bIsF) return -1
+    if (!aIsF && bIsF) return 1
+
+    // Numbers next
+    const aIsNum = /^\d+$/.test(a)
+    const bIsNum = /^\d+$/.test(b)
+
+    if (aIsNum && bIsNum) {
+      return parseInt(a) - parseInt(b)
+    }
+    if (aIsNum && !bIsNum) return -1
+    if (!aIsNum && bIsNum) return 1
+
+    // Letters
+    const aIsLetter = /^[A-Z]$/.test(a)
+    const bIsLetter = /^[A-Z]$/.test(b)
+
+    if (aIsLetter && bIsLetter) {
+      return a.localeCompare(b)
+    }
+    if (aIsLetter && !bIsLetter) return -1
+    if (!aIsLetter && bIsLetter) return 1
+
+    // Special keys
+    const specialOrder = ['Space', 'Tab', 'Enter', 'Escape']
+    const aSpecial = specialOrder.indexOf(a)
+    const bSpecial = specialOrder.indexOf(b)
+
+    if (aSpecial !== -1 && bSpecial !== -1) {
+      return aSpecial - bSpecial
+    }
+    if (aSpecial !== -1 && bSpecial === -1) return -1
+    if (aSpecial === -1 && bSpecial !== -1) return 1
+
+    // Default alphabetical
+    return a.localeCompare(b)
+  }
+
+  groupKeysByType(sortedKeys, keys) {
+    const groups = {
+      'Function Keys': [],
+      'Number Keys': [],
+      'Letter Keys': [],
+      'Special Keys': [],
+      'Modifier Combinations': [],
     }
 
-    generateFileFooter() {
-        return `; ================================================================
+    sortedKeys.forEach((key) => {
+      if (/^F\d+$/.test(key)) {
+        groups['Function Keys'].push(key)
+      } else if (/^\d+$/.test(key)) {
+        groups['Number Keys'].push(key)
+      } else if (/^[A-Z]$/.test(key)) {
+        groups['Letter Keys'].push(key)
+      } else if (key.includes('+')) {
+        groups['Modifier Combinations'].push(key)
+      } else {
+        groups['Special Keys'].push(key)
+      }
+    })
+
+    return groups
+  }
+
+  generateFileFooter() {
+    return `; ================================================================
 ; End of keybind file
 ; ================================================================
 ; 
@@ -328,109 +347,121 @@ export default class STOExportManager {
 ; 
 ; For more commands and help, visit the STO Wiki or community forums.
 ; ================================================================
-`;
+`
+  }
+
+  // JSON Profile Export
+  exportJSONProfile(profile) {
+    try {
+      const exportData = {
+        version: STO_DATA.settings.version,
+        exported: new Date().toISOString(),
+        type: 'profile',
+        profile: this.sanitizeProfileForExport(profile),
+      }
+
+      const content = JSON.stringify(exportData, null, 2)
+      this.downloadFile(
+        content,
+        this.generateFileName(profile, 'json'),
+        'application/json'
+      )
+
+      stoUI.showToast('Profile exported as JSON', 'success')
+    } catch (error) {
+      stoUI.showToast('Failed to export profile: ' + error.message, 'error')
+    }
+  }
+
+  // Complete Project Export
+  exportCompleteProject() {
+    try {
+      const data = stoStorage.getAllData()
+      const exportData = {
+        version: STO_DATA.settings.version,
+        exported: new Date().toISOString(),
+        type: 'project',
+        data: data,
+      }
+
+      const content = JSON.stringify(exportData, null, 2)
+      const filename = `STO_Tools_Keybinds_Project_${new Date().toISOString().split('T')[0]}.json`
+      this.downloadFile(content, filename, 'application/json')
+
+      stoUI.showToast('Complete project exported', 'success')
+    } catch (error) {
+      stoUI.showToast('Failed to export project: ' + error.message, 'error')
+    }
+  }
+
+  // CSV Data Export
+  exportCSVData(profile) {
+    try {
+      const csvContent = this.generateCSVData(profile)
+      this.downloadFile(
+        csvContent,
+        this.generateFileName(profile, 'csv'),
+        'text/csv'
+      )
+
+      stoUI.showToast('Data exported as CSV', 'success')
+    } catch (error) {
+      stoUI.showToast('Failed to export CSV: ' + error.message, 'error')
+    }
+  }
+
+  generateCSVData(profile) {
+    let csv = 'Key,Command,Type,Description,Position\n'
+
+    Object.entries(profile.keys).forEach(([key, commands]) => {
+      commands.forEach((command, index) => {
+        const row = [
+          this.escapeCSV(key),
+          this.escapeCSV(command.command),
+          this.escapeCSV(command.type),
+          this.escapeCSV(command.text || ''),
+          index + 1,
+        ].join(',')
+        csv += row + '\n'
+      })
+    })
+
+    return csv
+  }
+
+  escapeCSV(value) {
+    if (typeof value !== 'string') {
+      value = String(value)
     }
 
-    // JSON Profile Export
-    exportJSONProfile(profile) {
-        try {
-            const exportData = {
-                version: STO_DATA.settings.version,
-                exported: new Date().toISOString(),
-                type: 'profile',
-                profile: this.sanitizeProfileForExport(profile)
-            };
-
-            const content = JSON.stringify(exportData, null, 2);
-            this.downloadFile(content, this.generateFileName(profile, 'json'), 'application/json');
-            
-            stoUI.showToast('Profile exported as JSON', 'success');
-        } catch (error) {
-            stoUI.showToast('Failed to export profile: ' + error.message, 'error');
-        }
+    if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+      return '"' + value.replace(/"/g, '""') + '"'
     }
 
-    // Complete Project Export
-    exportCompleteProject() {
-        try {
-            const data = stoStorage.getAllData();
-            const exportData = {
-                version: STO_DATA.settings.version,
-                exported: new Date().toISOString(),
-                type: 'project',
-                data: data
-            };
+    return value
+  }
 
-            const content = JSON.stringify(exportData, null, 2);
-            const filename = `STO_Tools_Keybinds_Project_${new Date().toISOString().split('T')[0]}.json`;
-            this.downloadFile(content, filename, 'application/json');
-            
-            stoUI.showToast('Complete project exported', 'success');
-        } catch (error) {
-            stoUI.showToast('Failed to export project: ' + error.message, 'error');
-        }
+  // HTML Report Export
+  exportHTMLReport(profile) {
+    try {
+      const htmlContent = this.generateHTMLReport(profile)
+      this.downloadFile(
+        htmlContent,
+        this.generateFileName(profile, 'html'),
+        'text/html'
+      )
+
+      stoUI.showToast('HTML report exported', 'success')
+    } catch (error) {
+      stoUI.showToast('Failed to export HTML report: ' + error.message, 'error')
     }
+  }
 
-    // CSV Data Export
-    exportCSVData(profile) {
-        try {
-            const csvContent = this.generateCSVData(profile);
-            this.downloadFile(csvContent, this.generateFileName(profile, 'csv'), 'text/csv');
-            
-            stoUI.showToast('Data exported as CSV', 'success');
-        } catch (error) {
-            stoUI.showToast('Failed to export CSV: ' + error.message, 'error');
-        }
-    }
+  generateHTMLReport(profile) {
+    const stats = stoKeybinds.getProfileStats(profile)
+    const timestamp = new Date().toLocaleString()
 
-    generateCSVData(profile) {
-        let csv = 'Key,Command,Type,Description,Position\n';
-        
-        Object.entries(profile.keys).forEach(([key, commands]) => {
-            commands.forEach((command, index) => {
-                const row = [
-                    this.escapeCSV(key),
-                    this.escapeCSV(command.command),
-                    this.escapeCSV(command.type),
-                    this.escapeCSV(command.text || ''),
-                    index + 1
-                ].join(',');
-                csv += row + '\n';
-            });
-        });
-
-        return csv;
-    }
-
-    escapeCSV(value) {
-        if (typeof value !== 'string') {
-            value = String(value);
-        }
-        
-        if (value.includes(',') || value.includes('"') || value.includes('\n')) {
-            return '"' + value.replace(/"/g, '""') + '"';
-        }
-        
-        return value;
-    }
-
-    // HTML Report Export
-    exportHTMLReport(profile) {
-        try {
-            const htmlContent = this.generateHTMLReport(profile);
-            this.downloadFile(htmlContent, this.generateFileName(profile, 'html'), 'text/html');
-            
-            stoUI.showToast('HTML report exported', 'success');
-        } catch (error) {
-            stoUI.showToast('Failed to export HTML report: ' + error.message, 'error');
-        }
-    }
-
-    generateHTMLReport(profile) {
-        const stats = stoKeybinds.getProfileStats(profile);
-        const timestamp = new Date().toLocaleString();
-
-        return `<!DOCTYPE html>
+    return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -481,198 +512,212 @@ export default class STOExportManager {
         <p>This report was generated by STO Tools Keybind Manager. For more information about Star Trek Online keybinds, visit the STO Wiki.</p>
     </div>
 </body>
-</html>`;
+</html>`
+  }
+
+  generateHTMLKeybindSection(keys) {
+    if (!keys || Object.keys(keys).length === 0) {
+      return '<div class="keybind-group"><h2>Keybinds</h2><p>No keybinds defined.</p></div>'
     }
 
-    generateHTMLKeybindSection(keys) {
-        if (!keys || Object.keys(keys).length === 0) {
-            return '<div class="keybind-group"><h2>Keybinds</h2><p>No keybinds defined.</p></div>';
-        }
+    const sortedKeys = Object.keys(keys).sort(
+      stoKeybinds.compareKeys.bind(stoKeybinds)
+    )
+    const keyGroups = this.groupKeysByType(sortedKeys, keys)
 
-        const sortedKeys = Object.keys(keys).sort(stoKeybinds.compareKeys.bind(stoKeybinds));
-        const keyGroups = this.groupKeysByType(sortedKeys, keys);
+    let html = '<div class="keybind-group"><h2>Keybinds</h2>'
 
-        let html = '<div class="keybind-group"><h2>Keybinds</h2>';
+    Object.entries(keyGroups).forEach(([groupName, groupKeys]) => {
+      if (groupKeys.length === 0) return
 
-        Object.entries(keyGroups).forEach(([groupName, groupKeys]) => {
-            if (groupKeys.length === 0) return;
+      html += `<h3>${groupName}</h3>`
 
-            html += `<h3>${groupName}</h3>`;
-            
-            groupKeys.forEach(key => {
-                const commands = keys[key];
-                if (commands && commands.length > 0) {
-                    html += `<div class="keybind">
+      groupKeys.forEach((key) => {
+        const commands = keys[key]
+        if (commands && commands.length > 0) {
+          html += `<div class="keybind">
                         <div class="key">${key}</div>
                         <div class="commands">
-                            ${commands.map(cmd => 
-                                `<span class="command ${cmd.type}">${cmd.text || cmd.command}</span>`
-                            ).join('')}
+                            ${commands
+                              .map(
+                                (cmd) =>
+                                  `<span class="command ${cmd.type}">${cmd.text || cmd.command}</span>`
+                              )
+                              .join('')}
                         </div>
-                    </div>`;
-                }
-            });
-        });
+                    </div>`
+        }
+      })
+    })
 
-        html += '</div>';
-        return html;
+    html += '</div>'
+    return html
+  }
+
+  generateHTMLAliasSection(aliases) {
+    if (!aliases || Object.keys(aliases).length === 0) {
+      return ''
     }
 
-    generateHTMLAliasSection(aliases) {
-        if (!aliases || Object.keys(aliases).length === 0) {
-            return '';
-        }
+    let html = '<div class="aliases"><h2>Command Aliases</h2>'
 
-        let html = '<div class="aliases"><h2>Command Aliases</h2>';
-
-        Object.entries(aliases).sort(([a], [b]) => a.localeCompare(b)).forEach(([name, alias]) => {
-            html += `<div class="alias">
+    Object.entries(aliases)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .forEach(([name, alias]) => {
+        html += `<div class="alias">
                 <div class="alias-name">${name}</div>
                 ${alias.description ? `<div>${alias.description}</div>` : ''}
                 <div class="alias-commands">${alias.commands}</div>
-            </div>`;
-        });
+            </div>`
+      })
 
-        html += '</div>';
-        return html;
+    html += '</div>'
+    return html
+  }
+
+  // Copy Operations
+  copyCommandPreview() {
+    const preview = document.getElementById('commandPreview')
+    if (!preview || !preview.textContent.trim()) {
+      stoUI.showToast('No command to copy', 'warning')
+      return
     }
 
-    // Copy Operations
-    copyCommandPreview() {
-        const preview = document.getElementById('commandPreview');
-        if (!preview || !preview.textContent.trim()) {
-            stoUI.showToast('No command to copy', 'warning');
-            return;
-        }
+    stoUI.copyToClipboard(preview.textContent)
+  }
 
-        stoUI.copyToClipboard(preview.textContent);
+  // Utility Methods
+  generateFileName(profile, extension) {
+    const safeName = profile.name.replace(/[^a-zA-Z0-9\-_]/g, '_')
+    const timestamp = new Date().toISOString().split('T')[0]
+    const environment = profile.mode || 'space' // Use mode for environment
+    return `${safeName}_${environment}_${timestamp}.${extension}`
+  }
+
+  downloadFile(content, filename, mimeType) {
+    const blob = new Blob([content], { type: mimeType })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }
+
+  sanitizeProfileForExport(profile) {
+    // Create a clean copy of the profile for export
+    const sanitized = JSON.parse(JSON.stringify(profile))
+
+    // Remove any internal IDs or temporary data
+    if (sanitized.keys) {
+      Object.values(sanitized.keys).forEach((commands) => {
+        commands.forEach((command) => {
+          // Keep essential data, remove internal IDs
+          delete command.id
+        })
+      })
     }
 
-    // Utility Methods
-    generateFileName(profile, extension) {
-        const safeName = profile.name.replace(/[^a-zA-Z0-9\-_]/g, '_');
-        const timestamp = new Date().toISOString().split('T')[0];
-        const environment = profile.mode || 'space'; // Use mode for environment
-        return `${safeName}_${environment}_${timestamp}.${extension}`;
+    return sanitized
+  }
+
+  // Batch Export Operations
+  exportAllProfiles() {
+    const data = stoStorage.getAllData()
+    const profiles = data.profiles
+
+    if (!profiles || Object.keys(profiles).length === 0) {
+      stoUI.showToast('No profiles to export', 'warning')
+      return
     }
 
-    downloadFile(content, filename, mimeType) {
-        const blob = new Blob([content], { type: mimeType });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = filename;
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        URL.revokeObjectURL(url);
-    }
+    // Create a zip-like structure (for now, export as separate files)
+    Object.entries(profiles).forEach(([id, profile]) => {
+      setTimeout(() => {
+        this.exportSTOKeybindFile(profile)
+      }, 100) // Small delay to prevent browser blocking
+    })
 
-    sanitizeProfileForExport(profile) {
-        // Create a clean copy of the profile for export
-        const sanitized = JSON.parse(JSON.stringify(profile));
-        
-        // Remove any internal IDs or temporary data
-        if (sanitized.keys) {
-            Object.values(sanitized.keys).forEach(commands => {
-                commands.forEach(command => {
-                    // Keep essential data, remove internal IDs
-                    delete command.id;
-                });
-            });
-        }
+    stoUI.showToast(
+      `Exporting ${Object.keys(profiles).length} profiles...`,
+      'info'
+    )
+  }
 
-        return sanitized;
-    }
+  // Import Operations (for completeness)
+  async importFromFile(file) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
 
-    // Batch Export Operations
-    exportAllProfiles() {
-        const data = stoStorage.getAllData();
-        const profiles = data.profiles;
-        
-        if (!profiles || Object.keys(profiles).length === 0) {
-            stoUI.showToast('No profiles to export', 'warning');
-            return;
-        }
-
-        // Create a zip-like structure (for now, export as separate files)
-        Object.entries(profiles).forEach(([id, profile]) => {
-            setTimeout(() => {
-                this.exportSTOKeybindFile(profile);
-            }, 100); // Small delay to prevent browser blocking
-        });
-
-        stoUI.showToast(`Exporting ${Object.keys(profiles).length} profiles...`, 'info');
-    }
-
-    // Import Operations (for completeness)
-    async importFromFile(file) {
-        return new Promise((resolve, reject) => {
-            const reader = new FileReader();
-            
-            reader.onload = (e) => {
-                try {
-                    const content = e.target.result;
-                    const extension = file.name.split('.').pop().toLowerCase();
-                    
-                    switch (extension) {
-                        case 'txt':
-                            resolve(stoKeybinds.importKeybindFile(content));
-                            break;
-                        case 'json':
-                            resolve(this.importJSONFile(content));
-                            break;
-                        default:
-                            reject(new Error('Unsupported file format'));
-                    }
-                } catch (error) {
-                    reject(error);
-                }
-            };
-            
-            reader.onerror = () => reject(new Error('Failed to read file'));
-            reader.readAsText(file);
-        });
-    }
-
-    importJSONFile(content) {
+      reader.onload = (e) => {
         try {
-            const data = JSON.parse(content);
-            
-            if (data.type === 'profile' && data.profile) {
-                return stoProfiles.importProfile(content);
-            } else if (data.type === 'project' && data.data) {
-                return stoStorage.importData(JSON.stringify(data.data));
-            } else {
-                throw new Error('Unknown JSON file format');
-            }
+          const content = e.target.result
+          const extension = file.name.split('.').pop().toLowerCase()
+
+          switch (extension) {
+            case 'txt':
+              resolve(stoKeybinds.importKeybindFile(content))
+              break
+            case 'json':
+              resolve(this.importJSONFile(content))
+              break
+            default:
+              reject(new Error('Unsupported file format'))
+          }
         } catch (error) {
-            throw new Error('Invalid JSON file: ' + error.message);
+          reject(error)
         }
+      }
+
+      reader.onerror = () => reject(new Error('Failed to read file'))
+      reader.readAsText(file)
+    })
+  }
+
+  importJSONFile(content) {
+    try {
+      const data = JSON.parse(content)
+
+      if (data.type === 'profile' && data.profile) {
+        return stoProfiles.importProfile(content)
+      } else if (data.type === 'project' && data.data) {
+        return stoStorage.importData(JSON.stringify(data.data))
+      } else {
+        throw new Error('Unknown JSON file format')
+      }
+    } catch (error) {
+      throw new Error('Invalid JSON file: ' + error.message)
+    }
+  }
+
+  // Separate Alias Export
+  exportAliases(profile) {
+    try {
+      const content = this.generateAliasFile(profile)
+      this.downloadFile(
+        content,
+        this.generateAliasFileName(profile, 'txt'),
+        'text/plain'
+      )
+
+      stoUI.showToast('Aliases exported successfully', 'success')
+    } catch (error) {
+      stoUI.showToast('Failed to export aliases: ' + error.message, 'error')
+    }
+  }
+
+  generateAliasFile(profile) {
+    let content = ''
+
+    // Header with metadata
+    const timestamp = new Date().toLocaleString()
+    const stats = {
+      totalAliases: Object.keys(profile.aliases || {}).length,
     }
 
-    // Separate Alias Export
-    exportAliases(profile) {
-        try {
-            const content = this.generateAliasFile(profile);
-            this.downloadFile(content, this.generateAliasFileName(profile, 'txt'), 'text/plain');
-            
-            stoUI.showToast('Aliases exported successfully', 'success');
-        } catch (error) {
-            stoUI.showToast('Failed to export aliases: ' + error.message, 'error');
-        }
-    }
-
-    generateAliasFile(profile) {
-        let content = '';
-        
-        // Header with metadata
-        const timestamp = new Date().toLocaleString();
-        const stats = {
-            totalAliases: Object.keys(profile.aliases || {}).length
-        };
-        
-        content += `; ================================================================
+    content += `; ================================================================
 ; ${profile.name} - STO Alias Configuration
 ; ================================================================
 ; Mode: ${profile.mode.toUpperCase()}
@@ -697,24 +742,24 @@ export default class STOExportManager {
 ; - Arc: C:\\Program Files (x86)\\Perfect World Entertainment\\Arc Games\\Star Trek Online
 ; ================================================================
 
-`;
+`
 
-        // Export aliases
-        if (profile.aliases && Object.keys(profile.aliases).length > 0) {
-            content += this.generateAliasSection(profile.aliases);
-        } else {
-            content += '; No aliases defined\n\n';
-        }
-        
-        return content;
+    // Export aliases
+    if (profile.aliases && Object.keys(profile.aliases).length > 0) {
+      content += this.generateAliasSection(profile.aliases)
+    } else {
+      content += '; No aliases defined\n\n'
     }
 
-    generateAliasFileName(profile, extension) {
-        const safeName = profile.name.replace(/[^a-zA-Z0-9\-_]/g, '_');
-        const timestamp = new Date().toISOString().split('T')[0];
-        const environment = profile.mode || 'space';
-        return `${safeName}_aliases_${environment}_${timestamp}.${extension}`;
-    }
+    return content
+  }
+
+  generateAliasFileName(profile, extension) {
+    const safeName = profile.name.replace(/[^a-zA-Z0-9\-_]/g, '_')
+    const timestamp = new Date().toISOString().split('T')[0]
+    const environment = profile.mode || 'space'
+    return `${safeName}_aliases_${environment}_${timestamp}.${extension}`
+  }
 }
 
 // Global export manager instance

--- a/src/js/keybinds.js
+++ b/src/js/keybinds.js
@@ -3,643 +3,763 @@
 import store from './store.js'
 
 export default class STOKeybindFileManager {
-    constructor() {
-        this.keybindPatterns = {
-            // Standard keybind format: Key "command1 $$ command2" or Key "command" "optional"
-            standard: /^([a-zA-Z0-9_+\-\s\[\]]+)\s+"([^"]*)"(?:\s+"([^"]*)")?$/,
-            // Bind command format: /bind Key command or /bind Key "command"
-            bind: /^\/bind\s+([a-zA-Z0-9_+\-\s\[\]]+)\s+(.+)$/,
-            // Alias format: alias AliasName "command sequence" or alias AliasName <& command sequence &>
-            alias: /^alias\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+(?:"([^"]+)"|<&\s+(.+?)\s+&>)$/,
-            // Comment lines (both # and ; style comments)
-            comment: /^[#;].*$/
-        };
-        
-        this.validKeys = this.generateValidKeys();
-        // Don't initialize immediately - wait for app to be ready
+  constructor() {
+    this.keybindPatterns = {
+      // Standard keybind format: Key "command1 $$ command2" or Key "command" "optional"
+      standard: /^([a-zA-Z0-9_+\-\s\[\]]+)\s+"([^"]*)"(?:\s+"([^"]*)")?$/,
+      // Bind command format: /bind Key command or /bind Key "command"
+      bind: /^\/bind\s+([a-zA-Z0-9_+\-\s\[\]]+)\s+(.+)$/,
+      // Alias format: alias AliasName "command sequence" or alias AliasName <& command sequence &>
+      alias:
+        /^alias\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+(?:"([^"]+)"|<&\s+(.+?)\s+&>)$/,
+      // Comment lines (both # and ; style comments)
+      comment: /^[#;].*$/,
     }
 
-    init() {
-        this.setupEventListeners();
+    this.validKeys = this.generateValidKeys()
+    // Don't initialize immediately - wait for app to be ready
+  }
+
+  init() {
+    this.setupEventListeners()
+  }
+
+  // Generate list of valid STO keys
+  generateValidKeys() {
+    const keys = new Set()
+
+    // Function keys
+    for (let i = 1; i <= 12; i++) {
+      keys.add(`F${i}`)
     }
 
-    // Generate list of valid STO keys
-    generateValidKeys() {
-        const keys = new Set();
-        
-        // Function keys
-        for (let i = 1; i <= 12; i++) {
-            keys.add(`F${i}`);
-        }
-        
-        // Number keys
-        for (let i = 0; i <= 9; i++) {
-            keys.add(i.toString());
-        }
-        
-        // Letter keys
-        for (let i = 65; i <= 90; i++) {
-            keys.add(String.fromCharCode(i));
-        }
-        
-        // Special keys
-        const specialKeys = [
-            'Space', 'Tab', 'Enter', 'Escape', 'Backspace', 'Delete',
-            'Insert', 'Home', 'End', 'PageUp', 'PageDown',
-            'Up', 'Down', 'Left', 'Right',
-            'NumPad0', 'NumPad1', 'NumPad2', 'NumPad3', 'NumPad4',
-            'NumPad5', 'NumPad6', 'NumPad7', 'NumPad8', 'NumPad9',
-            'NumPadEnter', 'NumPadPlus', 'NumPadMinus', 'NumPadMultiply', 'NumPadDivide',
-            // Lowercase numpad variants (for compatibility)
-            'numpad0', 'numpad1', 'numpad2', 'numpad3', 'numpad4',
-            'numpad5', 'numpad6', 'numpad7', 'numpad8', 'numpad9',
-            'divide', 'multiply', // STO-style names for numpad math keys
-            // Mouse buttons
-            'Button4', 'Button5', 'Button6', 'Button7', 'Button8',
-            'Lbutton', 'Rbutton', 'Mbutton', 'Leftdrag', 'Rightdrag', 'Middleclick',
-            'Mousechord', 'Wheelplus', 'Wheelminus',
-            'Semicolon', 'Equals', 'Comma', 'Minus', 'Period', 'Slash',
-            'Grave', 'LeftBracket', 'Backslash', 'RightBracket', 'Quote',
-            // Bracket characters (for STO keybinds like Control+[)
-            '[', ']'
-        ];
-        
-        specialKeys.forEach(key => keys.add(key));
-        
-        // Modifier combinations
-        const modifiers = ['Ctrl', 'Alt', 'Shift', 'Control']; // Include both Ctrl and Control
-        const baseKeys = Array.from(keys); // Capture base keys before adding modifiers
-        
-        modifiers.forEach(modifier => {
-            baseKeys.forEach(key => {
-                keys.add(`${modifier}+${key}`);
-            });
-        });
-        
-
-        
-        // Double modifier combinations
-        keys.add('Ctrl+Alt');
-        keys.add('Ctrl+Shift');
-        keys.add('Alt+Shift');
-        keys.add('Control+Alt');
-        keys.add('Control+Shift');
-        
-        baseKeys.forEach(key => {
-            keys.add(`Ctrl+Alt+${key}`);
-            keys.add(`Ctrl+Shift+${key}`);
-            keys.add(`Alt+Shift+${key}`);
-            keys.add(`Control+Alt+${key}`);
-            keys.add(`Control+Shift+${key}`);
-        });
-        
-        return Array.from(keys).sort();
+    // Number keys
+    for (let i = 0; i <= 9; i++) {
+      keys.add(i.toString())
     }
 
-    // Parse keybind file content
-    parseKeybindFile(content) {
-        const lines = content.split('\n');
-        const result = {
-            keybinds: {},
-            aliases: {},
-            comments: [],
-            errors: []
-        };
-        
-        lines.forEach((line, index) => {
-            const trimmed = line.trim();
-            if (!trimmed) return;
-            
-            try {
-                if (this.keybindPatterns.comment.test(trimmed)) {
-                    result.comments.push({
-                        line: index + 1,
-                        content: trimmed
-                    });
-                } else if (this.keybindPatterns.alias.test(trimmed)) {
-                    const match = trimmed.match(this.keybindPatterns.alias);
-                    if (match) {
-                        const [, aliasName, quotedCommands, bracketCommands] = match;
-                        // Use whichever format was matched (quoted or bracket syntax)
-                        const commands = quotedCommands || bracketCommands;
-                        result.aliases[aliasName] = {
-                            name: aliasName,
-                            commands: commands,
-                            line: index + 1
-                        };
-                    }
-                } else if (this.keybindPatterns.standard.test(trimmed)) {
-                    const match = trimmed.match(this.keybindPatterns.standard);
-                    if (match) {
-                        const [, key, commandString, optionalParam] = match;
-                        const commands = this.parseCommandString(commandString);
-                        
-                        result.keybinds[key] = {
-                            key: key,
-                            commands: commands,
-                            line: index + 1,
-                            raw: commandString,
-                            // Store optional parameter if present (for completeness, though we ignore it)
-                            optionalParam: optionalParam || null
-                        };
-                    }
-                } else if (this.keybindPatterns.bind.test(trimmed)) {
-                    const match = trimmed.match(this.keybindPatterns.bind);
-                    if (match) {
-                        const [, key, commandString] = match;
-                        // Remove quotes if present
-                        const cleanCommandString = commandString.replace(/^"(.*)"$/, '$1');
-                        const commands = this.parseCommandString(cleanCommandString);
-                        
-                        result.keybinds[key] = {
-                            key: key,
-                            commands: commands,
-                            line: index + 1,
-                            raw: cleanCommandString
-                        };
-                    }
-                } else {
-                    result.errors.push({
-                        line: index + 1,
-                        content: trimmed,
-                        error: 'Invalid keybind format'
-                    });
-                }
-            } catch (error) {
-                result.errors.push({
-                    line: index + 1,
-                    content: trimmed,
-                    error: error.message
-                });
-            }
-        });
-        
-        return result;
+    // Letter keys
+    for (let i = 65; i <= 90; i++) {
+      keys.add(String.fromCharCode(i))
     }
 
-    // Generate mirrored command string for stable execution order
-    generateMirroredCommandString(commands) {
-        if (!commands || commands.length <= 1) {
-            return commands.map(cmd => cmd.command || cmd).join(' $$ ');
-        }
-        
-        // Extract command strings
-        const commandStrings = commands.map(cmd => cmd.command || cmd);
-        
-        // Create mirrored pattern: original + reverse(without last element)
-        // This ensures Phase 1 (left-to-right) and Phase 2 (right-to-left) execute in same order
-        // Pattern: [A, B, C] -> [A, B, C, B, A] (palindrome-like structure)
-        const reversed = [...commandStrings].reverse();
-        const reversedWithoutLast = reversed.slice(1); // Remove first element of reverse (which is last of original)
-        const mirrored = [...commandStrings, ...reversedWithoutLast];
-        
-        return mirrored.join(' $$ ');
+    // Special keys
+    const specialKeys = [
+      'Space',
+      'Tab',
+      'Enter',
+      'Escape',
+      'Backspace',
+      'Delete',
+      'Insert',
+      'Home',
+      'End',
+      'PageUp',
+      'PageDown',
+      'Up',
+      'Down',
+      'Left',
+      'Right',
+      'NumPad0',
+      'NumPad1',
+      'NumPad2',
+      'NumPad3',
+      'NumPad4',
+      'NumPad5',
+      'NumPad6',
+      'NumPad7',
+      'NumPad8',
+      'NumPad9',
+      'NumPadEnter',
+      'NumPadPlus',
+      'NumPadMinus',
+      'NumPadMultiply',
+      'NumPadDivide',
+      // Lowercase numpad variants (for compatibility)
+      'numpad0',
+      'numpad1',
+      'numpad2',
+      'numpad3',
+      'numpad4',
+      'numpad5',
+      'numpad6',
+      'numpad7',
+      'numpad8',
+      'numpad9',
+      'divide',
+      'multiply', // STO-style names for numpad math keys
+      // Mouse buttons
+      'Button4',
+      'Button5',
+      'Button6',
+      'Button7',
+      'Button8',
+      'Lbutton',
+      'Rbutton',
+      'Mbutton',
+      'Leftdrag',
+      'Rightdrag',
+      'Middleclick',
+      'Mousechord',
+      'Wheelplus',
+      'Wheelminus',
+      'Semicolon',
+      'Equals',
+      'Comma',
+      'Minus',
+      'Period',
+      'Slash',
+      'Grave',
+      'LeftBracket',
+      'Backslash',
+      'RightBracket',
+      'Quote',
+      // Bracket characters (for STO keybinds like Control+[)
+      '[',
+      ']',
+    ]
+
+    specialKeys.forEach((key) => keys.add(key))
+
+    // Modifier combinations
+    const modifiers = ['Ctrl', 'Alt', 'Shift', 'Control'] // Include both Ctrl and Control
+    const baseKeys = Array.from(keys) // Capture base keys before adding modifiers
+
+    modifiers.forEach((modifier) => {
+      baseKeys.forEach((key) => {
+        keys.add(`${modifier}+${key}`)
+      })
+    })
+
+    // Double modifier combinations
+    keys.add('Ctrl+Alt')
+    keys.add('Ctrl+Shift')
+    keys.add('Alt+Shift')
+    keys.add('Control+Alt')
+    keys.add('Control+Shift')
+
+    baseKeys.forEach((key) => {
+      keys.add(`Ctrl+Alt+${key}`)
+      keys.add(`Ctrl+Shift+${key}`)
+      keys.add(`Alt+Shift+${key}`)
+      keys.add(`Control+Alt+${key}`)
+      keys.add(`Control+Shift+${key}`)
+    })
+
+    return Array.from(keys).sort()
+  }
+
+  // Parse keybind file content
+  parseKeybindFile(content) {
+    const lines = content.split('\n')
+    const result = {
+      keybinds: {},
+      aliases: {},
+      comments: [],
+      errors: [],
     }
 
-    // Detect if a command string uses mirroring pattern and extract original commands
-    detectAndUnmirrorCommands(commandString) {
-        if (!commandString || typeof commandString !== 'string') {
-            return { isMirrored: false, originalCommands: [] };
-        }
+    lines.forEach((line, index) => {
+      const trimmed = line.trim()
+      if (!trimmed) return
 
-        const commands = commandString.split(' $$ ').map(cmd => cmd.trim()).filter(cmd => cmd);
-        
-        // Single command or empty - not mirrored
-        if (commands.length <= 1) {
-            return { isMirrored: false, originalCommands: commands };
-        }
-
-        // Check if this follows the mirroring pattern: [A, B, C, B, A]
-        // For mirrored commands, length should be odd and >= 3
-        if (commands.length < 3 || commands.length % 2 === 0) {
-            return { isMirrored: false, originalCommands: commands };
-        }
-
-        const midIndex = Math.floor(commands.length / 2);
-        const firstHalf = commands.slice(0, midIndex + 1); // Include middle element
-        const secondHalf = commands.slice(midIndex + 1); // After middle element
-        
-        // Check if second half is reverse of first half (without the middle element)
-        const expectedReverse = firstHalf.slice(0, -1).reverse(); // Remove middle, then reverse
-        
-        if (secondHalf.length === expectedReverse.length && 
-            secondHalf.every((cmd, index) => cmd === expectedReverse[index])) {
-            return { 
-                isMirrored: true, 
-                originalCommands: firstHalf 
-            };
-        }
-
-        return { isMirrored: false, originalCommands: commands };
-    }
-
-    // Parse command string into individual commands
-    parseCommandString(commandString) {
-        const commands = commandString.split('$$').map(cmd => cmd.trim());
-        
-        return commands.map((command, index) => {
-            const commandObj = {
-                command: command,
-                type: window.stoCommands ? window.stoCommands.detectCommandType(command) : 'custom',
-                icon: window.stoCommands ? window.stoCommands.getCommandIcon(command) : '⚙️',
-                text: window.stoCommands ? window.stoCommands.getCommandText(command) : command,
-                id: `imported_${Date.now()}_${index}`
-            };
-            
-            // Try to extract parameters for known command types
-            if (command.includes('+STOTrayExecByTray')) {
-                const match = command.match(/\+STOTrayExecByTray\s+(\d+)\s+(\d+)/);
-                if (match) {
-                    commandObj.parameters = {
-                        tray: parseInt(match[1]),
-                        slot: parseInt(match[2])
-                    };
-                    commandObj.text = `Execute Tray ${parseInt(match[1]) + 1} Slot ${parseInt(match[2]) + 1}`;
-                }
-            } else if (command.includes('"')) {
-                // Extract quoted parameters (for communication commands)
-                const match = command.match(/^(\w+)\s+"([^"]+)"$/);
-                if (match) {
-                    commandObj.parameters = {
-                        message: match[2]
-                    };
-                    commandObj.text = `${commandObj.text}: ${match[2]}`;
-                }
+      try {
+        if (this.keybindPatterns.comment.test(trimmed)) {
+          result.comments.push({
+            line: index + 1,
+            content: trimmed,
+          })
+        } else if (this.keybindPatterns.alias.test(trimmed)) {
+          const match = trimmed.match(this.keybindPatterns.alias)
+          if (match) {
+            const [, aliasName, quotedCommands, bracketCommands] = match
+            // Use whichever format was matched (quoted or bracket syntax)
+            const commands = quotedCommands || bracketCommands
+            result.aliases[aliasName] = {
+              name: aliasName,
+              commands: commands,
+              line: index + 1,
             }
-            
-            return commandObj;
-        });
-    }
+          }
+        } else if (this.keybindPatterns.standard.test(trimmed)) {
+          const match = trimmed.match(this.keybindPatterns.standard)
+          if (match) {
+            const [, key, commandString, optionalParam] = match
+            const commands = this.parseCommandString(commandString)
 
-    // Import keybind file content
-    importKeybindFile(content) {
-        // Get the actual profile from storage to work with the real structure
-        const actualProfile = stoStorage.getProfile(store.currentProfile)
-        if (!actualProfile) {
-            stoUI.showToast('No profile selected for import', 'warning')
-            return { success: false, error: 'No active profile' }
-        }
-
-        try {
-            const parsed = this.parseKeybindFile(content)
-            
-            // Only import keybinds, ignore aliases (they have separate import)
-            const keyCount = Object.keys(parsed.keybinds).length
-            
-            if (keyCount === 0) {
-                stoUI.showToast('No keybinds found in file', 'warning')
-                return { success: false, error: 'No keybinds found' }
+            result.keybinds[key] = {
+              key: key,
+              commands: commands,
+              line: index + 1,
+              raw: commandString,
+              // Store optional parameter if present (for completeness, though we ignore it)
+              optionalParam: optionalParam || null,
             }
+          }
+        } else if (this.keybindPatterns.bind.test(trimmed)) {
+          const match = trimmed.match(this.keybindPatterns.bind)
+          if (match) {
+            const [, key, commandString] = match
+            // Remove quotes if present
+            const cleanCommandString = commandString.replace(/^"(.*)"$/, '$1')
+            const commands = this.parseCommandString(cleanCommandString)
 
-            // Ensure builds structure exists
-            if (!actualProfile.builds) {
-                actualProfile.builds = {
-                    space: { keys: {} },
-                    ground: { keys: {} }
-                }
+            result.keybinds[key] = {
+              key: key,
+              commands: commands,
+              line: index + 1,
+              raw: cleanCommandString,
             }
-
-            // Ensure current environment build exists
-            if (!actualProfile.builds[store.currentEnvironment]) {
-                actualProfile.builds[store.currentEnvironment] = { keys: {} }
-            }
-
-            // Get reference to the current build's keys
-            const buildKeys = actualProfile.builds[store.currentEnvironment].keys
-
-            // Merge keybinds into the actual build structure
-            Object.entries(parsed.keybinds).forEach(([key, keybindData]) => {
-                // Detect if commands are mirrored and extract original commands
-                const commandString = keybindData.commands.map(cmd => cmd.command).join(' $$ ');
-                const mirrorInfo = this.detectAndUnmirrorCommands(commandString);
-                
-                if (mirrorInfo.isMirrored) {
-                    // Store original commands with stabilization flag
-                    buildKeys[key] = this.parseCommandString(mirrorInfo.originalCommands.join(' $$ '));
-                    // Store metadata about stabilization at profile level (scoped by environment)
-                    const env = store.currentEnvironment;
-                    if (!actualProfile.keybindMetadata) {
-                        actualProfile.keybindMetadata = {};
-                    }
-                    if (!actualProfile.keybindMetadata[env]) {
-                        actualProfile.keybindMetadata[env] = {};
-                    }
-                    actualProfile.keybindMetadata[env][key] = {
-                        stabilizeExecutionOrder: true
-                    };
-                } else {
-                    // Store commands as-is
-                    buildKeys[key] = keybindData.commands;
-                }
-            })
-
-            // Save the modified profile directly
-            stoStorage.saveProfile(store.currentProfile, actualProfile)
-            app.setModified(true)
-
-            // Refresh key grid
-            app.renderKeyGrid()
-
-            const message = `Import completed: ${keyCount} keybinds`
-            if (Object.keys(parsed.aliases).length > 0) {
-                stoUI.showToast(message + ` (${Object.keys(parsed.aliases).length} aliases ignored - use Import Aliases)`, 'success')
-            } else {
-                stoUI.showToast(message, 'success')
-            }
-
-            return {
-                success: true,
-                imported: {
-                    keys: keyCount
-                },
-                errors: parsed.errors
-            }
-        } catch (error) {
-            stoUI.showToast('Import failed: ' + error.message, 'error')
-            return { success: false, error: error.message }
-        }
-    }
-
-    // Separate Alias Import
-    importAliasFile(content) {
-        const profile = app.getCurrentProfile()
-        if (!profile) {
-            stoUI.showToast('No profile selected for import', 'warning')
-            return { success: false, error: 'No active profile' }
-        }
-
-        try {
-            const parsed = this.parseKeybindFile(content)
-            
-            // Only import aliases, ignore keybinds
-            const aliasCount = Object.keys(parsed.aliases).length
-            
-            if (aliasCount === 0) {
-                stoUI.showToast('No aliases found in file', 'warning')
-                return { success: false, error: 'No aliases found' }
-            }
-
-            // Get the actual profile from storage (aliases are profile-level, not build-specific)
-            const actualProfile = stoStorage.getProfile(store.currentProfile)
-            if (!actualProfile) {
-                stoUI.showToast('Failed to get profile for import', 'error')
-                return { success: false, error: 'Profile not found' }
-            }
-
-            // Ensure aliases structure exists at profile level
-            if (!actualProfile.aliases) {
-                actualProfile.aliases = {}
-            }
-
-            // Merge aliases into profile (profile-level, not build-specific)
-            Object.entries(parsed.aliases).forEach(([name, aliasData]) => {
-                actualProfile.aliases[name] = {
-                    commands: aliasData.commands,
-                    description: aliasData.description || ''
-                }
-            })
-
-            // Update storage and UI
-            stoStorage.saveProfile(store.currentProfile, actualProfile)
-            app.setModified(true)
-
-            // Refresh alias manager if open
-            if (window.stoAliases && typeof window.stoAliases.updateCommandLibrary === 'function') {
-                window.stoAliases.updateCommandLibrary()
-            }
-
-            const message = `Import completed: ${aliasCount} aliases`
-            stoUI.showToast(message, 'success')
-        
-        return {
-            success: true,
-                imported: {
-                    aliases: aliasCount
-                },
-            errors: parsed.errors
-            }
-        } catch (error) {
-            stoUI.showToast('Import failed: ' + error.message, 'error')
-            return { success: false, error: error.message }
-        }
-    }
-
-    // Export profile to keybind file format
-    exportProfile(profile) {
-        let output = '';
-        
-        // Header
-        output += `# ${profile.name} - ${profile.mode} mode\n`;
-        output += `# Generated by STO Tools Keybind Manager\n`;
-        output += `# ${new Date().toLocaleString()}\n\n`;
-        
-        // Export keybinds only (aliases exported separately)
-        output += `# Keybind Commands\n`;
-        const sortedKeys = Object.keys(profile.keys).sort(this.compareKeys.bind(this));
-        
-        sortedKeys.forEach(key => {
-            const commands = profile.keys[key];
-            if (commands && commands.length > 0) {
-                let commandString;
-                
-                // Check if this key should use stabilized execution order
-                let shouldStabilize = false;
-                if (profile.keybindMetadata) {
-                    const env = profile.mode || 'space';
-                    if (profile.keybindMetadata[env] && profile.keybindMetadata[env][key]) {
-                        shouldStabilize = !!profile.keybindMetadata[env][key].stabilizeExecutionOrder;
-                    } else if (profile.keybindMetadata[key]) {
-                        // Legacy flat structure
-                        shouldStabilize = !!profile.keybindMetadata[key].stabilizeExecutionOrder;
-                    }
-                }
-                
-                if (shouldStabilize && commands.length > 1) {
-                    commandString = this.generateMirroredCommandString(commands);
-                } else {
-                    commandString = commands.map(cmd => cmd.command).join(' $$ ');
-                }
-                
-                // Export with optional parameter format for compatibility (empty second parameter)
-                output += `${key} "${commandString}" ""\n`;
-            } else {
-                // Export empty keybinds with the two-parameter format
-                output += `${key} "" ""\n`;
-            }
-        });
-        
-        return output;
-    }
-
-    // Key comparison for sorting
-    compareKeys(a, b) {
-        // Function keys first
-        const aIsF = a.match(/^F(\d+)$/);
-        const bIsF = b.match(/^F(\d+)$/);
-        
-        if (aIsF && bIsF) {
-            return parseInt(aIsF[1]) - parseInt(bIsF[1]);
-        }
-        if (aIsF && !bIsF) return -1;
-        if (!aIsF && bIsF) return 1;
-        
-        // Numbers next
-        const aIsNum = /^\d+$/.test(a);
-        const bIsNum = /^\d+$/.test(b);
-        
-        if (aIsNum && bIsNum) {
-            return parseInt(a) - parseInt(b);
-        }
-        if (aIsNum && !bIsNum) return -1;
-        if (!aIsNum && bIsNum) return 1;
-        
-        // Letters
-        const aIsLetter = /^[A-Z]$/.test(a);
-        const bIsLetter = /^[A-Z]$/.test(b);
-        
-        if (aIsLetter && bIsLetter) {
-            return a.localeCompare(b);
-        }
-        if (aIsLetter && !bIsLetter) return -1;
-        if (!aIsLetter && bIsLetter) return 1;
-        
-        // Special keys
-        const specialOrder = ['Space', 'Tab', 'Enter', 'Escape'];
-        const aSpecial = specialOrder.indexOf(a);
-        const bSpecial = specialOrder.indexOf(b);
-        
-        if (aSpecial !== -1 && bSpecial !== -1) {
-            return aSpecial - bSpecial;
-        }
-        if (aSpecial !== -1 && bSpecial === -1) return -1;
-        if (aSpecial === -1 && bSpecial !== -1) return 1;
-        
-        // Default alphabetical
-        return a.localeCompare(b);
-    }
-
-    // Validation methods
-    isValidKey(key) {
-        // Handle null, undefined, or non-string values
-        if (!key || typeof key !== 'string') {
-            return false;
-        }
-        
-        // Case-insensitive validation since STO keybinds are case insensitive
-        return this.validKeys.some(validKey => validKey.toLowerCase() === key.toLowerCase());
-    }
-
-    isValidAliasName(name) {
-        return STO_DATA.validation.aliasNamePattern.test(name);
-    }
-
-    validateKeybind(key, commands) {
-        const errors = [];
-        
-        // Validate key
-        if (!this.isValidKey(key)) {
-            errors.push(`Invalid key name: ${key}`);
-        }
-        
-        // Validate commands
-        if (!commands || commands.length === 0) {
-            errors.push('At least one command is required');
+          }
         } else {
-            commands.forEach((command, index) => {
-                if (!command.command || command.command.trim().length === 0) {
-                    errors.push(`Command ${index + 1} is empty`);
-                }
-            });
+          result.errors.push({
+            line: index + 1,
+            content: trimmed,
+            error: 'Invalid keybind format',
+          })
         }
-        
-        // Check command count limit
-        if (commands && commands.length > STO_DATA.validation.maxCommandsPerKey) {
-            errors.push(`Too many commands (max ${STO_DATA.validation.maxCommandsPerKey})`);
+      } catch (error) {
+        result.errors.push({
+          line: index + 1,
+          content: trimmed,
+          error: error.message,
+        })
+      }
+    })
+
+    return result
+  }
+
+  // Generate mirrored command string for stable execution order
+  generateMirroredCommandString(commands) {
+    if (!commands || commands.length <= 1) {
+      return commands.map((cmd) => cmd.command || cmd).join(' $$ ')
+    }
+
+    // Extract command strings
+    const commandStrings = commands.map((cmd) => cmd.command || cmd)
+
+    // Create mirrored pattern: original + reverse(without last element)
+    // This ensures Phase 1 (left-to-right) and Phase 2 (right-to-left) execute in same order
+    // Pattern: [A, B, C] -> [A, B, C, B, A] (palindrome-like structure)
+    const reversed = [...commandStrings].reverse()
+    const reversedWithoutLast = reversed.slice(1) // Remove first element of reverse (which is last of original)
+    const mirrored = [...commandStrings, ...reversedWithoutLast]
+
+    return mirrored.join(' $$ ')
+  }
+
+  // Detect if a command string uses mirroring pattern and extract original commands
+  detectAndUnmirrorCommands(commandString) {
+    if (!commandString || typeof commandString !== 'string') {
+      return { isMirrored: false, originalCommands: [] }
+    }
+
+    const commands = commandString
+      .split(' $$ ')
+      .map((cmd) => cmd.trim())
+      .filter((cmd) => cmd)
+
+    // Single command or empty - not mirrored
+    if (commands.length <= 1) {
+      return { isMirrored: false, originalCommands: commands }
+    }
+
+    // Check if this follows the mirroring pattern: [A, B, C, B, A]
+    // For mirrored commands, length should be odd and >= 3
+    if (commands.length < 3 || commands.length % 2 === 0) {
+      return { isMirrored: false, originalCommands: commands }
+    }
+
+    const midIndex = Math.floor(commands.length / 2)
+    const firstHalf = commands.slice(0, midIndex + 1) // Include middle element
+    const secondHalf = commands.slice(midIndex + 1) // After middle element
+
+    // Check if second half is reverse of first half (without the middle element)
+    const expectedReverse = firstHalf.slice(0, -1).reverse() // Remove middle, then reverse
+
+    if (
+      secondHalf.length === expectedReverse.length &&
+      secondHalf.every((cmd, index) => cmd === expectedReverse[index])
+    ) {
+      return {
+        isMirrored: true,
+        originalCommands: firstHalf,
+      }
+    }
+
+    return { isMirrored: false, originalCommands: commands }
+  }
+
+  // Parse command string into individual commands
+  parseCommandString(commandString) {
+    const commands = commandString.split('$$').map((cmd) => cmd.trim())
+
+    return commands.map((command, index) => {
+      const commandObj = {
+        command: command,
+        type: window.stoCommands
+          ? window.stoCommands.detectCommandType(command)
+          : 'custom',
+        icon: window.stoCommands
+          ? window.stoCommands.getCommandIcon(command)
+          : '⚙️',
+        text: window.stoCommands
+          ? window.stoCommands.getCommandText(command)
+          : command,
+        id: `imported_${Date.now()}_${index}`,
+      }
+
+      // Try to extract parameters for known command types
+      if (command.includes('+STOTrayExecByTray')) {
+        const match = command.match(/\+STOTrayExecByTray\s+(\d+)\s+(\d+)/)
+        if (match) {
+          commandObj.parameters = {
+            tray: parseInt(match[1]),
+            slot: parseInt(match[2]),
+          }
+          commandObj.text = `Execute Tray ${parseInt(match[1]) + 1} Slot ${parseInt(match[2]) + 1}`
         }
-        
-        return {
-            valid: errors.length === 0,
-            errors
-        };
+      } else if (command.includes('"')) {
+        // Extract quoted parameters (for communication commands)
+        const match = command.match(/^(\w+)\s+"([^"]+)"$/)
+        if (match) {
+          commandObj.parameters = {
+            message: match[2],
+          }
+          commandObj.text = `${commandObj.text}: ${match[2]}`
+        }
+      }
+
+      return commandObj
+    })
+  }
+
+  // Import keybind file content
+  importKeybindFile(content) {
+    // Get the actual profile from storage to work with the real structure
+    const actualProfile = stoStorage.getProfile(store.currentProfile)
+    if (!actualProfile) {
+      stoUI.showToast('No profile selected for import', 'warning')
+      return { success: false, error: 'No active profile' }
     }
 
-    // Key suggestion and filtering
-    suggestKeys(filter = '') {
-        const filterLower = filter.toLowerCase();
-        
-        return this.validKeys.filter(key => 
-            key.toLowerCase().includes(filterLower)
-        ).slice(0, 20); // Limit suggestions
+    try {
+      const parsed = this.parseKeybindFile(content)
+
+      // Only import keybinds, ignore aliases (they have separate import)
+      const keyCount = Object.keys(parsed.keybinds).length
+
+      if (keyCount === 0) {
+        stoUI.showToast('No keybinds found in file', 'warning')
+        return { success: false, error: 'No keybinds found' }
+      }
+
+      // Ensure builds structure exists
+      if (!actualProfile.builds) {
+        actualProfile.builds = {
+          space: { keys: {} },
+          ground: { keys: {} },
+        }
+      }
+
+      // Ensure current environment build exists
+      if (!actualProfile.builds[store.currentEnvironment]) {
+        actualProfile.builds[store.currentEnvironment] = { keys: {} }
+      }
+
+      // Get reference to the current build's keys
+      const buildKeys = actualProfile.builds[store.currentEnvironment].keys
+
+      // Merge keybinds into the actual build structure
+      Object.entries(parsed.keybinds).forEach(([key, keybindData]) => {
+        // Detect if commands are mirrored and extract original commands
+        const commandString = keybindData.commands
+          .map((cmd) => cmd.command)
+          .join(' $$ ')
+        const mirrorInfo = this.detectAndUnmirrorCommands(commandString)
+
+        if (mirrorInfo.isMirrored) {
+          // Store original commands with stabilization flag
+          buildKeys[key] = this.parseCommandString(
+            mirrorInfo.originalCommands.join(' $$ ')
+          )
+          // Store metadata about stabilization at profile level (scoped by environment)
+          const env = store.currentEnvironment
+          if (!actualProfile.keybindMetadata) {
+            actualProfile.keybindMetadata = {}
+          }
+          if (!actualProfile.keybindMetadata[env]) {
+            actualProfile.keybindMetadata[env] = {}
+          }
+          actualProfile.keybindMetadata[env][key] = {
+            stabilizeExecutionOrder: true,
+          }
+        } else {
+          // Store commands as-is
+          buildKeys[key] = keybindData.commands
+        }
+      })
+
+      // Save the modified profile directly
+      stoStorage.saveProfile(store.currentProfile, actualProfile)
+      app.setModified(true)
+
+      // Refresh key grid
+      app.renderKeyGrid()
+
+      const message = `Import completed: ${keyCount} keybinds`
+      if (Object.keys(parsed.aliases).length > 0) {
+        stoUI.showToast(
+          message +
+            ` (${Object.keys(parsed.aliases).length} aliases ignored - use Import Aliases)`,
+          'success'
+        )
+      } else {
+        stoUI.showToast(message, 'success')
+      }
+
+      return {
+        success: true,
+        imported: {
+          keys: keyCount,
+        },
+        errors: parsed.errors,
+      }
+    } catch (error) {
+      stoUI.showToast('Import failed: ' + error.message, 'error')
+      return { success: false, error: error.message }
+    }
+  }
+
+  // Separate Alias Import
+  importAliasFile(content) {
+    const profile = app.getCurrentProfile()
+    if (!profile) {
+      stoUI.showToast('No profile selected for import', 'warning')
+      return { success: false, error: 'No active profile' }
     }
 
-    getCommonKeys() {
-        return [
-            'Space', 'Tab', 'Enter',
-            'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8',
-            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
-            'Ctrl+1', 'Ctrl+2', 'Ctrl+3', 'Ctrl+4',
-            'Alt+1', 'Alt+2', 'Alt+3', 'Alt+4',
-            'Shift+1', 'Shift+2', 'Shift+3', 'Shift+4'
-        ];
+    try {
+      const parsed = this.parseKeybindFile(content)
+
+      // Only import aliases, ignore keybinds
+      const aliasCount = Object.keys(parsed.aliases).length
+
+      if (aliasCount === 0) {
+        stoUI.showToast('No aliases found in file', 'warning')
+        return { success: false, error: 'No aliases found' }
+      }
+
+      // Get the actual profile from storage (aliases are profile-level, not build-specific)
+      const actualProfile = stoStorage.getProfile(store.currentProfile)
+      if (!actualProfile) {
+        stoUI.showToast('Failed to get profile for import', 'error')
+        return { success: false, error: 'Profile not found' }
+      }
+
+      // Ensure aliases structure exists at profile level
+      if (!actualProfile.aliases) {
+        actualProfile.aliases = {}
+      }
+
+      // Merge aliases into profile (profile-level, not build-specific)
+      Object.entries(parsed.aliases).forEach(([name, aliasData]) => {
+        actualProfile.aliases[name] = {
+          commands: aliasData.commands,
+          description: aliasData.description || '',
+        }
+      })
+
+      // Update storage and UI
+      stoStorage.saveProfile(store.currentProfile, actualProfile)
+      app.setModified(true)
+
+      // Refresh alias manager if open
+      if (
+        window.stoAliases &&
+        typeof window.stoAliases.updateCommandLibrary === 'function'
+      ) {
+        window.stoAliases.updateCommandLibrary()
+      }
+
+      const message = `Import completed: ${aliasCount} aliases`
+      stoUI.showToast(message, 'success')
+
+      return {
+        success: true,
+        imported: {
+          aliases: aliasCount,
+        },
+        errors: parsed.errors,
+      }
+    } catch (error) {
+      stoUI.showToast('Import failed: ' + error.message, 'error')
+      return { success: false, error: error.message }
+    }
+  }
+
+  // Export profile to keybind file format
+  exportProfile(profile) {
+    let output = ''
+
+    // Header
+    output += `# ${profile.name} - ${profile.mode} mode\n`
+    output += `# Generated by STO Tools Keybind Manager\n`
+    output += `# ${new Date().toLocaleString()}\n\n`
+
+    // Export keybinds only (aliases exported separately)
+    output += `# Keybind Commands\n`
+    const sortedKeys = Object.keys(profile.keys).sort(
+      this.compareKeys.bind(this)
+    )
+
+    sortedKeys.forEach((key) => {
+      const commands = profile.keys[key]
+      if (commands && commands.length > 0) {
+        let commandString
+
+        // Check if this key should use stabilized execution order
+        let shouldStabilize = false
+        if (profile.keybindMetadata) {
+          const env = profile.mode || 'space'
+          if (
+            profile.keybindMetadata[env] &&
+            profile.keybindMetadata[env][key]
+          ) {
+            shouldStabilize =
+              !!profile.keybindMetadata[env][key].stabilizeExecutionOrder
+          } else if (profile.keybindMetadata[key]) {
+            // Legacy flat structure
+            shouldStabilize =
+              !!profile.keybindMetadata[key].stabilizeExecutionOrder
+          }
+        }
+
+        if (shouldStabilize && commands.length > 1) {
+          commandString = this.generateMirroredCommandString(commands)
+        } else {
+          commandString = commands.map((cmd) => cmd.command).join(' $$ ')
+        }
+
+        // Export with optional parameter format for compatibility (empty second parameter)
+        output += `${key} "${commandString}" ""\n`
+      } else {
+        // Export empty keybinds with the two-parameter format
+        output += `${key} "" ""\n`
+      }
+    })
+
+    return output
+  }
+
+  // Key comparison for sorting
+  compareKeys(a, b) {
+    // Function keys first
+    const aIsF = a.match(/^F(\d+)$/)
+    const bIsF = b.match(/^F(\d+)$/)
+
+    if (aIsF && bIsF) {
+      return parseInt(aIsF[1]) - parseInt(bIsF[1])
+    }
+    if (aIsF && !bIsF) return -1
+    if (!aIsF && bIsF) return 1
+
+    // Numbers next
+    const aIsNum = /^\d+$/.test(a)
+    const bIsNum = /^\d+$/.test(b)
+
+    if (aIsNum && bIsNum) {
+      return parseInt(a) - parseInt(b)
+    }
+    if (aIsNum && !bIsNum) return -1
+    if (!aIsNum && bIsNum) return 1
+
+    // Letters
+    const aIsLetter = /^[A-Z]$/.test(a)
+    const bIsLetter = /^[A-Z]$/.test(b)
+
+    if (aIsLetter && bIsLetter) {
+      return a.localeCompare(b)
+    }
+    if (aIsLetter && !bIsLetter) return -1
+    if (!aIsLetter && bIsLetter) return 1
+
+    // Special keys
+    const specialOrder = ['Space', 'Tab', 'Enter', 'Escape']
+    const aSpecial = specialOrder.indexOf(a)
+    const bSpecial = specialOrder.indexOf(b)
+
+    if (aSpecial !== -1 && bSpecial !== -1) {
+      return aSpecial - bSpecial
+    }
+    if (aSpecial !== -1 && bSpecial === -1) return -1
+    if (aSpecial === -1 && bSpecial !== -1) return 1
+
+    // Default alphabetical
+    return a.localeCompare(b)
+  }
+
+  // Validation methods
+  isValidKey(key) {
+    // Handle null, undefined, or non-string values
+    if (!key || typeof key !== 'string') {
+      return false
     }
 
-    // Event listeners
-    setupEventListeners() {
-        // Note: File input handling is done directly in profiles.js
-        // No global event delegation needed for file input
+    // Case-insensitive validation since STO keybinds are case insensitive
+    return this.validKeys.some(
+      (validKey) => validKey.toLowerCase() === key.toLowerCase()
+    )
+  }
+
+  isValidAliasName(name) {
+    return STO_DATA.validation.aliasNamePattern.test(name)
+  }
+
+  validateKeybind(key, commands) {
+    const errors = []
+
+    // Validate key
+    if (!this.isValidKey(key)) {
+      errors.push(`Invalid key name: ${key}`)
     }
 
-    handleKeybindFileImport(event) {
-        const file = event.target.files[0];
-        if (!file) return;
-        
-        const reader = new FileReader();
-        reader.onload = (e) => {
-            try {
-                this.importKeybindFile(e.target.result);
-            } catch (error) {
-                stoUI.showToast('Failed to import keybind file: ' + error.message, 'error');
-            }
-        };
-        reader.readAsText(file);
-        
-        // Reset file input
-        event.target.value = '';
+    // Validate commands
+    if (!commands || commands.length === 0) {
+      errors.push('At least one command is required')
+    } else {
+      commands.forEach((command, index) => {
+        if (!command.command || command.command.trim().length === 0) {
+          errors.push(`Command ${index + 1} is empty`)
+        }
+      })
     }
 
-    // Utility methods
-    generateKeybindId() {
-        return 'keybind_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+    // Check command count limit
+    if (commands && commands.length > STO_DATA.validation.maxCommandsPerKey) {
+      errors.push(
+        `Too many commands (max ${STO_DATA.validation.maxCommandsPerKey})`
+      )
     }
 
-    cloneKeybind(keybind) {
-        return JSON.parse(JSON.stringify(keybind));
+    return {
+      valid: errors.length === 0,
+      errors,
+    }
+  }
+
+  // Key suggestion and filtering
+  suggestKeys(filter = '') {
+    const filterLower = filter.toLowerCase()
+
+    return this.validKeys
+      .filter((key) => key.toLowerCase().includes(filterLower))
+      .slice(0, 20) // Limit suggestions
+  }
+
+  getCommonKeys() {
+    return [
+      'Space',
+      'Tab',
+      'Enter',
+      'F1',
+      'F2',
+      'F3',
+      'F4',
+      'F5',
+      'F6',
+      'F7',
+      'F8',
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      '0',
+      'Ctrl+1',
+      'Ctrl+2',
+      'Ctrl+3',
+      'Ctrl+4',
+      'Alt+1',
+      'Alt+2',
+      'Alt+3',
+      'Alt+4',
+      'Shift+1',
+      'Shift+2',
+      'Shift+3',
+      'Shift+4',
+    ]
+  }
+
+  // Event listeners
+  setupEventListeners() {
+    // Note: File input handling is done directly in profiles.js
+    // No global event delegation needed for file input
+  }
+
+  handleKeybindFileImport(event) {
+    const file = event.target.files[0]
+    if (!file) return
+
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      try {
+        this.importKeybindFile(e.target.result)
+      } catch (error) {
+        stoUI.showToast(
+          'Failed to import keybind file: ' + error.message,
+          'error'
+        )
+      }
+    }
+    reader.readAsText(file)
+
+    // Reset file input
+    event.target.value = ''
+  }
+
+  // Utility methods
+  generateKeybindId() {
+    return (
+      'keybind_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9)
+    )
+  }
+
+  cloneKeybind(keybind) {
+    return JSON.parse(JSON.stringify(keybind))
+  }
+
+  // Statistics
+  getProfileStats(profile) {
+    const stats = {
+      totalKeys: Object.keys(profile.keys).length,
+      totalCommands: 0,
+      totalAliases: Object.keys(profile.aliases || {}).length,
+      commandTypes: {},
+      mostUsedCommands: {},
     }
 
-    // Statistics
-    getProfileStats(profile) {
-        const stats = {
-            totalKeys: Object.keys(profile.keys).length,
-            totalCommands: 0,
-            totalAliases: Object.keys(profile.aliases || {}).length,
-            commandTypes: {},
-            mostUsedCommands: {}
-        };
-        
-        Object.values(profile.keys).forEach(commands => {
-            stats.totalCommands += commands.length;
-            
-            commands.forEach(command => {
-                // Count by type
-                stats.commandTypes[command.type] = (stats.commandTypes[command.type] || 0) + 1;
-                
-                // Count by command
-                stats.mostUsedCommands[command.command] = (stats.mostUsedCommands[command.command] || 0) + 1;
-            });
-        });
-        
-        return stats;
-    }
+    Object.values(profile.keys).forEach((commands) => {
+      stats.totalCommands += commands.length
+
+      commands.forEach((command) => {
+        // Count by type
+        stats.commandTypes[command.type] =
+          (stats.commandTypes[command.type] || 0) + 1
+
+        // Count by command
+        stats.mostUsedCommands[command.command] =
+          (stats.mostUsedCommands[command.command] || 0) + 1
+      })
+    })
+
+    return stats
+  }
 }
 
 // Global keybind manager instance

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,30 +1,30 @@
-import './constants.js';
-import eventBus from './eventBus.js';
-import './data.js';
-import './errors.js';
-import STOStorage from './storage.js';
-import STOProfileManager from './profiles.js';
-import STOKeybindFileManager from './keybinds.js';
-import STOAliasManager from './aliases.js';
-import STOExportManager from './export.js';
-import STOModalManager from './modalManager.js';
-import STOUIManager from './ui.js';
-import STOCommandManager from './commands.js';
-import STOFileExplorer from './fileexplorer.js';
-import VertigoManager, { VFX_EFFECTS } from './vertigo_data.js';
-import STOToolsKeybindManager from './app.js';
-import './version.js';
+import './constants.js'
+import eventBus from './eventBus.js'
+import './data.js'
+import './errors.js'
+import STOStorage from './storage.js'
+import STOProfileManager from './profiles.js'
+import STOKeybindFileManager from './keybinds.js'
+import STOAliasManager from './aliases.js'
+import STOExportManager from './export.js'
+import STOModalManager from './modalManager.js'
+import STOUIManager from './ui.js'
+import STOCommandManager from './commands.js'
+import STOFileExplorer from './fileexplorer.js'
+import VertigoManager, { VFX_EFFECTS } from './vertigo_data.js'
+import STOToolsKeybindManager from './app.js'
+import './version.js'
 
-const stoStorage = new STOStorage();
-const stoProfiles = new STOProfileManager();
-const stoKeybinds = new STOKeybindFileManager();
-const stoAliases = new STOAliasManager();
-const stoExport = new STOExportManager();
-const modalManager = new STOModalManager();
-const stoUI = new STOUIManager();
-const stoCommands = new STOCommandManager();
-const stoFileExplorer = new STOFileExplorer();
-const vertigoManager = new VertigoManager();
+const stoStorage = new STOStorage()
+const stoProfiles = new STOProfileManager()
+const stoKeybinds = new STOKeybindFileManager()
+const stoAliases = new STOAliasManager()
+const stoExport = new STOExportManager()
+const modalManager = new STOModalManager()
+const stoUI = new STOUIManager()
+const stoCommands = new STOCommandManager()
+const stoFileExplorer = new STOFileExplorer()
+const vertigoManager = new VertigoManager()
 Object.assign(window, {
   stoStorage,
   stoProfiles,
@@ -37,16 +37,16 @@ Object.assign(window, {
   stoFileExplorer,
   vertigoManager,
   VFX_EFFECTS,
-  VERTIGO_EFFECTS: VFX_EFFECTS
-});
+  VERTIGO_EFFECTS: VFX_EFFECTS,
+})
 
-const app = new STOToolsKeybindManager();
-window.app = app;
+const app = new STOToolsKeybindManager()
+window.app = app
 
 eventBus.on('sto-app-ready', () => {
-  stoProfiles.init();
-  stoKeybinds.init();
-  stoAliases.init();
-  stoExport.init();
-  stoFileExplorer.init();
-});
+  stoProfiles.init()
+  stoKeybinds.init()
+  stoAliases.init()
+  stoExport.init()
+  stoFileExplorer.init()
+})

--- a/src/js/modalManager.js
+++ b/src/js/modalManager.js
@@ -1,44 +1,44 @@
 export default class STOModalManager {
-    constructor() {
-        this.overlayId = 'modalOverlay';
+  constructor() {
+    this.overlayId = 'modalOverlay'
+  }
+
+  getOverlay() {
+    return document.getElementById(this.overlayId)
+  }
+
+  show(id) {
+    const modal = typeof id === 'string' ? document.getElementById(id) : id
+    const overlay = this.getOverlay()
+    if (overlay && modal) {
+      overlay.classList.add('active')
+      modal.classList.add('active')
+      document.body.classList.add('modal-open')
+
+      const firstInput = modal.querySelector('input, textarea, select')
+      if (firstInput) {
+        setTimeout(() => firstInput.focus(), 100)
+      }
+      return true
     }
+    return false
+  }
 
-    getOverlay() {
-        return document.getElementById(this.overlayId);
+  hide(id) {
+    const modal = typeof id === 'string' ? document.getElementById(id) : id
+    const overlay = this.getOverlay()
+    if (overlay && modal) {
+      modal.classList.remove('active')
+
+      // Hide overlay if no other modals are active
+      if (!document.querySelector('.modal.active')) {
+        overlay.classList.remove('active')
+        document.body.classList.remove('modal-open')
+      }
+      return true
     }
-
-    show(id) {
-        const modal = typeof id === 'string' ? document.getElementById(id) : id;
-        const overlay = this.getOverlay();
-        if (overlay && modal) {
-            overlay.classList.add('active');
-            modal.classList.add('active');
-            document.body.classList.add('modal-open');
-
-            const firstInput = modal.querySelector('input, textarea, select');
-            if (firstInput) {
-                setTimeout(() => firstInput.focus(), 100);
-            }
-            return true;
-        }
-        return false;
-    }
-
-    hide(id) {
-        const modal = typeof id === 'string' ? document.getElementById(id) : id;
-        const overlay = this.getOverlay();
-        if (overlay && modal) {
-            modal.classList.remove('active');
-
-            // Hide overlay if no other modals are active
-            if (!document.querySelector('.modal.active')) {
-                overlay.classList.remove('active');
-                document.body.classList.remove('modal-open');
-            }
-            return true;
-        }
-        return false;
-    }
+    return false
+  }
 }
 
 // Global instance

--- a/src/js/profiles.js
+++ b/src/js/profiles.js
@@ -4,853 +4,982 @@ import store from './store.js'
 import eventBus from './eventBus.js'
 
 export default class STOProfileManager {
-    constructor() {
-        this.currentModal = null;
-        // Don't initialize immediately - wait for app to be ready
+  constructor() {
+    this.currentModal = null
+    // Don't initialize immediately - wait for app to be ready
+  }
+
+  init() {
+    this.setupEventListeners()
+  }
+
+  setupEventListeners() {
+    // Profile dropdown change
+    const profileSelect = document.getElementById('profileSelect')
+    if (profileSelect) {
+      profileSelect.addEventListener('change', (e) => {
+        app.switchProfile(e.target.value)
+      })
     }
 
-    init() {
-        this.setupEventListeners();
+    // Profile action buttons
+    eventBus.onDom('newProfileBtn', 'click', 'profile-new', () => {
+      this.showNewProfileModal()
+    })
+
+    eventBus.onDom('cloneProfileBtn', 'click', 'profile-clone', () => {
+      this.showCloneProfileModal()
+    })
+
+    eventBus.onDom('renameProfileBtn', 'click', 'profile-rename', () => {
+      this.showRenameProfileModal()
+    })
+
+    eventBus.onDom('deleteProfileBtn', 'click', 'profile-delete', () => {
+      this.confirmDeleteProfile()
+    })
+
+    // Profile modal save button
+    eventBus.onDom('saveProfileBtn', 'click', 'profile-save', () => {
+      this.handleProfileSave()
+    })
+
+    // Settings dropdown
+    eventBus.onDom('settingsBtn', 'click', 'settings-menu', (e) => {
+      e.stopPropagation()
+      this.toggleSettingsMenu()
+    })
+
+    // Keybinds dropdown
+    eventBus.onDom('keybindsBtn', 'click', 'keybinds-menu', (e) => {
+      e.stopPropagation()
+      this.toggleKeybindsMenu()
+    })
+
+    // Aliases dropdown
+    eventBus.onDom('aliasesBtn', 'click', 'aliases-menu', (e) => {
+      e.stopPropagation()
+      this.toggleAliasesMenu()
+    })
+
+    eventBus.onDom('importKeybindsBtn', 'click', 'keybinds-import', () => {
+      this.importKeybinds()
+      this.closeKeybindsMenu()
+    })
+
+    eventBus.onDom('exportKeybindsBtn', 'click', 'keybinds-export', () => {
+      this.exportKeybinds()
+      this.closeKeybindsMenu()
+    })
+
+    eventBus.onDom('importAliasesBtn', 'click', 'aliases-import', () => {
+      this.importAliases()
+      this.closeAliasesMenu()
+    })
+
+    eventBus.onDom('exportAliasesBtn', 'click', 'aliases-export', () => {
+      this.exportAliases()
+      this.closeAliasesMenu()
+    })
+
+    eventBus.onDom('loadDefaultDataBtn', 'click', 'load-default-data', () => {
+      this.loadDefaultData()
+      this.closeSettingsMenu()
+    })
+
+    eventBus.onDom('resetAppBtn', 'click', 'reset-app', () => {
+      this.confirmResetApp()
+      this.closeSettingsMenu()
+    })
+
+    eventBus.onDom('aboutBtn', 'click', 'about-open', () => {
+      modalManager.show('aboutModal')
+    })
+
+    eventBus.onDom('themeToggleBtn', 'click', 'theme-toggle', () => {
+      app.toggleTheme()
+      this.closeSettingsMenu()
+    })
+
+    // Close settings menu when clicking outside
+    document.addEventListener('click', () => {
+      this.closeSettingsMenu()
+      this.closeKeybindsMenu()
+      this.closeAliasesMenu()
+    })
+  }
+
+  // Profile Modal Management
+  showNewProfileModal() {
+    const modal = document.getElementById('profileModal')
+    const title = document.getElementById('profileModalTitle')
+    const nameInput = document.getElementById('profileName')
+    const descInput = document.getElementById('profileDescription')
+
+    if (title) title.textContent = 'New Profile'
+    if (nameInput) {
+      nameInput.value = ''
+      nameInput.placeholder = 'Enter profile name'
+    }
+    if (descInput) {
+      descInput.value = ''
     }
 
-    setupEventListeners() {
-        // Profile dropdown change
-        const profileSelect = document.getElementById('profileSelect');
-        if (profileSelect) {
-            profileSelect.addEventListener('change', (e) => {
-                app.switchProfile(e.target.value);
-            });
-        }
+    this.currentModal = 'new'
+    modalManager.show('profileModal')
+  }
 
-        // Profile action buttons
-        eventBus.onDom('newProfileBtn', 'click', 'profile-new', () => {
-            this.showNewProfileModal();
-        });
-
-        eventBus.onDom('cloneProfileBtn', 'click', 'profile-clone', () => {
-            this.showCloneProfileModal();
-        });
-
-        eventBus.onDom('renameProfileBtn', 'click', 'profile-rename', () => {
-            this.showRenameProfileModal();
-        });
-
-        eventBus.onDom('deleteProfileBtn', 'click', 'profile-delete', () => {
-            this.confirmDeleteProfile();
-        });
-
-        // Profile modal save button
-        eventBus.onDom('saveProfileBtn', 'click', 'profile-save', () => {
-            this.handleProfileSave();
-        });
-
-        // Settings dropdown
-        eventBus.onDom('settingsBtn', 'click', 'settings-menu', (e) => {
-            e.stopPropagation();
-            this.toggleSettingsMenu();
-        });
-
-        // Keybinds dropdown
-        eventBus.onDom('keybindsBtn', 'click', 'keybinds-menu', (e) => {
-            e.stopPropagation();
-            this.toggleKeybindsMenu();
-        });
-
-        // Aliases dropdown  
-        eventBus.onDom('aliasesBtn', 'click', 'aliases-menu', (e) => {
-            e.stopPropagation();
-            this.toggleAliasesMenu();
-        });
-
-        eventBus.onDom('importKeybindsBtn', 'click', 'keybinds-import', () => {
-            this.importKeybinds();
-            this.closeKeybindsMenu();
-        });
-
-        eventBus.onDom('exportKeybindsBtn', 'click', 'keybinds-export', () => {
-            this.exportKeybinds();
-            this.closeKeybindsMenu();
-        });
-
-        eventBus.onDom('importAliasesBtn', 'click', 'aliases-import', () => {
-            this.importAliases();
-            this.closeAliasesMenu();
-        });
-
-        eventBus.onDom('exportAliasesBtn', 'click', 'aliases-export', () => {
-            this.exportAliases();
-            this.closeAliasesMenu();
-        });
-
-        eventBus.onDom('loadDefaultDataBtn', 'click', 'load-default-data', () => {
-            this.loadDefaultData();
-            this.closeSettingsMenu();
-        });
-
-        eventBus.onDom('resetAppBtn', 'click', 'reset-app', () => {
-            this.confirmResetApp();
-            this.closeSettingsMenu();
-        });
-
-        eventBus.onDom('aboutBtn', 'click', 'about-open', () => {
-            modalManager.show('aboutModal');
-        });
-
-        eventBus.onDom('themeToggleBtn', 'click', 'theme-toggle', () => {
-            app.toggleTheme();
-            this.closeSettingsMenu();
-        });
-
-        // Close settings menu when clicking outside
-        document.addEventListener('click', () => {
-            this.closeSettingsMenu();
-            this.closeKeybindsMenu();
-            this.closeAliasesMenu();
-        });
+  showCloneProfileModal() {
+    const currentProfile = app.getCurrentProfile()
+    if (!currentProfile) {
+      stoUI.showToast('No profile selected to clone', 'warning')
+      return
     }
 
-    // Profile Modal Management
-    showNewProfileModal() {
-        const modal = document.getElementById('profileModal');
-        const title = document.getElementById('profileModalTitle');
-        const nameInput = document.getElementById('profileName');
-        const descInput = document.getElementById('profileDescription');
+    const modal = document.getElementById('profileModal')
+    const title = document.getElementById('profileModalTitle')
+    const nameInput = document.getElementById('profileName')
+    const descInput = document.getElementById('profileDescription')
 
-        if (title) title.textContent = 'New Profile';
-        if (nameInput) {
-            nameInput.value = '';
-            nameInput.placeholder = 'Enter profile name';
-        }
-        if (descInput) {
-            descInput.value = '';
-        }
-
-        this.currentModal = 'new';
-        modalManager.show('profileModal');
+    if (title) title.textContent = 'Clone Profile'
+    if (nameInput) {
+      nameInput.value = `${currentProfile.name} Copy`
+      nameInput.placeholder = 'Enter new profile name'
+    }
+    if (descInput) {
+      descInput.value = `Copy of ${currentProfile.name}`
     }
 
-    showCloneProfileModal() {
-        const currentProfile = app.getCurrentProfile();
-        if (!currentProfile) {
-            stoUI.showToast('No profile selected to clone', 'warning');
-            return;
-        }
+    this.currentModal = 'clone'
+    modalManager.show('profileModal')
+  }
 
-        const modal = document.getElementById('profileModal');
-        const title = document.getElementById('profileModalTitle');
-        const nameInput = document.getElementById('profileName');
-        const descInput = document.getElementById('profileDescription');
-
-        if (title) title.textContent = 'Clone Profile';
-        if (nameInput) {
-            nameInput.value = `${currentProfile.name} Copy`;
-            nameInput.placeholder = 'Enter new profile name';
-        }
-        if (descInput) {
-            descInput.value = `Copy of ${currentProfile.name}`;
-        }
-
-        this.currentModal = 'clone';
-        modalManager.show('profileModal');
+  showRenameProfileModal() {
+    const currentProfile = app.getCurrentProfile()
+    if (!currentProfile) {
+      stoUI.showToast('No profile selected to rename', 'warning')
+      return
     }
 
-    showRenameProfileModal() {
-        const currentProfile = app.getCurrentProfile();
-        if (!currentProfile) {
-            stoUI.showToast('No profile selected to rename', 'warning');
-            return;
-        }
+    const modal = document.getElementById('profileModal')
+    const title = document.getElementById('profileModalTitle')
+    const nameInput = document.getElementById('profileName')
+    const descInput = document.getElementById('profileDescription')
 
-        const modal = document.getElementById('profileModal');
-        const title = document.getElementById('profileModalTitle');
-        const nameInput = document.getElementById('profileName');
-        const descInput = document.getElementById('profileDescription');
-
-        if (title) title.textContent = 'Rename Profile';
-        if (nameInput) {
-            nameInput.value = currentProfile.name;
-            nameInput.placeholder = 'Enter profile name';
-        }
-        if (descInput) {
-            descInput.value = currentProfile.description || '';
-        }
-
-        this.currentModal = 'rename';
-        modalManager.show('profileModal');
+    if (title) title.textContent = 'Rename Profile'
+    if (nameInput) {
+      nameInput.value = currentProfile.name
+      nameInput.placeholder = 'Enter profile name'
+    }
+    if (descInput) {
+      descInput.value = currentProfile.description || ''
     }
 
-    handleProfileSave() {
-        const nameInput = document.getElementById('profileName');
-        const descInput = document.getElementById('profileDescription');
+    this.currentModal = 'rename'
+    modalManager.show('profileModal')
+  }
 
-        if (!nameInput) return;
+  handleProfileSave() {
+    const nameInput = document.getElementById('profileName')
+    const descInput = document.getElementById('profileDescription')
 
-        const name = nameInput.value.trim();
-        const description = descInput?.value.trim() || '';
+    if (!nameInput) return
 
-        if (!name) {
-            stoUI.showToast('Profile name is required', 'error');
-            nameInput.focus();
-            return;
-        }
+    const name = nameInput.value.trim()
+    const description = descInput?.value.trim() || ''
 
-        if (name.length > 50) {
-            stoUI.showToast('Profile name is too long (max 50 characters)', 'error');
-            nameInput.focus();
-            return;
-        }
+    if (!name) {
+      stoUI.showToast('Profile name is required', 'error')
+      nameInput.focus()
+      return
+    }
 
-        // Check for duplicate names (except when renaming current profile)
-        const data = stoStorage.getAllData();
-        const existingProfile = Object.values(data.profiles).find(p => 
-            p.name.toLowerCase() === name.toLowerCase() && 
-            (this.currentModal !== 'rename' || p.name !== app.getCurrentProfile()?.name)
-        );
+    if (name.length > 50) {
+      stoUI.showToast('Profile name is too long (max 50 characters)', 'error')
+      nameInput.focus()
+      return
+    }
 
-        if (existingProfile) {
-            stoUI.showToast('A profile with this name already exists', 'error');
-            nameInput.focus();
-            return;
-        }
+    // Check for duplicate names (except when renaming current profile)
+    const data = stoStorage.getAllData()
+    const existingProfile = Object.values(data.profiles).find(
+      (p) =>
+        p.name.toLowerCase() === name.toLowerCase() &&
+        (this.currentModal !== 'rename' ||
+          p.name !== app.getCurrentProfile()?.name)
+    )
 
-        try {
-            switch (this.currentModal) {
-                case 'new':
-                    this.createNewProfile(name, description);
-                    break;
-                case 'clone':
-                    this.cloneCurrentProfile(name, description);
-                    break;
-                case 'rename':
-                    this.renameCurrentProfile(name, description);
-                    break;
+    if (existingProfile) {
+      stoUI.showToast('A profile with this name already exists', 'error')
+      nameInput.focus()
+      return
+    }
+
+    try {
+      switch (this.currentModal) {
+        case 'new':
+          this.createNewProfile(name, description)
+          break
+        case 'clone':
+          this.cloneCurrentProfile(name, description)
+          break
+        case 'rename':
+          this.renameCurrentProfile(name, description)
+          break
+      }
+
+      modalManager.hide('profileModal')
+      this.currentModal = null
+    } catch (error) {
+      stoUI.showToast('Failed to save profile: ' + error.message, 'error')
+    }
+  }
+
+  createNewProfile(name, description) {
+    const profileId = app.generateProfileId(name)
+    const profile = {
+      name,
+      description,
+      mode: 'space',
+      keys: {},
+      aliases: {},
+      created: new Date().toISOString(),
+      lastModified: new Date().toISOString(),
+    }
+
+    if (stoStorage.saveProfile(profileId, profile)) {
+      app.switchProfile(profileId)
+      app.renderProfiles()
+      stoUI.showToast(`Profile "${name}" created`, 'success')
+    } else {
+      throw new Error('Failed to save profile')
+    }
+  }
+
+  cloneCurrentProfile(name, description) {
+    const currentProfile = app.getCurrentProfile()
+    if (!currentProfile) {
+      throw new Error('No profile to clone')
+    }
+
+    const profileId = app.generateProfileId(name)
+    const clonedProfile = {
+      ...JSON.parse(JSON.stringify(currentProfile)), // Deep clone
+      name,
+      description,
+      created: new Date().toISOString(),
+      lastModified: new Date().toISOString(),
+    }
+
+    if (stoStorage.saveProfile(profileId, clonedProfile)) {
+      app.switchProfile(profileId)
+      app.renderProfiles()
+      stoUI.showToast(
+        `Profile "${name}" created from "${currentProfile.name}"`,
+        'success'
+      )
+    } else {
+      throw new Error('Failed to save cloned profile')
+    }
+  }
+
+  renameCurrentProfile(name, description) {
+    const currentProfile = app.getCurrentProfile()
+    if (!currentProfile) {
+      throw new Error('No profile to rename')
+    }
+
+    const oldName = currentProfile.name
+    currentProfile.name = name
+    currentProfile.description = description
+    currentProfile.lastModified = new Date().toISOString()
+
+    if (stoStorage.saveProfile(store.currentProfile, currentProfile)) {
+      app.renderProfiles()
+      app.setModified(true)
+      stoUI.showToast(
+        `Profile renamed from "${oldName}" to "${name}"`,
+        'success'
+      )
+    } else {
+      throw new Error('Failed to save renamed profile')
+    }
+  }
+
+  async confirmDeleteProfile() {
+    const currentProfile = app.getCurrentProfile()
+    if (!currentProfile) {
+      stoUI.showToast('No profile selected to delete', 'warning')
+      return
+    }
+
+    const data = stoStorage.getAllData()
+    const profileCount = Object.keys(data.profiles).length
+
+    if (profileCount <= 1) {
+      stoUI.showToast('Cannot delete the last profile', 'warning')
+      return
+    }
+
+    const confirmed = await stoUI.confirm(
+      `Are you sure you want to delete the profile "${currentProfile.name}"?\n\nThis action cannot be undone.`,
+      'Delete Profile',
+      'danger'
+    )
+
+    if (confirmed) {
+      this.deleteCurrentProfile()
+    }
+  }
+
+  deleteCurrentProfile() {
+    const currentProfile = app.getCurrentProfile()
+    if (!currentProfile) return
+
+    const profileName = currentProfile.name
+
+    if (app.deleteProfile(app.currentProfile)) {
+      stoUI.showToast(`Profile "${profileName}" deleted`, 'success')
+    } else {
+      stoUI.showToast('Failed to delete profile', 'error')
+    }
+  }
+
+  // Settings Menu Management
+  toggleSettingsMenu() {
+    const settingsBtn = document.getElementById('settingsBtn')
+    if (settingsBtn) {
+      const dropdown = settingsBtn.closest('.dropdown')
+      if (dropdown) {
+        dropdown.classList.toggle('active')
+      }
+    }
+  }
+
+  closeSettingsMenu() {
+    const settingsBtn = document.getElementById('settingsBtn')
+    if (settingsBtn) {
+      const dropdown = settingsBtn.closest('.dropdown')
+      if (dropdown) {
+        dropdown.classList.remove('active')
+      }
+    }
+  }
+
+  // Keybinds Menu Management
+  toggleKeybindsMenu() {
+    // Close other dropdowns first
+    this.closeSettingsMenu()
+    this.closeAliasesMenu()
+
+    const keybindsBtn = document.getElementById('keybindsBtn')
+    if (keybindsBtn) {
+      const dropdown = keybindsBtn.closest('.dropdown')
+      if (dropdown) {
+        dropdown.classList.toggle('active')
+      }
+    }
+  }
+
+  closeKeybindsMenu() {
+    const keybindsBtn = document.getElementById('keybindsBtn')
+    if (keybindsBtn) {
+      const dropdown = keybindsBtn.closest('.dropdown')
+      if (dropdown) {
+        dropdown.classList.remove('active')
+      }
+    }
+  }
+
+  // Aliases Menu Management
+  toggleAliasesMenu() {
+    // Close other dropdowns first
+    this.closeSettingsMenu()
+    this.closeKeybindsMenu()
+
+    const aliasesBtn = document.getElementById('aliasesBtn')
+    if (aliasesBtn) {
+      const dropdown = aliasesBtn.closest('.dropdown')
+      if (dropdown) {
+        dropdown.classList.toggle('active')
+      }
+    }
+  }
+
+  closeAliasesMenu() {
+    const aliasesBtn = document.getElementById('aliasesBtn')
+    if (aliasesBtn) {
+      const dropdown = aliasesBtn.closest('.dropdown')
+      if (dropdown) {
+        dropdown.classList.remove('active')
+      }
+    }
+  }
+
+  // Import/Export Operations
+  importKeybinds() {
+    const input = document.getElementById('fileInput')
+    if (input) {
+      input.accept = '.txt'
+      input.onchange = (e) => {
+        const file = e.target.files[0]
+        if (file) {
+          const reader = new FileReader()
+          reader.onload = (e) => {
+            try {
+              stoKeybinds.importKeybindFile(e.target.result)
+            } catch (error) {
+              stoUI.showToast(
+                'Failed to import keybind file: ' + error.message,
+                'error'
+              )
             }
-
-            modalManager.hide('profileModal');
-            this.currentModal = null;
-        } catch (error) {
-            stoUI.showToast('Failed to save profile: ' + error.message, 'error');
+          }
+          reader.readAsText(file)
         }
+        // Reset file input
+        e.target.value = ''
+      }
+      input.click()
+    }
+  }
+
+  exportKeybinds() {
+    const profile = app.getCurrentProfile()
+    if (!profile) {
+      stoUI.showToast('No profile selected to export', 'warning')
+      return
     }
 
-    createNewProfile(name, description) {
-        const profileId = app.generateProfileId(name);
-        const profile = {
-            name,
-            description,
-            mode: 'space',
-            keys: {},
-            aliases: {},
-            created: new Date().toISOString(),
-            lastModified: new Date().toISOString()
-        };
-
-        if (stoStorage.saveProfile(profileId, profile)) {
-            app.switchProfile(profileId);
-            app.renderProfiles();
-            stoUI.showToast(`Profile "${name}" created`, 'success');
-        } else {
-            throw new Error('Failed to save profile');
-        }
+    if (!profile.keys || Object.keys(profile.keys).length === 0) {
+      stoUI.showToast('No keybinds to export', 'warning')
+      return
     }
 
-    cloneCurrentProfile(name, description) {
-        const currentProfile = app.getCurrentProfile();
-        if (!currentProfile) {
-            throw new Error('No profile to clone');
-        }
+    stoExport.exportSTOKeybindFile(profile)
+  }
 
-        const profileId = app.generateProfileId(name);
-        const clonedProfile = {
-            ...JSON.parse(JSON.stringify(currentProfile)), // Deep clone
-            name,
-            description,
-            created: new Date().toISOString(),
-            lastModified: new Date().toISOString()
-        };
+  importAliases() {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = '.txt'
+    input.onchange = (e) => {
+      const file = e.target.files[0]
+      if (file) {
+        const reader = new FileReader()
+        reader.onload = (e) => {
+          try {
+            const content = e.target.result
+            stoKeybinds.importAliasFile(content)
 
-        if (stoStorage.saveProfile(profileId, clonedProfile)) {
-            app.switchProfile(profileId);
-            app.renderProfiles();
-            stoUI.showToast(`Profile "${name}" created from "${currentProfile.name}"`, 'success');
-        } else {
-            throw new Error('Failed to save cloned profile');
-        }
-    }
-
-    renameCurrentProfile(name, description) {
-        const currentProfile = app.getCurrentProfile();
-        if (!currentProfile) {
-            throw new Error('No profile to rename');
-        }
-
-        const oldName = currentProfile.name;
-        currentProfile.name = name;
-        currentProfile.description = description;
-        currentProfile.lastModified = new Date().toISOString();
-
-        if (stoStorage.saveProfile(store.currentProfile, currentProfile)) {
-            app.renderProfiles();
-            app.setModified(true);
-            stoUI.showToast(`Profile renamed from "${oldName}" to "${name}"`, 'success');
-        } else {
-            throw new Error('Failed to save renamed profile');
-        }
-    }
-
-    async confirmDeleteProfile() {
-        const currentProfile = app.getCurrentProfile();
-        if (!currentProfile) {
-            stoUI.showToast('No profile selected to delete', 'warning');
-            return;
-        }
-
-        const data = stoStorage.getAllData();
-        const profileCount = Object.keys(data.profiles).length;
-
-        if (profileCount <= 1) {
-            stoUI.showToast('Cannot delete the last profile', 'warning');
-            return;
-        }
-
-        const confirmed = await stoUI.confirm(
-            `Are you sure you want to delete the profile "${currentProfile.name}"?\n\nThis action cannot be undone.`,
-            'Delete Profile',
-            'danger'
-        );
-
-        if (confirmed) {
-            this.deleteCurrentProfile();
-        }
-    }
-
-    deleteCurrentProfile() {
-        const currentProfile = app.getCurrentProfile();
-        if (!currentProfile) return;
-
-        const profileName = currentProfile.name;
-        
-        if (app.deleteProfile(app.currentProfile)) {
-            stoUI.showToast(`Profile "${profileName}" deleted`, 'success');
-        } else {
-            stoUI.showToast('Failed to delete profile', 'error');
-        }
-    }
-
-    // Settings Menu Management
-    toggleSettingsMenu() {
-        const settingsBtn = document.getElementById('settingsBtn');
-        if (settingsBtn) {
-            const dropdown = settingsBtn.closest('.dropdown');
-        if (dropdown) {
-            dropdown.classList.toggle('active');
+            // Refresh alias manager if open
+            if (
+              window.stoAliases &&
+              typeof window.stoAliases.renderAliasList === 'function'
+            ) {
+              window.stoAliases.renderAliasList()
             }
+          } catch (error) {
+            stoUI.showToast(
+              'Failed to import aliases: ' + error.message,
+              'error'
+            )
+          }
         }
+        reader.readAsText(file)
+      }
+    }
+    input.click()
+  }
+
+  exportAliases() {
+    const profile = app.getCurrentProfile()
+    if (!profile) {
+      stoUI.showToast('No profile selected to export', 'warning')
+      return
     }
 
-    closeSettingsMenu() {
-        const settingsBtn = document.getElementById('settingsBtn');
-        if (settingsBtn) {
-            const dropdown = settingsBtn.closest('.dropdown');
-        if (dropdown) {
-            dropdown.classList.remove('active');
-            }
-        }
+    if (!profile.aliases || Object.keys(profile.aliases).length === 0) {
+      stoUI.showToast('No aliases to export', 'warning')
+      return
     }
 
-    // Keybinds Menu Management
-    toggleKeybindsMenu() {
-        // Close other dropdowns first
-        this.closeSettingsMenu();
-        this.closeAliasesMenu();
-        
-        const keybindsBtn = document.getElementById('keybindsBtn');
-        if (keybindsBtn) {
-            const dropdown = keybindsBtn.closest('.dropdown');
-            if (dropdown) {
-                dropdown.classList.toggle('active');
-            }
-        }
+    stoExport.exportAliases(profile)
+  }
+
+  async confirmResetApp() {
+    const confirmed = await stoUI.confirm(
+      'Are you sure you want to reset the application?\n\nThis will delete all profiles, keybinds, and settings. This action cannot be undone.',
+      'Reset Application',
+      'danger'
+    )
+
+    if (confirmed) {
+      this.resetApplication()
+    }
+  }
+
+  resetApplication() {
+    try {
+      // Clear all data
+      stoStorage.clearAllData()
+
+      // Reinitialize app with empty data instead of reloading
+      app.currentProfile = null
+      app.selectedKey = null
+      app.setModified(false)
+
+      // Re-render UI with empty state
+      app.renderProfiles()
+      app.renderKeyGrid()
+      app.renderCommandChain()
+      app.updateProfileInfo()
+
+      stoUI.showToast(
+        'Application reset successfully. All data cleared.',
+        'success'
+      )
+    } catch (error) {
+      stoUI.showToast('Failed to reset application: ' + error.message, 'error')
+    }
+  }
+
+  // Load default/demo data
+  loadDefaultData() {
+    try {
+      if (stoStorage.loadDefaultData()) {
+        // Reinitialize app with default data
+        const data = stoStorage.getAllData()
+        app.currentProfile = data.currentProfile
+        app.selectedKey = null
+        app.setModified(false)
+
+        // Re-render UI with default data
+        app.renderProfiles()
+        app.renderKeyGrid()
+        app.renderCommandChain()
+        app.updateProfileInfo()
+
+        stoUI.showToast('Default demo data loaded successfully', 'success')
+      } else {
+        stoUI.showToast('Failed to load default data', 'error')
+      }
+    } catch (error) {
+      stoUI.showToast('Failed to load default data: ' + error.message, 'error')
+    }
+  }
+
+  // Profile Statistics and Analysis
+  getProfileAnalysis(profile) {
+    const analysis = {
+      keyCount: Object.keys(profile.keys).length,
+      commandCount: 0,
+      aliasCount: Object.keys(profile.aliases || {}).length,
+      commandTypes: {},
+      keyTypes: {
+        function: 0,
+        number: 0,
+        letter: 0,
+        special: 0,
+        modifier: 0,
+      },
+      complexity: 'Simple',
+      recommendations: [],
     }
 
-    closeKeybindsMenu() {
-        const keybindsBtn = document.getElementById('keybindsBtn');
-        if (keybindsBtn) {
-            const dropdown = keybindsBtn.closest('.dropdown');
-            if (dropdown) {
-                dropdown.classList.remove('active');
-            }
-        }
+    // Analyze keys and commands
+    Object.entries(profile.keys).forEach(([key, commands]) => {
+      analysis.commandCount += commands.length
+
+      // Categorize key types
+      if (/^F\d+$/.test(key)) {
+        analysis.keyTypes.function++
+      } else if (/^\d+$/.test(key)) {
+        analysis.keyTypes.number++
+      } else if (/^[A-Z]$/.test(key)) {
+        analysis.keyTypes.letter++
+      } else if (key.includes('+')) {
+        analysis.keyTypes.modifier++
+      } else {
+        analysis.keyTypes.special++
+      }
+
+      // Count command types
+      commands.forEach((command) => {
+        analysis.commandTypes[command.type] =
+          (analysis.commandTypes[command.type] || 0) + 1
+      })
+    })
+
+    // Determine complexity
+    if (analysis.commandCount > 50) {
+      analysis.complexity = 'Complex'
+    } else if (analysis.commandCount > 20) {
+      analysis.complexity = 'Moderate'
     }
 
-    // Aliases Menu Management
-    toggleAliasesMenu() {
-        // Close other dropdowns first
-        this.closeSettingsMenu();
-        this.closeKeybindsMenu();
-        
-        const aliasesBtn = document.getElementById('aliasesBtn');
-        if (aliasesBtn) {
-            const dropdown = aliasesBtn.closest('.dropdown');
-            if (dropdown) {
-                dropdown.classList.toggle('active');
-            }
-        }
+    // Generate recommendations
+    this.generateRecommendations(analysis, profile)
+
+    return analysis
+  }
+
+  generateRecommendations(analysis, profile) {
+    const recommendations = []
+
+    // Check for basic combat setup
+    if (!analysis.commandTypes.targeting && !analysis.commandTypes.combat) {
+      recommendations.push({
+        type: 'setup',
+        title: 'Add Basic Combat Commands',
+        description:
+          'Consider adding targeting and firing commands for basic combat functionality.',
+        priority: 'high',
+      })
     }
 
-    closeAliasesMenu() {
-        const aliasesBtn = document.getElementById('aliasesBtn');
-        if (aliasesBtn) {
-            const dropdown = aliasesBtn.closest('.dropdown');
-            if (dropdown) {
-                dropdown.classList.remove('active');
-            }
-        }
+    // Check for defensive abilities
+    if (!analysis.commandTypes.power) {
+      recommendations.push({
+        type: 'defensive',
+        title: 'Add Defensive Abilities',
+        description:
+          'Add shield management commands like shield distribution and shield routing.',
+        priority: 'medium',
+      })
     }
 
-    // Import/Export Operations
-    importKeybinds() {
-        const input = document.getElementById('fileInput');
-        if (input) {
-            input.accept = '.txt';
-            input.onchange = (e) => {
-                const file = e.target.files[0];
-                if (file) {
-                    const reader = new FileReader();
-                    reader.onload = (e) => {
-                        try {
-                            stoKeybinds.importKeybindFile(e.target.result);
-                        } catch (error) {
-                            stoUI.showToast('Failed to import keybind file: ' + error.message, 'error');
-                        }
-                    };
-                    reader.readAsText(file);
-                }
-                // Reset file input
-                e.target.value = '';
-            };
-            input.click();
-        }
+    // Check for key efficiency
+    if (analysis.keyTypes.modifier < 3 && analysis.keyCount > 10) {
+      recommendations.push({
+        type: 'efficiency',
+        title: 'Use Modifier Keys',
+        description:
+          'Consider using Ctrl+, Alt+, and Shift+ combinations to access more commands efficiently.',
+        priority: 'low',
+      })
     }
 
-    exportKeybinds() {
-        const profile = app.getCurrentProfile();
-        if (!profile) {
-            stoUI.showToast('No profile selected to export', 'warning');
-            return;
-        }
-
-        if (!profile.keys || Object.keys(profile.keys).length === 0) {
-            stoUI.showToast('No keybinds to export', 'warning');
-            return;
-        }
-
-        stoExport.exportSTOKeybindFile(profile);
+    // Check for aliases
+    if (analysis.aliasCount === 0 && analysis.commandCount > 15) {
+      recommendations.push({
+        type: 'organization',
+        title: 'Create Command Aliases',
+        description:
+          'Use aliases to group related commands and simplify complex sequences.',
+        priority: 'medium',
+      })
     }
 
-    importAliases() {
-        const input = document.createElement('input');
-        input.type = 'file';
-        input.accept = '.txt';
-        input.onchange = (e) => {
-            const file = e.target.files[0];
-            if (file) {
-                const reader = new FileReader();
-                reader.onload = (e) => {
-                    try {
-                        const content = e.target.result;
-                        stoKeybinds.importAliasFile(content);
-                        
-                        // Refresh alias manager if open
-                        if (window.stoAliases && typeof window.stoAliases.renderAliasList === 'function') {
-                            window.stoAliases.renderAliasList();
-                        }
-                    } catch (error) {
-                        stoUI.showToast('Failed to import aliases: ' + error.message, 'error');
-                    }
-                };
-                reader.readAsText(file);
-            }
-        };
-        input.click();
+    // Check for space vs ground mode appropriateness
+    const spaceCommands = ['FireAll', 'target_nearest_enemy', '+fullimpulse']
+    const hasSpaceCommands = Object.values(profile.keys).some((commands) =>
+      commands.some((cmd) =>
+        spaceCommands.some((sc) => cmd.command.includes(sc))
+      )
+    )
+
+    if (profile.mode === 'ground' && hasSpaceCommands) {
+      recommendations.push({
+        type: 'mode',
+        title: 'Check Profile Mode',
+        description:
+          'This profile contains space combat commands but is set to ground mode.',
+        priority: 'medium',
+      })
     }
 
-    exportAliases() {
-        const profile = app.getCurrentProfile();
-        if (!profile) {
-            stoUI.showToast('No profile selected to export', 'warning');
-            return;
-        }
+    analysis.recommendations = recommendations
+  }
 
-        if (!profile.aliases || Object.keys(profile.aliases).length === 0) {
-            stoUI.showToast('No aliases to export', 'warning');
-            return;
-        }
-
-        stoExport.exportAliases(profile);
-    }
-
-    async confirmResetApp() {
-        const confirmed = await stoUI.confirm(
-            'Are you sure you want to reset the application?\n\nThis will delete all profiles, keybinds, and settings. This action cannot be undone.',
-            'Reset Application',
-            'danger'
-        );
-
-        if (confirmed) {
-            this.resetApplication();
-        }
-    }
-
-    resetApplication() {
-        try {
-            // Clear all data
-            stoStorage.clearAllData();
-            
-            // Reinitialize app with empty data instead of reloading
-            app.currentProfile = null;
-            app.selectedKey = null;
-            app.setModified(false);
-            
-            // Re-render UI with empty state
-            app.renderProfiles();
-            app.renderKeyGrid();
-            app.renderCommandChain();
-            app.updateProfileInfo();
-            
-            stoUI.showToast('Application reset successfully. All data cleared.', 'success');
-        } catch (error) {
-            stoUI.showToast('Failed to reset application: ' + error.message, 'error');
-        }
-    }
-
-    // Load default/demo data
-    loadDefaultData() {
-        try {
-            if (stoStorage.loadDefaultData()) {
-                // Reinitialize app with default data
-                const data = stoStorage.getAllData();
-                app.currentProfile = data.currentProfile;
-                app.selectedKey = null;
-                app.setModified(false);
-                
-                // Re-render UI with default data
-                app.renderProfiles();
-                app.renderKeyGrid();
-                app.renderCommandChain();
-                app.updateProfileInfo();
-                
-                stoUI.showToast('Default demo data loaded successfully', 'success');
-            } else {
-                stoUI.showToast('Failed to load default data', 'error');
-            }
-        } catch (error) {
-            stoUI.showToast('Failed to load default data: ' + error.message, 'error');
-        }
-    }
-
-    // Profile Statistics and Analysis
-    getProfileAnalysis(profile) {
-        const analysis = {
-            keyCount: Object.keys(profile.keys).length,
-            commandCount: 0,
-            aliasCount: Object.keys(profile.aliases || {}).length,
-            commandTypes: {},
-            keyTypes: {
-                function: 0,
-                number: 0,
-                letter: 0,
-                special: 0,
-                modifier: 0
+  // Profile Templates
+  getProfileTemplates() {
+    return {
+      basic_space: {
+        name: 'Basic Space Combat',
+        description: 'Essential space combat keybinds for new players',
+        mode: 'space',
+        keys: {
+          Space: [
+            {
+              command: 'target_nearest_enemy',
+              type: 'targeting',
+              icon: '🎯',
+              text: 'Target nearest enemy',
             },
-            complexity: 'Simple',
-            recommendations: []
-        };
-
-        // Analyze keys and commands
-        Object.entries(profile.keys).forEach(([key, commands]) => {
-            analysis.commandCount += commands.length;
-
-            // Categorize key types
-            if (/^F\d+$/.test(key)) {
-                analysis.keyTypes.function++;
-            } else if (/^\d+$/.test(key)) {
-                analysis.keyTypes.number++;
-            } else if (/^[A-Z]$/.test(key)) {
-                analysis.keyTypes.letter++;
-            } else if (key.includes('+')) {
-                analysis.keyTypes.modifier++;
-            } else {
-                analysis.keyTypes.special++;
-            }
-
-            // Count command types
-            commands.forEach(command => {
-                analysis.commandTypes[command.type] = (analysis.commandTypes[command.type] || 0) + 1;
-            });
-        });
-
-        // Determine complexity
-        if (analysis.commandCount > 50) {
-            analysis.complexity = 'Complex';
-        } else if (analysis.commandCount > 20) {
-            analysis.complexity = 'Moderate';
-        }
-
-        // Generate recommendations
-        this.generateRecommendations(analysis, profile);
-
-        return analysis;
-    }
-
-    generateRecommendations(analysis, profile) {
-        const recommendations = [];
-
-        // Check for basic combat setup
-        if (!analysis.commandTypes.targeting && !analysis.commandTypes.combat) {
-            recommendations.push({
-                type: 'setup',
-                title: 'Add Basic Combat Commands',
-                description: 'Consider adding targeting and firing commands for basic combat functionality.',
-                priority: 'high'
-            });
-        }
-
-        // Check for defensive abilities
-        if (!analysis.commandTypes.power) {
-            recommendations.push({
-                type: 'defensive',
-                title: 'Add Defensive Abilities',
-                description: 'Add shield management commands like shield distribution and shield routing.',
-                priority: 'medium'
-            });
-        }
-
-        // Check for key efficiency
-        if (analysis.keyTypes.modifier < 3 && analysis.keyCount > 10) {
-            recommendations.push({
-                type: 'efficiency',
-                title: 'Use Modifier Keys',
-                description: 'Consider using Ctrl+, Alt+, and Shift+ combinations to access more commands efficiently.',
-                priority: 'low'
-            });
-        }
-
-        // Check for aliases
-        if (analysis.aliasCount === 0 && analysis.commandCount > 15) {
-            recommendations.push({
-                type: 'organization',
-                title: 'Create Command Aliases',
-                description: 'Use aliases to group related commands and simplify complex sequences.',
-                priority: 'medium'
-            });
-        }
-
-        // Check for space vs ground mode appropriateness
-        const spaceCommands = ['FireAll', 'target_nearest_enemy', '+fullimpulse'];
-        const hasSpaceCommands = Object.values(profile.keys).some(commands =>
-            commands.some(cmd => spaceCommands.some(sc => cmd.command.includes(sc)))
-        );
-
-        if (profile.mode === 'ground' && hasSpaceCommands) {
-            recommendations.push({
-                type: 'mode',
-                title: 'Check Profile Mode',
-                description: 'This profile contains space combat commands but is set to ground mode.',
-                priority: 'medium'
-            });
-        }
-
-        analysis.recommendations = recommendations;
-    }
-
-    // Profile Templates
-    getProfileTemplates() {
-        return {
-            basic_space: {
-                name: 'Basic Space Combat',
-                description: 'Essential space combat keybinds for new players',
-                mode: 'space',
-                keys: {
-                    'Space': [
-                        { command: 'target_nearest_enemy', type: 'targeting', icon: '🎯', text: 'Target nearest enemy' },
-                        { command: 'FireAll', type: 'combat', icon: '🔥', text: 'Fire all weapons' }
-                    ],
-                    'Tab': [
-                        { command: 'target_nearest_friend', type: 'targeting', icon: '🤝', text: 'Target nearest friend' }
-                    ],
-                    'F1': [
-                        { command: 'target_self', type: 'targeting', icon: '👤', text: 'Target self' },
-                        { command: '+power_exec Distribute_Shields', type: 'power', icon: '🛡️', text: 'Distribute shields' }
-                    ]
-                },
-                aliases: {}
+            {
+              command: 'FireAll',
+              type: 'combat',
+              icon: '🔥',
+              text: 'Fire all weapons',
             },
-            
-            advanced_tactical: {
-                name: 'Advanced Tactical',
-                description: 'Comprehensive DPS-focused space build',
-                mode: 'space',
-                keys: {
-                    'Space': [
-                        { command: 'target_nearest_enemy', type: 'targeting', icon: '🎯', text: 'Target nearest enemy' },
-                        { command: '+STOTrayExecByTray 0 0', type: 'tray', icon: '⚡', text: 'Execute Tray 1 Slot 1' },
-                        { command: 'FireAll', type: 'combat', icon: '🔥', text: 'Fire all weapons' }
-                    ],
-                    '1': [
-                        { command: '+STOTrayExecByTray 1 0', type: 'tray', icon: '⚡', text: 'Execute Tray 2 Slot 1' }
-                    ],
-                    '2': [
-                        { command: '+STOTrayExecByTray 1 1', type: 'tray', icon: '⚡', text: 'Execute Tray 2 Slot 2' }
-                    ],
-                    'F1': [
-                        { command: 'target_self', type: 'targeting', icon: '👤', text: 'Target self' },
-                    ],
-                    'F2': [
-                        { command: 'target_self', type: 'targeting', icon: '👤', text: 'Target self' },
-                    ]
-                },
-                aliases: {
-                    'AlphaStrike': {
-                        name: 'AlphaStrike',
-                        commands: 'target_nearest_enemy $$ +STOTrayExecByTray 0 0 $$ +STOTrayExecByTray 0 1',
-                        description: 'Full alpha strike sequence'
-                    }
-                }
+          ],
+          Tab: [
+            {
+              command: 'target_nearest_friend',
+              type: 'targeting',
+              icon: '🤝',
+              text: 'Target nearest friend',
             },
+          ],
+          F1: [
+            {
+              command: 'target_self',
+              type: 'targeting',
+              icon: '👤',
+              text: 'Target self',
+            },
+            {
+              command: '+power_exec Distribute_Shields',
+              type: 'power',
+              icon: '🛡️',
+              text: 'Distribute shields',
+            },
+          ],
+        },
+        aliases: {},
+      },
 
-            ground_combat: {
-                name: 'Ground Combat',
-                description: 'Ground combat and away team keybinds',
-                mode: 'ground',
-                keys: {
-                    'Space': [
-                        { command: 'target_nearest_enemy', type: 'targeting', icon: '🎯', text: 'Target nearest enemy' },
-                        { command: '+STOTrayExecByTray 0 0', type: 'tray', icon: '⚡', text: 'Primary attack' }
-                    ],
-                    '1': [
-                        { command: '+STOTrayExecByTray 0 1', type: 'tray', icon: '⚡', text: 'Secondary attack' }
-                    ],
-                    '2': [
-                        { command: '+STOTrayExecByTray 0 2', type: 'tray', icon: '⚡', text: 'Kit ability 1' }
-                    ],
-                    'F1': [
-                        { command: 'target_self', type: 'targeting', icon: '👤', text: 'Target self' },
-                        { command: '+STOTrayExecByTray 1 0', type: 'tray', icon: '💊', text: 'Heal self' }
-                    ]
-                },
-                aliases: {}
-            }
-        };
+      advanced_tactical: {
+        name: 'Advanced Tactical',
+        description: 'Comprehensive DPS-focused space build',
+        mode: 'space',
+        keys: {
+          Space: [
+            {
+              command: 'target_nearest_enemy',
+              type: 'targeting',
+              icon: '🎯',
+              text: 'Target nearest enemy',
+            },
+            {
+              command: '+STOTrayExecByTray 0 0',
+              type: 'tray',
+              icon: '⚡',
+              text: 'Execute Tray 1 Slot 1',
+            },
+            {
+              command: 'FireAll',
+              type: 'combat',
+              icon: '🔥',
+              text: 'Fire all weapons',
+            },
+          ],
+          1: [
+            {
+              command: '+STOTrayExecByTray 1 0',
+              type: 'tray',
+              icon: '⚡',
+              text: 'Execute Tray 2 Slot 1',
+            },
+          ],
+          2: [
+            {
+              command: '+STOTrayExecByTray 1 1',
+              type: 'tray',
+              icon: '⚡',
+              text: 'Execute Tray 2 Slot 2',
+            },
+          ],
+          F1: [
+            {
+              command: 'target_self',
+              type: 'targeting',
+              icon: '👤',
+              text: 'Target self',
+            },
+          ],
+          F2: [
+            {
+              command: 'target_self',
+              type: 'targeting',
+              icon: '👤',
+              text: 'Target self',
+            },
+          ],
+        },
+        aliases: {
+          AlphaStrike: {
+            name: 'AlphaStrike',
+            commands:
+              'target_nearest_enemy $$ +STOTrayExecByTray 0 0 $$ +STOTrayExecByTray 0 1',
+            description: 'Full alpha strike sequence',
+          },
+        },
+      },
+
+      ground_combat: {
+        name: 'Ground Combat',
+        description: 'Ground combat and away team keybinds',
+        mode: 'ground',
+        keys: {
+          Space: [
+            {
+              command: 'target_nearest_enemy',
+              type: 'targeting',
+              icon: '🎯',
+              text: 'Target nearest enemy',
+            },
+            {
+              command: '+STOTrayExecByTray 0 0',
+              type: 'tray',
+              icon: '⚡',
+              text: 'Primary attack',
+            },
+          ],
+          1: [
+            {
+              command: '+STOTrayExecByTray 0 1',
+              type: 'tray',
+              icon: '⚡',
+              text: 'Secondary attack',
+            },
+          ],
+          2: [
+            {
+              command: '+STOTrayExecByTray 0 2',
+              type: 'tray',
+              icon: '⚡',
+              text: 'Kit ability 1',
+            },
+          ],
+          F1: [
+            {
+              command: 'target_self',
+              type: 'targeting',
+              icon: '👤',
+              text: 'Target self',
+            },
+            {
+              command: '+STOTrayExecByTray 1 0',
+              type: 'tray',
+              icon: '💊',
+              text: 'Heal self',
+            },
+          ],
+        },
+        aliases: {},
+      },
+    }
+  }
+
+  createProfileFromTemplate(templateId) {
+    const templates = this.getProfileTemplates()
+    const template = templates[templateId]
+
+    if (!template) {
+      stoUI.showToast('Template not found', 'error')
+      return
     }
 
-    createProfileFromTemplate(templateId) {
-        const templates = this.getProfileTemplates();
-        const template = templates[templateId];
-        
-        if (!template) {
-            stoUI.showToast('Template not found', 'error');
-            return;
-        }
+    // Generate unique profile name
+    let profileName = template.name
+    let counter = 1
+    const data = stoStorage.getAllData()
 
-        // Generate unique profile name
-        let profileName = template.name;
-        let counter = 1;
-        const data = stoStorage.getAllData();
-        
-        while (Object.values(data.profiles).some(p => p.name === profileName)) {
-            profileName = `${template.name} ${counter}`;
-            counter++;
-        }
-
-        // Create profile
-        const profileId = app.generateProfileId(profileName);
-        const profile = {
-            ...template,
-            name: profileName,
-            created: new Date().toISOString(),
-            lastModified: new Date().toISOString()
-        };
-
-        // Add IDs to commands
-        Object.values(profile.keys).forEach(commands => {
-            commands.forEach(command => {
-                command.id = app.generateCommandId();
-            });
-        });
-
-        if (stoStorage.saveProfile(profileId, profile)) {
-            app.switchProfile(profileId);
-            app.renderProfiles();
-            stoUI.showToast(`Profile "${profileName}" created from template`, 'success');
-        } else {
-            stoUI.showToast('Failed to create profile from template', 'error');
-        }
+    while (Object.values(data.profiles).some((p) => p.name === profileName)) {
+      profileName = `${template.name} ${counter}`
+      counter++
     }
 
-    // Profile Export/Import
-    exportProfile(profileId) {
-        const profile = stoStorage.getProfile(profileId);
-        if (!profile) {
-            stoUI.showToast('Profile not found', 'error');
-            return;
-        }
-
-        const exportData = {
-            version: '1.0.0',
-            exported: new Date().toISOString(),
-            profile: profile
-        };
-
-        const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `${profile.name.replace(/[^a-zA-Z0-9]/g, '_')}_profile.json`;
-        a.click();
-        URL.revokeObjectURL(url);
-
-        stoUI.showToast(`Profile "${profile.name}" exported`, 'success');
+    // Create profile
+    const profileId = app.generateProfileId(profileName)
+    const profile = {
+      ...template,
+      name: profileName,
+      created: new Date().toISOString(),
+      lastModified: new Date().toISOString(),
     }
 
-    async importProfile(jsonData) {
-        try {
-            const data = JSON.parse(jsonData);
-            
-            if (!data.profile) {
-                throw new Error('Invalid profile file format');
-            }
+    // Add IDs to commands
+    Object.values(profile.keys).forEach((commands) => {
+      commands.forEach((command) => {
+        command.id = app.generateCommandId()
+      })
+    })
 
-            const profile = data.profile;
-            
-            // Generate unique profile name
-            let profileName = profile.name;
-            let counter = 1;
-            const existingData = stoStorage.getAllData();
-            
-            while (Object.values(existingData.profiles).some(p => p.name === profileName)) {
-                profileName = `${profile.name} (${counter})`;
-                counter++;
-            }
-
-            profile.name = profileName;
-            profile.imported = new Date().toISOString();
-            profile.lastModified = new Date().toISOString();
-
-            const profileId = app.generateProfileId(profileName);
-            
-            if (stoStorage.saveProfile(profileId, profile)) {
-                app.renderProfiles();
-                stoUI.showToast(`Profile "${profileName}" imported successfully`, 'success');
-                return true;
-            } else {
-                throw new Error('Failed to save imported profile');
-            }
-        } catch (error) {
-            stoUI.showToast('Failed to import profile: ' + error.message, 'error');
-            return false;
-        }
+    if (stoStorage.saveProfile(profileId, profile)) {
+      app.switchProfile(profileId)
+      app.renderProfiles()
+      stoUI.showToast(
+        `Profile "${profileName}" created from template`,
+        'success'
+      )
+    } else {
+      stoUI.showToast('Failed to create profile from template', 'error')
     }
+  }
+
+  // Profile Export/Import
+  exportProfile(profileId) {
+    const profile = stoStorage.getProfile(profileId)
+    if (!profile) {
+      stoUI.showToast('Profile not found', 'error')
+      return
+    }
+
+    const exportData = {
+      version: '1.0.0',
+      exported: new Date().toISOString(),
+      profile: profile,
+    }
+
+    const blob = new Blob([JSON.stringify(exportData, null, 2)], {
+      type: 'application/json',
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${profile.name.replace(/[^a-zA-Z0-9]/g, '_')}_profile.json`
+    a.click()
+    URL.revokeObjectURL(url)
+
+    stoUI.showToast(`Profile "${profile.name}" exported`, 'success')
+  }
+
+  async importProfile(jsonData) {
+    try {
+      const data = JSON.parse(jsonData)
+
+      if (!data.profile) {
+        throw new Error('Invalid profile file format')
+      }
+
+      const profile = data.profile
+
+      // Generate unique profile name
+      let profileName = profile.name
+      let counter = 1
+      const existingData = stoStorage.getAllData()
+
+      while (
+        Object.values(existingData.profiles).some((p) => p.name === profileName)
+      ) {
+        profileName = `${profile.name} (${counter})`
+        counter++
+      }
+
+      profile.name = profileName
+      profile.imported = new Date().toISOString()
+      profile.lastModified = new Date().toISOString()
+
+      const profileId = app.generateProfileId(profileName)
+
+      if (stoStorage.saveProfile(profileId, profile)) {
+        app.renderProfiles()
+        stoUI.showToast(
+          `Profile "${profileName}" imported successfully`,
+          'success'
+        )
+        return true
+      } else {
+        throw new Error('Failed to save imported profile')
+      }
+    } catch (error) {
+      stoUI.showToast('Failed to import profile: ' + error.message, 'error')
+      return false
+    }
+  }
 }
 
 // Global profile manager instance

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -2,394 +2,401 @@
 // Handles localStorage persistence and data management
 
 export default class STOStorage {
-    constructor() {
-        this.storageKey = 'sto_keybind_manager';
-        this.backupKey = 'sto_keybind_manager_backup';
-        this.settingsKey = 'sto_keybind_settings';
-        this.version = '1.0.0';
-        
-        this.init();
+  constructor() {
+    this.storageKey = 'sto_keybind_manager'
+    this.backupKey = 'sto_keybind_manager_backup'
+    this.settingsKey = 'sto_keybind_settings'
+    this.version = '1.0.0'
+
+    this.init()
+  }
+
+  init() {
+    // Check if we need to migrate old data
+    this.migrateData()
+
+    // Ensure we have basic structure
+    this.ensureStorageStructure()
+  }
+
+  // Get all data from storage
+  getAllData() {
+    try {
+      const data = localStorage.getItem(this.storageKey)
+      const resetFlag = localStorage.getItem('sto_app_reset')
+
+      if (!data) {
+        // If reset flag exists, return empty structure instead of default data
+        if (resetFlag) {
+          localStorage.removeItem('sto_app_reset')
+          return this.getEmptyData()
+        }
+        return this.getDefaultData()
+      }
+
+      const parsed = JSON.parse(data)
+
+      // Validate data structure
+      if (!this.isValidDataStructure(parsed)) {
+        return this.getDefaultData()
+      }
+
+      return parsed
+    } catch (error) {
+      console.error('Error loading data from storage:', error)
+      return this.getDefaultData()
+    }
+  }
+
+  // Save all data to storage
+  saveAllData(data) {
+    try {
+      // Create backup of current data
+      this.createBackup()
+
+      // Add metadata
+      const dataWithMeta = {
+        ...data,
+        version: this.version,
+        lastModified: new Date().toISOString(),
+        lastBackup: new Date().toISOString(),
+      }
+
+      localStorage.setItem(this.storageKey, JSON.stringify(dataWithMeta))
+      return true
+    } catch (error) {
+      console.error('Error saving data to storage:', error)
+      return false
+    }
+  }
+
+  // Get specific profile
+  getProfile(profileId) {
+    const data = this.getAllData()
+    return data.profiles[profileId] || null
+  }
+
+  // Save specific profile
+  saveProfile(profileId, profile) {
+    const data = this.getAllData()
+    data.profiles[profileId] = {
+      ...profile,
+      lastModified: new Date().toISOString(),
+    }
+    return this.saveAllData(data)
+  }
+
+  // Delete profile
+  deleteProfile(profileId) {
+    const data = this.getAllData()
+    if (data.profiles[profileId]) {
+      delete data.profiles[profileId]
+
+      // If this was the current profile, switch to first available
+      if (data.currentProfile === profileId) {
+        const remainingProfiles = Object.keys(data.profiles)
+        data.currentProfile =
+          remainingProfiles.length > 0 ? remainingProfiles[0] : null
+      }
+
+      return this.saveAllData(data)
+    }
+    return false
+  }
+
+  // Get application settings
+  getSettings() {
+    try {
+      const settings = localStorage.getItem(this.settingsKey)
+      return settings ? JSON.parse(settings) : this.getDefaultSettings()
+    } catch (error) {
+      console.error('Error loading settings:', error)
+      return this.getDefaultSettings()
+    }
+  }
+
+  // Save application settings
+  saveSettings(settings) {
+    try {
+      localStorage.setItem(this.settingsKey, JSON.stringify(settings))
+      return true
+    } catch (error) {
+      console.error('Error saving settings:', error)
+      return false
+    }
+  }
+
+  // Create backup of current data
+  createBackup() {
+    try {
+      const currentData = localStorage.getItem(this.storageKey)
+      if (currentData) {
+        const backup = {
+          data: currentData,
+          timestamp: new Date().toISOString(),
+          version: this.version,
+        }
+        localStorage.setItem(this.backupKey, JSON.stringify(backup))
+      }
+    } catch (error) {
+      console.error('Error creating backup:', error)
+    }
+  }
+
+  // Restore from backup
+  restoreFromBackup() {
+    try {
+      const backup = localStorage.getItem(this.backupKey)
+      if (backup) {
+        const parsed = JSON.parse(backup)
+        localStorage.setItem(this.storageKey, parsed.data)
+        return true
+      }
+    } catch (error) {
+      console.error('Error restoring from backup:', error)
+    }
+    return false
+  }
+
+  // Export data as JSON string
+  exportData() {
+    const data = this.getAllData()
+    return JSON.stringify(data, null, 2)
+  }
+
+  // Import data from JSON string
+  importData(jsonString) {
+    try {
+      const data = JSON.parse(jsonString)
+
+      if (!this.isValidDataStructure(data)) {
+        // Invalid data structure is an expected validation result, not an error
+        return false
+      }
+
+      return this.saveAllData(data)
+    } catch (error) {
+      // Only log if it's not an expected JSON parse error from tests
+      if (!(error instanceof SyntaxError && jsonString.includes('invalid'))) {
+        console.error('Error importing data:', error)
+      }
+      return false
+    }
+  }
+
+  // Clear all data (reset application)
+  clearAllData() {
+    try {
+      localStorage.removeItem(this.storageKey)
+      localStorage.removeItem(this.backupKey)
+      localStorage.removeItem(this.settingsKey)
+
+      // Set reset flag to prevent loading default data on next startup
+      localStorage.setItem('sto_app_reset', 'true')
+
+      return true
+    } catch (error) {
+      console.error('Error clearing data:', error)
+      return false
+    }
+  }
+
+  // Get storage usage info
+  getStorageInfo() {
+    try {
+      const dataSize = localStorage.getItem(this.storageKey)?.length || 0
+      const backupSize = localStorage.getItem(this.backupKey)?.length || 0
+      const settingsSize = localStorage.getItem(this.settingsKey)?.length || 0
+
+      return {
+        totalSize: dataSize + backupSize + settingsSize,
+        dataSize,
+        backupSize,
+        settingsSize,
+        available: this.getAvailableStorage(),
+      }
+    } catch (error) {
+      console.error('Error getting storage info:', error)
+      return null
+    }
+  }
+
+  // Private methods
+
+  getDefaultData() {
+    return {
+      version: this.version,
+      created: new Date().toISOString(),
+      lastModified: new Date().toISOString(),
+      currentProfile: 'default_space',
+      profiles: {
+        default_space: { ...STO_DATA.defaultProfiles.default_space },
+        tactical_space: { ...STO_DATA.defaultProfiles.tactical_space },
+      },
+      globalAliases: {},
+      settings: this.getDefaultSettings(),
+    }
+  }
+
+  getEmptyData() {
+    return {
+      version: this.version,
+      created: new Date().toISOString(),
+      lastModified: new Date().toISOString(),
+      currentProfile: null,
+      profiles: {},
+      globalAliases: {},
+      settings: this.getDefaultSettings(),
+    }
+  }
+
+  getDefaultSettings() {
+    return {
+      theme: 'default',
+      autoSave: true,
+      showTooltips: true,
+      confirmDeletes: true,
+      maxUndoSteps: 50,
+      defaultMode: 'space',
+      compactView: false,
+    }
+  }
+
+  isValidDataStructure(data) {
+    if (!data || typeof data !== 'object') return false
+
+    // Check required properties
+    const required = ['profiles', 'currentProfile']
+    for (const prop of required) {
+      if (!(prop in data)) return false
     }
 
-    init() {
-        // Check if we need to migrate old data
-        this.migrateData();
-        
-        // Ensure we have basic structure
-        this.ensureStorageStructure();
+    // Check profiles structure
+    if (typeof data.profiles !== 'object') return false
+
+    // Validate each profile
+    for (const [profileId, profile] of Object.entries(data.profiles)) {
+      if (!this.isValidProfile(profile)) {
+        // Invalid profile structure is an expected validation result, not something to log
+        return false
+      }
     }
 
-    // Get all data from storage
-    getAllData() {
+    return true
+  }
+
+  isValidProfile(profile) {
+    if (!profile || typeof profile !== 'object') return false
+
+    // New format with builds structure
+    if (profile.builds) {
+      if (!profile.name || typeof profile.builds !== 'object') return false
+
+      // Check if at least one build exists
+      const builds = profile.builds
+      if (!builds.space && !builds.ground) return false
+
+      // Validate build structure
+      for (const [env, build] of Object.entries(builds)) {
+        if (env === 'space' || env === 'ground') {
+          if (!build || typeof build !== 'object') return false
+          if (!build.keys || typeof build.keys !== 'object') return false
+        }
+      }
+
+      return true
+    }
+
+    // Old format - maintain backward compatibility
+    const required = ['name', 'mode', 'keys']
+    for (const prop of required) {
+      if (!(prop in profile)) return false
+    }
+
+    if (typeof profile.keys !== 'object') return false
+
+    return true
+  }
+
+  ensureStorageStructure() {
+    const data = this.getAllData()
+
+    // Ensure all required properties exist
+    if (!data.globalAliases) data.globalAliases = {}
+    if (!data.settings) data.settings = this.getDefaultSettings()
+
+    // Only ensure we have at least one profile if this isn't a post-reset state
+    if (
+      Object.keys(data.profiles).length === 0 &&
+      data.currentProfile !== null
+    ) {
+      data.profiles = {
+        default_space: { ...STO_DATA.defaultProfiles.default_space },
+      }
+      data.currentProfile = 'default_space'
+    }
+
+    // Ensure current profile exists (if we have profiles)
+    if (
+      Object.keys(data.profiles).length > 0 &&
+      !data.profiles[data.currentProfile]
+    ) {
+      data.currentProfile = Object.keys(data.profiles)[0]
+    }
+
+    this.saveAllData(data)
+  }
+
+  migrateData() {
+    // Handle data migration for future versions
+    const data = this.getAllData()
+
+    if (data.version !== this.version) {
+      console.log(`Migrating data from ${data.version} to ${this.version}`)
+
+      // Add migration logic here for future versions
+
+      data.version = this.version
+      this.saveAllData(data)
+    }
+  }
+
+  getAvailableStorage() {
+    try {
+      // Test available localStorage space
+      let testKey = 'storage_test'
+      let testData = '0'
+      let testSize = 0
+
+      // Binary search for max storage
+      let low = 0
+      let high = 10 * 1024 * 1024 // 10MB max test
+
+      while (low <= high) {
+        let mid = Math.floor((low + high) / 2)
+        testData = '0'.repeat(mid)
+
         try {
-            const data = localStorage.getItem(this.storageKey);
-            const resetFlag = localStorage.getItem('sto_app_reset');
-            
-            if (!data) {
-                // If reset flag exists, return empty structure instead of default data
-                if (resetFlag) {
-                    localStorage.removeItem('sto_app_reset');
-                    return this.getEmptyData();
-                }
-                return this.getDefaultData();
-            }
-            
-            const parsed = JSON.parse(data);
-            
-            // Validate data structure
-            if (!this.isValidDataStructure(parsed)) {
-                return this.getDefaultData();
-            }
-            
-            return parsed;
-        } catch (error) {
-            console.error('Error loading data from storage:', error);
-            return this.getDefaultData();
+          localStorage.setItem(testKey, testData)
+          localStorage.removeItem(testKey)
+          testSize = mid
+          low = mid + 1
+        } catch (e) {
+          high = mid - 1
         }
-    }
+      }
 
-    // Save all data to storage
-    saveAllData(data) {
-        try {
-            // Create backup of current data
-            this.createBackup();
-            
-            // Add metadata
-            const dataWithMeta = {
-                ...data,
-                version: this.version,
-                lastModified: new Date().toISOString(),
-                lastBackup: new Date().toISOString()
-            };
-            
-            localStorage.setItem(this.storageKey, JSON.stringify(dataWithMeta));
-            return true;
-        } catch (error) {
-            console.error('Error saving data to storage:', error);
-            return false;
-        }
+      return testSize
+    } catch (error) {
+      return 0
     }
+  }
 
-    // Get specific profile
-    getProfile(profileId) {
-        const data = this.getAllData();
-        return data.profiles[profileId] || null;
-    }
-
-    // Save specific profile
-    saveProfile(profileId, profile) {
-        const data = this.getAllData();
-        data.profiles[profileId] = {
-            ...profile,
-            lastModified: new Date().toISOString()
-        };
-        return this.saveAllData(data);
-    }
-
-    // Delete profile
-    deleteProfile(profileId) {
-        const data = this.getAllData();
-        if (data.profiles[profileId]) {
-            delete data.profiles[profileId];
-            
-            // If this was the current profile, switch to first available
-            if (data.currentProfile === profileId) {
-                const remainingProfiles = Object.keys(data.profiles);
-                data.currentProfile = remainingProfiles.length > 0 ? remainingProfiles[0] : null;
-            }
-            
-            return this.saveAllData(data);
-        }
-        return false;
-    }
-
-    // Get application settings
-    getSettings() {
-        try {
-            const settings = localStorage.getItem(this.settingsKey);
-            return settings ? JSON.parse(settings) : this.getDefaultSettings();
-        } catch (error) {
-            console.error('Error loading settings:', error);
-            return this.getDefaultSettings();
-        }
-    }
-
-    // Save application settings
-    saveSettings(settings) {
-        try {
-            localStorage.setItem(this.settingsKey, JSON.stringify(settings));
-            return true;
-        } catch (error) {
-            console.error('Error saving settings:', error);
-            return false;
-        }
-    }
-
-    // Create backup of current data
-    createBackup() {
-        try {
-            const currentData = localStorage.getItem(this.storageKey);
-            if (currentData) {
-                const backup = {
-                    data: currentData,
-                    timestamp: new Date().toISOString(),
-                    version: this.version
-                };
-                localStorage.setItem(this.backupKey, JSON.stringify(backup));
-            }
-        } catch (error) {
-            console.error('Error creating backup:', error);
-        }
-    }
-
-    // Restore from backup
-    restoreFromBackup() {
-        try {
-            const backup = localStorage.getItem(this.backupKey);
-            if (backup) {
-                const parsed = JSON.parse(backup);
-                localStorage.setItem(this.storageKey, parsed.data);
-                return true;
-            }
-        } catch (error) {
-            console.error('Error restoring from backup:', error);
-        }
-        return false;
-    }
-
-    // Export data as JSON string
-    exportData() {
-        const data = this.getAllData();
-        return JSON.stringify(data, null, 2);
-    }
-
-    // Import data from JSON string
-    importData(jsonString) {
-        try {
-            const data = JSON.parse(jsonString);
-            
-            if (!this.isValidDataStructure(data)) {
-                // Invalid data structure is an expected validation result, not an error
-                return false;
-            }
-            
-            return this.saveAllData(data);
-        } catch (error) {
-            // Only log if it's not an expected JSON parse error from tests
-            if (!(error instanceof SyntaxError && jsonString.includes('invalid'))) {
-                console.error('Error importing data:', error);
-            }
-            return false;
-        }
-    }
-
-    // Clear all data (reset application)
-    clearAllData() {
-        try {
-            localStorage.removeItem(this.storageKey);
-            localStorage.removeItem(this.backupKey);
-            localStorage.removeItem(this.settingsKey);
-            
-            // Set reset flag to prevent loading default data on next startup
-            localStorage.setItem('sto_app_reset', 'true');
-            
-            return true;
-        } catch (error) {
-            console.error('Error clearing data:', error);
-            return false;
-        }
-    }
-
-    // Get storage usage info
-    getStorageInfo() {
-        try {
-            const dataSize = localStorage.getItem(this.storageKey)?.length || 0;
-            const backupSize = localStorage.getItem(this.backupKey)?.length || 0;
-            const settingsSize = localStorage.getItem(this.settingsKey)?.length || 0;
-            
-            return {
-                totalSize: dataSize + backupSize + settingsSize,
-                dataSize,
-                backupSize,
-                settingsSize,
-                available: this.getAvailableStorage()
-            };
-        } catch (error) {
-            console.error('Error getting storage info:', error);
-            return null;
-        }
-    }
-
-    // Private methods
-
-    getDefaultData() {
-        return {
-            version: this.version,
-            created: new Date().toISOString(),
-            lastModified: new Date().toISOString(),
-            currentProfile: 'default_space',
-            profiles: {
-                default_space: { ...STO_DATA.defaultProfiles.default_space },
-                tactical_space: { ...STO_DATA.defaultProfiles.tactical_space }
-            },
-            globalAliases: {},
-            settings: this.getDefaultSettings()
-        };
-    }
-
-    getEmptyData() {
-        return {
-            version: this.version,
-            created: new Date().toISOString(),
-            lastModified: new Date().toISOString(),
-            currentProfile: null,
-            profiles: {},
-            globalAliases: {},
-            settings: this.getDefaultSettings()
-        };
-    }
-
-    getDefaultSettings() {
-        return {
-            theme: 'default',
-            autoSave: true,
-            showTooltips: true,
-            confirmDeletes: true,
-            maxUndoSteps: 50,
-            defaultMode: 'space',
-            compactView: false
-        };
-    }
-
-    isValidDataStructure(data) {
-        if (!data || typeof data !== 'object') return false;
-        
-        // Check required properties
-        const required = ['profiles', 'currentProfile'];
-        for (const prop of required) {
-            if (!(prop in data)) return false;
-        }
-        
-        // Check profiles structure
-        if (typeof data.profiles !== 'object') return false;
-        
-        // Validate each profile
-        for (const [profileId, profile] of Object.entries(data.profiles)) {
-            if (!this.isValidProfile(profile)) {
-                // Invalid profile structure is an expected validation result, not something to log
-                return false;
-            }
-        }
-        
-        return true;
-    }
-
-    isValidProfile(profile) {
-        if (!profile || typeof profile !== 'object') return false;
-        
-        // New format with builds structure
-        if (profile.builds) {
-            if (!profile.name || typeof profile.builds !== 'object') return false;
-            
-            // Check if at least one build exists
-            const builds = profile.builds;
-            if (!builds.space && !builds.ground) return false;
-            
-            // Validate build structure
-            for (const [env, build] of Object.entries(builds)) {
-                if (env === 'space' || env === 'ground') {
-                    if (!build || typeof build !== 'object') return false;
-                    if (!build.keys || typeof build.keys !== 'object') return false;
-                }
-            }
-            
-            return true;
-        }
-        
-        // Old format - maintain backward compatibility
-        const required = ['name', 'mode', 'keys'];
-        for (const prop of required) {
-            if (!(prop in profile)) return false;
-        }
-        
-        if (typeof profile.keys !== 'object') return false;
-        
-        return true;
-    }
-
-    ensureStorageStructure() {
-        const data = this.getAllData();
-        
-        // Ensure all required properties exist
-        if (!data.globalAliases) data.globalAliases = {};
-        if (!data.settings) data.settings = this.getDefaultSettings();
-        
-        // Only ensure we have at least one profile if this isn't a post-reset state
-        if (Object.keys(data.profiles).length === 0 && data.currentProfile !== null) {
-            data.profiles = {
-                default_space: { ...STO_DATA.defaultProfiles.default_space }
-            };
-            data.currentProfile = 'default_space';
-        }
-        
-        // Ensure current profile exists (if we have profiles)
-        if (Object.keys(data.profiles).length > 0 && !data.profiles[data.currentProfile]) {
-            data.currentProfile = Object.keys(data.profiles)[0];
-        }
-        
-        this.saveAllData(data);
-    }
-
-    migrateData() {
-        // Handle data migration for future versions
-        const data = this.getAllData();
-        
-        if (data.version !== this.version) {
-            console.log(`Migrating data from ${data.version} to ${this.version}`);
-            
-            // Add migration logic here for future versions
-            
-            data.version = this.version;
-            this.saveAllData(data);
-        }
-    }
-
-    getAvailableStorage() {
-        try {
-            // Test available localStorage space
-            let testKey = 'storage_test';
-            let testData = '0';
-            let testSize = 0;
-            
-            // Binary search for max storage
-            let low = 0;
-            let high = 10 * 1024 * 1024; // 10MB max test
-            
-            while (low <= high) {
-                let mid = Math.floor((low + high) / 2);
-                testData = '0'.repeat(mid);
-                
-                try {
-                    localStorage.setItem(testKey, testData);
-                    localStorage.removeItem(testKey);
-                    testSize = mid;
-                    low = mid + 1;
-                } catch (e) {
-                    high = mid - 1;
-                }
-            }
-            
-            return testSize;
-        } catch (error) {
-            return 0;
-        }
-    }
-
-    // Load default/demo data explicitly
-    loadDefaultData() {
-        const defaultData = this.getDefaultData();
-        return this.saveAllData(defaultData);
-    }
+  // Load default/demo data explicitly
+  loadDefaultData() {
+    const defaultData = this.getDefaultData()
+    return this.saveAllData(defaultData)
+  }
 }
 
 // Global storage instance

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -9,7 +9,7 @@ const state = {
   undoStack: [],
   redoStack: [],
   maxUndoSteps: 50,
-  commandIdCounter: 0
+  commandIdCounter: 0,
 }
 
 const store = new Proxy(state, {
@@ -19,7 +19,7 @@ const store = new Proxy(state, {
       eventBus.emit(`store:${prop}`, value)
     }
     return true
-  }
+  },
 })
 
 export function resetStore() {
@@ -32,10 +32,8 @@ export function resetStore() {
     undoStack: [],
     redoStack: [],
     maxUndoSteps: 50,
-    commandIdCounter: 0
+    commandIdCounter: 0,
   })
 }
 
 export default store
-
-

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -2,54 +2,54 @@
 // Handles DOM manipulation, notifications, and user interface helpers
 
 export default class STOUIManager {
-    constructor() {
-        this.toastQueue = [];
-        this.dragState = {
-            isDragging: false,
-            dragElement: null,
-            dragData: null
-        };
-        
-        this.init();
+  constructor() {
+    this.toastQueue = []
+    this.dragState = {
+      isDragging: false,
+      dragElement: null,
+      dragData: null,
     }
 
-    init() {
-        this.setupGlobalEventListeners();
-        this.setupTooltips();
+    this.init()
+  }
+
+  init() {
+    this.setupGlobalEventListeners()
+    this.setupTooltips()
+  }
+
+  // Toast Notifications
+  showToast(message, type = 'info', duration = 3000) {
+    const toast = this.createToast(message, type, duration)
+    const container = document.getElementById('toastContainer')
+
+    if (container) {
+      container.appendChild(toast)
+
+      // Trigger animation
+      requestAnimationFrame(() => {
+        toast.classList.add('show')
+      })
+
+      // Auto remove
+      setTimeout(() => {
+        this.removeToast(toast)
+      }, duration)
+    }
+  }
+
+  createToast(message, type, duration) {
+    const toast = document.createElement('div')
+    toast.className = `toast toast-${type}`
+
+    const iconMap = {
+      success: 'fa-check-circle',
+      error: 'fa-exclamation-circle',
+      warning: 'fa-exclamation-triangle',
+      info: 'fa-info-circle',
     }
 
-    // Toast Notifications
-    showToast(message, type = 'info', duration = 3000) {
-        const toast = this.createToast(message, type, duration);
-        const container = document.getElementById('toastContainer');
-        
-        if (container) {
-            container.appendChild(toast);
-            
-            // Trigger animation
-            requestAnimationFrame(() => {
-                toast.classList.add('show');
-            });
-            
-            // Auto remove
-            setTimeout(() => {
-                this.removeToast(toast);
-            }, duration);
-        }
-    }
-
-    createToast(message, type, duration) {
-        const toast = document.createElement('div');
-        toast.className = `toast toast-${type}`;
-        
-        const iconMap = {
-            success: 'fa-check-circle',
-            error: 'fa-exclamation-circle', 
-            warning: 'fa-exclamation-triangle',
-            info: 'fa-info-circle'
-        };
-        
-        toast.innerHTML = `
+    toast.innerHTML = `
             <div class="toast-content">
                 <i class="fas ${iconMap[type] || iconMap.info}"></i>
                 <span class="toast-message">${message}</span>
@@ -57,172 +57,174 @@ export default class STOUIManager {
                     <i class="fas fa-times"></i>
                 </button>
             </div>
-        `;
-        
-        // Add close button functionality
-        const closeBtn = toast.querySelector('.toast-close');
-        closeBtn.addEventListener('click', () => {
-            this.removeToast(toast);
-        });
-        
-        return toast;
-    }
+        `
 
-    hideToast(toast) {
-        // Public method to hide a specific toast
-        if (toast && toast.parentNode) {
-            this.removeToast(toast);
+    // Add close button functionality
+    const closeBtn = toast.querySelector('.toast-close')
+    closeBtn.addEventListener('click', () => {
+      this.removeToast(toast)
+    })
+
+    return toast
+  }
+
+  hideToast(toast) {
+    // Public method to hide a specific toast
+    if (toast && toast.parentNode) {
+      this.removeToast(toast)
+    }
+  }
+
+  removeToast(toast) {
+    toast.classList.add('removing')
+    setTimeout(() => {
+      if (toast.parentNode) {
+        toast.parentNode.removeChild(toast)
+      }
+    }, 300)
+  }
+
+  // Modal Management
+  showModal(modalId, data = null) {
+    const modal = document.getElementById(modalId)
+
+    if (modalManager.show(modalId)) {
+      // Populate modal data if provided
+      if (data) {
+        this.populateModalData(modalId, data)
+      }
+      return true
+    }
+    return false
+  }
+
+  hideModal(modalId) {
+    const modal = document.getElementById(modalId)
+
+    if (modalManager.hide(modalId)) {
+      // Clear modal data
+      this.clearModalData(modalId)
+
+      return true
+    }
+    return false
+  }
+
+  hideAllModals() {
+    const modals = document.querySelectorAll('.modal.active')
+
+    modals.forEach((modal) => {
+      modalManager.hide(modal.id)
+    })
+  }
+
+  populateModalData(modalId, data) {
+    const modal = document.getElementById(modalId)
+    if (!modal) return
+
+    // Generic data population
+    Object.entries(data).forEach(([key, value]) => {
+      const element = modal.querySelector(`[data-field="${key}"], #${key}`)
+      if (element) {
+        if (element.type === 'checkbox') {
+          element.checked = value
+        } else {
+          element.value = value
         }
+      }
+    })
+  }
+
+  clearModalData(modalId) {
+    const modal = document.getElementById(modalId)
+    if (!modal) return
+
+    const inputs = modal.querySelectorAll('input, textarea, select')
+    inputs.forEach((input) => {
+      if (input.type === 'checkbox') {
+        input.checked = false
+      } else {
+        input.value = ''
+      }
+    })
+  }
+
+  // Loading States
+  showLoading(element, text = 'Loading...') {
+    if (typeof element === 'string') {
+      element = document.getElementById(element)
     }
 
-    removeToast(toast) {
-        toast.classList.add('removing');
-        setTimeout(() => {
-            if (toast.parentNode) {
-                toast.parentNode.removeChild(toast);
-            }
-        }, 300);
-    }
-
-    // Modal Management
-    showModal(modalId, data = null) {
-        const modal = document.getElementById(modalId);
-
-        if (modalManager.show(modalId)) {
-            
-            // Populate modal data if provided
-            if (data) {
-                this.populateModalData(modalId, data);
-            }
-            return true;
-        }
-        return false;
-    }
-
-    hideModal(modalId) {
-        const modal = document.getElementById(modalId);
-
-        if (modalManager.hide(modalId)) {
-            
-            // Clear modal data
-            this.clearModalData(modalId);
-
-            return true;
-        }
-        return false;
-    }
-
-    hideAllModals() {
-        const modals = document.querySelectorAll('.modal.active');
-
-        modals.forEach(modal => {
-            modalManager.hide(modal.id);
-        });
-    }
-
-    populateModalData(modalId, data) {
-        const modal = document.getElementById(modalId);
-        if (!modal) return;
-        
-        // Generic data population
-        Object.entries(data).forEach(([key, value]) => {
-            const element = modal.querySelector(`[data-field="${key}"], #${key}`);
-            if (element) {
-                if (element.type === 'checkbox') {
-                    element.checked = value;
-                } else {
-                    element.value = value;
-                }
-            }
-        });
-    }
-
-    clearModalData(modalId) {
-        const modal = document.getElementById(modalId);
-        if (!modal) return;
-        
-        const inputs = modal.querySelectorAll('input, textarea, select');
-        inputs.forEach(input => {
-            if (input.type === 'checkbox') {
-                input.checked = false;
-            } else {
-                input.value = '';
-            }
-        });
-    }
-
-    // Loading States
-    showLoading(element, text = 'Loading...') {
-        if (typeof element === 'string') {
-            element = document.getElementById(element);
-        }
-        
-        if (element) {
-            element.classList.add('loading');
-            const originalContent = element.innerHTML;
-            element.dataset.originalContent = originalContent;
-            element.innerHTML = `
+    if (element) {
+      element.classList.add('loading')
+      const originalContent = element.innerHTML
+      element.dataset.originalContent = originalContent
+      element.innerHTML = `
                 <div class="loading-spinner">
                     <i class="fas fa-spinner fa-spin"></i>
                     <span>${text}</span>
                 </div>
-            `;
-            element.disabled = true;
-        }
+            `
+      element.disabled = true
+    }
+  }
+
+  hideLoading(element) {
+    if (typeof element === 'string') {
+      element = document.getElementById(element)
     }
 
-    hideLoading(element) {
-        if (typeof element === 'string') {
-            element = document.getElementById(element);
-        }
-        
-        if (element && element.classList.contains('loading')) {
-            element.classList.remove('loading');
-            element.innerHTML = element.dataset.originalContent || '';
-            element.disabled = false;
-            delete element.dataset.originalContent;
-        }
+    if (element && element.classList.contains('loading')) {
+      element.classList.remove('loading')
+      element.innerHTML = element.dataset.originalContent || ''
+      element.disabled = false
+      delete element.dataset.originalContent
+    }
+  }
+
+  // Confirmation Dialogs
+  async confirm(message, title = 'Confirm', type = 'warning') {
+    return new Promise((resolve) => {
+      const confirmModal = this.createConfirmModal(message, title, type)
+      const confirmId = 'confirmModal'
+      confirmModal.id = confirmId
+      document.body.appendChild(confirmModal)
+
+      const handleConfirm = (result) => {
+        modalManager.hide(confirmId)
+        document.body.removeChild(confirmModal)
+        resolve(result)
+      }
+
+      confirmModal
+        .querySelector('.confirm-yes')
+        .addEventListener('click', () => {
+          handleConfirm(true)
+        })
+
+      confirmModal
+        .querySelector('.confirm-no')
+        .addEventListener('click', () => {
+          handleConfirm(false)
+        })
+
+      requestAnimationFrame(() => {
+        modalManager.show(confirmId)
+      })
+    })
+  }
+
+  createConfirmModal(message, title, type) {
+    const modal = document.createElement('div')
+    modal.className = 'modal confirm-modal'
+
+    const iconMap = {
+      warning: 'fa-exclamation-triangle',
+      danger: 'fa-exclamation-circle',
+      info: 'fa-info-circle',
     }
 
-    // Confirmation Dialogs
-    async confirm(message, title = 'Confirm', type = 'warning') {
-        return new Promise((resolve) => {
-            const confirmModal = this.createConfirmModal(message, title, type);
-            const confirmId = 'confirmModal';
-            confirmModal.id = confirmId;
-            document.body.appendChild(confirmModal);
-
-            const handleConfirm = (result) => {
-                modalManager.hide(confirmId);
-                document.body.removeChild(confirmModal);
-                resolve(result);
-            };
-
-            confirmModal.querySelector('.confirm-yes').addEventListener('click', () => {
-                handleConfirm(true);
-            });
-
-            confirmModal.querySelector('.confirm-no').addEventListener('click', () => {
-                handleConfirm(false);
-            });
-
-            requestAnimationFrame(() => {
-                modalManager.show(confirmId);
-            });
-        });
-    }
-
-    createConfirmModal(message, title, type) {
-        const modal = document.createElement('div');
-        modal.className = 'modal confirm-modal';
-        
-        const iconMap = {
-            warning: 'fa-exclamation-triangle',
-            danger: 'fa-exclamation-circle',
-            info: 'fa-info-circle'
-        };
-        
-        modal.innerHTML = `
+    modal.innerHTML = `
             <div class="modal-content">
                 <div class="modal-header">
                     <h3>
@@ -238,277 +240,294 @@ export default class STOUIManager {
                     <button class="btn btn-secondary confirm-no">No</button>
                 </div>
             </div>
-        `;
-        
-        return modal;
-    }
+        `
 
-    // Drag and Drop Helpers
-    initDragAndDrop(container, options = {}) {
-        const {
-            dragSelector = '.draggable',
-            dropZoneSelector = '.drop-zone',
-            onDragStart = null,
-            onDragEnd = null,
-            onDrop = null
-        } = options;
-        
-        // Make items draggable
-        container.addEventListener('dragstart', (e) => {
-            if (e.target.matches(dragSelector)) {
-                this.dragState.isDragging = true;
-                this.dragState.dragElement = e.target;
-                this.dragState.dragData = e.target.dataset;
-                
-                e.target.classList.add('dragging');
-                e.dataTransfer.effectAllowed = 'move';
-                
-                if (onDragStart) onDragStart(e, this.dragState);
-            }
-        });
-        
-        container.addEventListener('dragend', (e) => {
-            if (e.target.matches(dragSelector)) {
-                e.target.classList.remove('dragging');
-                this.dragState.isDragging = false;
-                this.dragState.dragElement = null;
-                this.dragState.dragData = null;
-                
-                if (onDragEnd) onDragEnd(e);
-            }
-        });
-        
-        // Handle drop zones
-        container.addEventListener('dragover', (e) => {
-            e.preventDefault();
-            const dropZone = e.target.closest(dropZoneSelector);
-            if (dropZone) {
-                dropZone.classList.add('drag-over');
-            }
-        });
-        
-        container.addEventListener('dragleave', (e) => {
-            const dropZone = e.target.closest(dropZoneSelector);
-            if (dropZone) {
-                dropZone.classList.remove('drag-over');
-            }
-        });
-        
-        container.addEventListener('drop', (e) => {
-            e.preventDefault();
-            const dropZone = e.target.closest(dropZoneSelector);
-            if (dropZone) {
-                dropZone.classList.remove('drag-over');
-                
-                if (onDrop) {
-                    onDrop(e, this.dragState, dropZone);
-                }
-            }
-        });
-    }
+    return modal
+  }
 
-    // Form Validation
-    validateForm(formElement) {
-        const errors = [];
-        const inputs = formElement.querySelectorAll('input[required], textarea[required], select[required]');
-        
-        inputs.forEach(input => {
-            const value = input.value.trim();
-            const fieldName = input.dataset.fieldName || input.name || input.id;
-            
-            if (!value) {
-                errors.push(`${fieldName} is required`);
-                input.classList.add('error');
-            } else {
-                input.classList.remove('error');
-                
-                // Type-specific validation
-                if (input.type === 'email' && !this.isValidEmail(value)) {
-                    errors.push(`${fieldName} must be a valid email`);
-                    input.classList.add('error');
-                }
-            }
-        });
-        
-        return {
-            isValid: errors.length === 0,
-            errors
-        };
-    }
+  // Drag and Drop Helpers
+  initDragAndDrop(container, options = {}) {
+    const {
+      dragSelector = '.draggable',
+      dropZoneSelector = '.drop-zone',
+      onDragStart = null,
+      onDragEnd = null,
+      onDrop = null,
+    } = options
 
-    isValidEmail(email) {
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        return emailRegex.test(email);
-    }
+    // Make items draggable
+    container.addEventListener('dragstart', (e) => {
+      if (e.target.matches(dragSelector)) {
+        this.dragState.isDragging = true
+        this.dragState.dragElement = e.target
+        this.dragState.dragData = e.target.dataset
 
-    // Clipboard Operations
-    async copyToClipboard(text) {
-        try {
-            await navigator.clipboard.writeText(text);
-            this.showToast('Copied to clipboard', 'success');
-            return true;
-        } catch (err) {
-            // Fallback for older browsers
-            const textArea = document.createElement('textarea');
-            textArea.value = text;
-            document.body.appendChild(textArea);
-            textArea.select();
-            
-            try {
-                document.execCommand('copy');
-                this.showToast('Copied to clipboard', 'success');
-                return true;
-            } catch (fallbackErr) {
-                this.showToast('Failed to copy to clipboard', 'error');
-                return false;
-            } finally {
-                document.body.removeChild(textArea);
-            }
+        e.target.classList.add('dragging')
+        e.dataTransfer.effectAllowed = 'move'
+
+        if (onDragStart) onDragStart(e, this.dragState)
+      }
+    })
+
+    container.addEventListener('dragend', (e) => {
+      if (e.target.matches(dragSelector)) {
+        e.target.classList.remove('dragging')
+        this.dragState.isDragging = false
+        this.dragState.dragElement = null
+        this.dragState.dragData = null
+
+        if (onDragEnd) onDragEnd(e)
+      }
+    })
+
+    // Handle drop zones
+    container.addEventListener('dragover', (e) => {
+      e.preventDefault()
+      const dropZone = e.target.closest(dropZoneSelector)
+      if (dropZone) {
+        dropZone.classList.add('drag-over')
+      }
+    })
+
+    container.addEventListener('dragleave', (e) => {
+      const dropZone = e.target.closest(dropZoneSelector)
+      if (dropZone) {
+        dropZone.classList.remove('drag-over')
+      }
+    })
+
+    container.addEventListener('drop', (e) => {
+      e.preventDefault()
+      const dropZone = e.target.closest(dropZoneSelector)
+      if (dropZone) {
+        dropZone.classList.remove('drag-over')
+
+        if (onDrop) {
+          onDrop(e, this.dragState, dropZone)
         }
-    }
+      }
+    })
+  }
 
-    // Animation Helpers
-    fadeIn(element, duration = 300) {
-        element.style.opacity = '0';
-        element.style.display = 'block';
-        
-        let start = null;
-        const animate = (timestamp) => {
-            if (!start) start = timestamp;
-            const progress = timestamp - start;
-            const opacity = Math.min(progress / duration, 1);
-            
-            element.style.opacity = opacity;
-            
-            if (progress < duration) {
-                requestAnimationFrame(animate);
-            }
-        };
-        
-        requestAnimationFrame(animate);
-    }
+  // Form Validation
+  validateForm(formElement) {
+    const errors = []
+    const inputs = formElement.querySelectorAll(
+      'input[required], textarea[required], select[required]'
+    )
 
-    fadeOut(element, duration = 300) {
-        let start = null;
-        const animate = (timestamp) => {
-            if (!start) start = timestamp;
-            const progress = timestamp - start;
-            const opacity = Math.max(1 - (progress / duration), 0);
-            
-            element.style.opacity = opacity;
-            
-            if (progress < duration) {
-                requestAnimationFrame(animate);
-            } else {
-                element.style.display = 'none';
-            }
-        };
-        
-        requestAnimationFrame(animate);
-    }
+    inputs.forEach((input) => {
+      const value = input.value.trim()
+      const fieldName = input.dataset.fieldName || input.name || input.id
 
-    // Utility Methods
-    debounce(func, wait) {
-        let timeout;
-        return function executedFunction(...args) {
-            const later = () => {
-                clearTimeout(timeout);
-                func(...args);
-            };
-            clearTimeout(timeout);
-            timeout = setTimeout(later, wait);
-        };
-    }
+      if (!value) {
+        errors.push(`${fieldName} is required`)
+        input.classList.add('error')
+      } else {
+        input.classList.remove('error')
 
-    throttle(func, limit) {
-        let inThrottle;
-        return function() {
-            const args = arguments;
-            const context = this;
-            if (!inThrottle) {
-                func.apply(context, args);
-                inThrottle = true;
-                setTimeout(() => inThrottle = false, limit);
-            }
-        };
-    }
-
-    // Setup Methods
-    setupGlobalEventListeners() {
-        // Escape key to close modals
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'Escape') {
-                this.hideAllModals();
-            }
-        });
-        
-        // Click outside modal to close
-        document.addEventListener('click', (e) => {
-            if (e.target.classList.contains('modal-overlay')) {
-                this.hideAllModals();
-            }
-        });
-    }
-
-    setupTooltips() {
-        // Simple tooltip implementation
-        document.addEventListener('mouseenter', (e) => {
-            if (e.target && typeof e.target.hasAttribute === 'function' && 
-                e.target.hasAttribute('title') && e.target.getAttribute('title').trim()) {
-                this.showTooltip(e.target, e.target.getAttribute('title'));
-            }
-        }, true);
-        
-        document.addEventListener('mouseleave', (e) => {
-            if (e.target && typeof e.target.hasAttribute === 'function' && 
-                e.target.hasAttribute('title')) {
-                this.hideTooltip();
-            }
-        }, true);
-    }
-
-    showTooltip(element, text) {
-        this.hideTooltip(); // Remove any existing tooltip
-        
-        const tooltip = document.createElement('div');
-        tooltip.className = 'tooltip';
-        tooltip.textContent = text;
-        tooltip.id = 'active-tooltip';
-        
-        document.body.appendChild(tooltip);
-        
-        // Position tooltip
-        const rect = element.getBoundingClientRect();
-        const tooltipRect = tooltip.getBoundingClientRect();
-        
-        let left = rect.left + (rect.width / 2) - (tooltipRect.width / 2);
-        let top = rect.top - tooltipRect.height - 8;
-        
-        // Adjust if tooltip goes off screen
-        if (left < 8) left = 8;
-        if (left + tooltipRect.width > window.innerWidth - 8) {
-            left = window.innerWidth - tooltipRect.width - 8;
+        // Type-specific validation
+        if (input.type === 'email' && !this.isValidEmail(value)) {
+          errors.push(`${fieldName} must be a valid email`)
+          input.classList.add('error')
         }
-        if (top < 8) {
-            top = rect.bottom + 8;
-            tooltip.classList.add('tooltip-bottom');
-        }
-        
-        tooltip.style.left = left + 'px';
-        tooltip.style.top = top + 'px';
-        
-        // Show tooltip
-        requestAnimationFrame(() => {
-            tooltip.classList.add('show');
-        });
+      }
+    })
+
+    return {
+      isValid: errors.length === 0,
+      errors,
+    }
+  }
+
+  isValidEmail(email) {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    return emailRegex.test(email)
+  }
+
+  // Clipboard Operations
+  async copyToClipboard(text) {
+    try {
+      await navigator.clipboard.writeText(text)
+      this.showToast('Copied to clipboard', 'success')
+      return true
+    } catch (err) {
+      // Fallback for older browsers
+      const textArea = document.createElement('textarea')
+      textArea.value = text
+      document.body.appendChild(textArea)
+      textArea.select()
+
+      try {
+        document.execCommand('copy')
+        this.showToast('Copied to clipboard', 'success')
+        return true
+      } catch (fallbackErr) {
+        this.showToast('Failed to copy to clipboard', 'error')
+        return false
+      } finally {
+        document.body.removeChild(textArea)
+      }
+    }
+  }
+
+  // Animation Helpers
+  fadeIn(element, duration = 300) {
+    element.style.opacity = '0'
+    element.style.display = 'block'
+
+    let start = null
+    const animate = (timestamp) => {
+      if (!start) start = timestamp
+      const progress = timestamp - start
+      const opacity = Math.min(progress / duration, 1)
+
+      element.style.opacity = opacity
+
+      if (progress < duration) {
+        requestAnimationFrame(animate)
+      }
     }
 
-    hideTooltip() {
-        const tooltip = document.getElementById('active-tooltip');
-        if (tooltip) {
-            tooltip.remove();
-        }
+    requestAnimationFrame(animate)
+  }
+
+  fadeOut(element, duration = 300) {
+    let start = null
+    const animate = (timestamp) => {
+      if (!start) start = timestamp
+      const progress = timestamp - start
+      const opacity = Math.max(1 - progress / duration, 0)
+
+      element.style.opacity = opacity
+
+      if (progress < duration) {
+        requestAnimationFrame(animate)
+      } else {
+        element.style.display = 'none'
+      }
     }
+
+    requestAnimationFrame(animate)
+  }
+
+  // Utility Methods
+  debounce(func, wait) {
+    let timeout
+    return function executedFunction(...args) {
+      const later = () => {
+        clearTimeout(timeout)
+        func(...args)
+      }
+      clearTimeout(timeout)
+      timeout = setTimeout(later, wait)
+    }
+  }
+
+  throttle(func, limit) {
+    let inThrottle
+    return function () {
+      const args = arguments
+      const context = this
+      if (!inThrottle) {
+        func.apply(context, args)
+        inThrottle = true
+        setTimeout(() => (inThrottle = false), limit)
+      }
+    }
+  }
+
+  // Setup Methods
+  setupGlobalEventListeners() {
+    // Escape key to close modals
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        this.hideAllModals()
+      }
+    })
+
+    // Click outside modal to close
+    document.addEventListener('click', (e) => {
+      if (e.target.classList.contains('modal-overlay')) {
+        this.hideAllModals()
+      }
+    })
+  }
+
+  setupTooltips() {
+    // Simple tooltip implementation
+    document.addEventListener(
+      'mouseenter',
+      (e) => {
+        if (
+          e.target &&
+          typeof e.target.hasAttribute === 'function' &&
+          e.target.hasAttribute('title') &&
+          e.target.getAttribute('title').trim()
+        ) {
+          this.showTooltip(e.target, e.target.getAttribute('title'))
+        }
+      },
+      true
+    )
+
+    document.addEventListener(
+      'mouseleave',
+      (e) => {
+        if (
+          e.target &&
+          typeof e.target.hasAttribute === 'function' &&
+          e.target.hasAttribute('title')
+        ) {
+          this.hideTooltip()
+        }
+      },
+      true
+    )
+  }
+
+  showTooltip(element, text) {
+    this.hideTooltip() // Remove any existing tooltip
+
+    const tooltip = document.createElement('div')
+    tooltip.className = 'tooltip'
+    tooltip.textContent = text
+    tooltip.id = 'active-tooltip'
+
+    document.body.appendChild(tooltip)
+
+    // Position tooltip
+    const rect = element.getBoundingClientRect()
+    const tooltipRect = tooltip.getBoundingClientRect()
+
+    let left = rect.left + rect.width / 2 - tooltipRect.width / 2
+    let top = rect.top - tooltipRect.height - 8
+
+    // Adjust if tooltip goes off screen
+    if (left < 8) left = 8
+    if (left + tooltipRect.width > window.innerWidth - 8) {
+      left = window.innerWidth - tooltipRect.width - 8
+    }
+    if (top < 8) {
+      top = rect.bottom + 8
+      tooltip.classList.add('tooltip-bottom')
+    }
+
+    tooltip.style.left = left + 'px'
+    tooltip.style.top = top + 'px'
+
+    // Show tooltip
+    requestAnimationFrame(() => {
+      tooltip.classList.add('show')
+    })
+  }
+
+  hideTooltip() {
+    const tooltip = document.getElementById('active-tooltip')
+    if (tooltip) {
+      tooltip.remove()
+    }
+  }
 }
 
 // Global UI manager instance

--- a/src/js/version.js
+++ b/src/js/version.js
@@ -1,18 +1,18 @@
-import { DISPLAY_VERSION } from "./constants.js";
+import { DISPLAY_VERSION } from './constants.js'
 /**
  * Version display management
  */
 
 document.addEventListener('DOMContentLoaded', () => {
-    // Update version in header
-    const appVersionElement = document.getElementById('appVersion');
-    if (appVersionElement) {
-        appVersionElement.textContent = DISPLAY_VERSION;
-    }
+  // Update version in header
+  const appVersionElement = document.getElementById('appVersion')
+  if (appVersionElement) {
+    appVersionElement.textContent = DISPLAY_VERSION
+  }
 
-    // Update version in about modal
-    const aboutVersionElement = document.getElementById('aboutVersion');
-    if (aboutVersionElement) {
-        aboutVersionElement.textContent = DISPLAY_VERSION;
-    }
-});
+  // Update version in about modal
+  const aboutVersionElement = document.getElementById('aboutVersion')
+  if (aboutVersionElement) {
+    aboutVersionElement.textContent = DISPLAY_VERSION
+  }
+})

--- a/src/js/vertigo_data.js
+++ b/src/js/vertigo_data.js
@@ -4,257 +4,589 @@
 // Error classes are defined in errors.js and exposed globally
 
 export const VFX_EFFECTS = {
-    space: [
-        { label: "Advanced inhibiting turret shield bubble", effect: "Fx_Rep_Temporal_Ship_Chroniton_Stabilization_Proc" },
-        { label: "Approaching Agony", effect: "Cfx_Lockboxfx_Cb29_Ship_Agony_Field" },
-        { label: "Attack Pattern Alpha", effect: "Fx_Ship_Tac_Attackpatternalpha" },
-        { label: "Attack Pattern Beta", effect: "Fx_Ship_Tac_Attackpatternbeta" },
-        { label: "Attack Pattern Delta", effect: "Fx_Ship_Tac_Attackpatterndelta" },
-        { label: "Attack Pattern Omega", effect: "Fx_Ship_Tac_Attackpatternomega" },
-        { label: "Beacon of Kahless", effect: "Fx_Er_Bbs_Beacon_Of_Kahless_Flash" },
-        { label: "Boost Morale", effect: "Fx_Ship_Spec_Powers_Command_Boost_Morale_Bufffx,Cfx_Ship_Spec_Powers_Command_Boost_Morale_Activate" },
-        { label: "Brace for Impact", effect: "Fx_Bop_Braceforimpact,Cfx_Ship_Sci_Hazardemitter_Buff" },
-        { label: "Breath of the Dragon", effect: "Fx_Ship_Cp_T6_Hysperian_Dragonbreath" },
-        { label: "Call Emergency Artillery", effect: "Fx_Ships_Boffs_Cmd_Callartillery_Activate,Fx_Ships_Boffs_Cmd_Callartillery_Explosion" },
-        { label: "Competitive Engine Buff Effect", effect: "Fx_Ship_Mod_Haste_Buff_Gen" },
-        { label: "Co-opt Energy Weapons", effect: "Fx_Capt_Powers_Ship_Sci_Coopt_Energy_Wep_Aoe,Cfx_Capt_Powers_Ship_Sci_Coopt_Energy_Wep_Area" },
-        { label: "Concentrate Fire Power", effect: "Fx_Ships_Boff_Cmd_Confire_Activatefx,Cfx_Ships_Boff_Cmd_Confire_Mark" },
-        { label: "Cnidarian Jellyfish AoE", effect: "Cfx_Ship_Sp_T6_Jellyfish_Cnidarian_Defense_Aoe" },
-        { label: "Dark Matter Anomaly", effect: "Cfx_Ship_Console_Dark_Matter_Anamoly_Costumefx" },
-        { label: "Delphic Tear", effect: "Fx_Ships_Consoles_Cb21_Delphictear" },
-        { label: "Destabilising Resonance Beam", effect: "P_Er_Ship_Destabilizing_Resonance_Beam_Aoe_Particles" },
-        { label: "Elachi Walker Combat Pet (3 effects)", effect: "Soundfx_Elachiwalker_Footstep_Pet,Fx_Er_Tfo_Elachi_Walker_Combat_Pet_Deathfx,Soundfx_Elachiwalker_Petsummon" },
-        { label: "Electrified Anomalies Trait", effect: "Fx_Tp_Ship_T6_Risian_Science_Electrified_Anomalies_Arc_Foe,Fx_Tp_Ship_T6_Risian_Science_Electrified_Anomalies_Arc_Friend" },
-        { label: "Emergency Pwr to Shields", effect: "Fx_Ship_Eng_Emergencypowershields" },
-        { label: "Emergency Pwr to Wep", effect: "Fx_Ship_Eng_Emergencypowerweapons" },
-        { label: "Engineering Fleet III", effect: "Fx_Ship_Boff_Fleet_Capt_Engineering_Teambuff" },
-        { label: "Engineering Team", effect: "Cfx_Ship_Crewteam_Engineeringteam_Buff" },
-        { label: "EPS Power Transfer", effect: "Cfx_Ship_Eng_Epspowertransfer_Target" },
-        { label: "Focus Frenzy", effect: "Fx_Skilltree_Ship_Ffrenzy_Activatefx" },
-        { label: "Go Down Fighting", effect: "Fx_Bop_Godownfighting" },
-        { label: "Hangar Pet Rank Up", effect: "Fx_Ship_Levelup_Fighter_Rankup" },
-        { label: "Hazard Emitters", effect: "Cfx_Ship_Sci_Hazardemitter_Buff" },
-        { label: "Intel Fleet III", effect: "Fx_Ship_Boff_Fleet_Capt_Intel_Teambuff" },
-        { label: "Intel Team (uses 3 effects)", effect: "Cfx_Ship_Cruiser_Auras_Taunt,Cfx_Spc_Boffpowers_Intel_Intelteam_Buff,Fx_Ships_Intel_Lyinginwait" },
-        { label: "Kemocite on ship animation", effect: "C1_E_Ship_Xindi_Lockboxcb15_Kemocite_Weaponry_Bufffx" },
-        { label: "Kemocite HitFX ring", effect: "Fx_Ship_Xindi_Lockboxcb15_Kemocite_Weaponry_Aoe_Proc" },
-        { label: "Kentari Ferocity Weapons Glow", effect: "P_Trait_Powers_Ship_Lukari_Colony_Kentari_Ferocity_Weapons_Glow" },
-        { label: "Kobayashi Maru powerup silenced", effect: "Fx_Evr_Kmaru_Ship_Dev_Resupply_Drop_Powerup_Bufffx,Fx_Evr_Kmaru_Ship_Dev_Resupply_Drop_Powerup" },
-        { label: "Less Obvious Loot Drop Common", effect: "Cfx_Space_Loot_Drop_Common_Costumefx" },
-        { label: "Less Obvious Loot Drop Uncommon", effect: "Cfx_Space_Loot_Drop_Uncommon_Costumefx" },
-        { label: "Less Obvious Loot Drop Rare", effect: "Cfx_Space_Loot_Drop_Rare_Costumefx" },
-        { label: "Less Obvious Loot Drop Very Rare", effect: "Cfx_Space_Loot_Drop_Veryrare_Costumefx" },
-        { label: "Less Obvious Loot Drop Lock Box", effect: "Cfx_Space_Loot_Drop_Chancebox_Costumefx" },
-        { label: "Less Obvious Loot Drop Dilithium", effect: "Cfx_Space_Loot_Drop_Dilithium_Costumefx" },
-        { label: "Miraculous Repairs", effect: "Fx_Bop_Miracleworker" },
-        { label: "MW - Align Shield Frequencies", effect: "Fx_Spc_Boffpowers_Miracleworker_Alignshieldfrequencies_Hitfx" },
-        { label: "MW - Destabilize Warp Core", effect: "Fx_Spc_Boffpowers_Miracleworker_Destabilizewarpcore" },
-        { label: "MW - Exceed rated limits", effect: "Fx_Spc_Boffpowers_Miracleworker_Energyweaponsexceedratedlimits_Dot_Hitfx,Fx_Spc_Boffpowers_Miracleworker_Energyweaponsexceedratedlimits" },
-        { label: "MW - Fix em up (and other green glows)", effect: "Fx_Ship_Mod_Damage_Buff" },
-        { label: "MW - Mixed Armaments Synergy", effect: "Fx_Spc_Boffpowers_Miracleworker_Mixedarmamentssynergy" },
-        { label: "MW - Narrow Sensor Bands", effect: "Fx_Spc_Boffpowers_Miracleworker_Narrowsensorbands" },
-        { label: "MW - Null Pointer Flood", effect: "Fx_Spc_Boffpowers_Miracleworker_Nullpointerflood" },
-        { label: "MW - Reroute shilds to Hull containment", effect: "Fx_Spc_Boffpowers_Miracleworker_Rerouteshieldstohullcontainment,Cfx_Spc_Boffpowers_Miracleworker_Rerouteshieldstohullcontainment" },
-        { label: "Nadion Inversion", effect: "Fx_Bop_Nadioinversion" },
-        { label: "Nanoprobe Shield Generator (Dyson Rep)", effect: "Cfx_Rp_Dyson_Ship_Reactive_Shielding" },
-        { label: "Neutronic Eddies", effect: "Cfx_Ships_Cp_T6_Risian_Science_Neutronic_Edides_Costumefx" },
-        { label: "Overwhelm Emitters", effect: "Fx_Ships_Boff_Cmd_Owemitters_Activatefx" },
-        { label: "Photonic Officer", effect: "Fx_Bop_Photonicofficer_activate" },
-        { label: "PILOT - Clean Getaway", effect: "Fx_Spc_Boff_Pilot_Cleangetaway_Activate" },
-        { label: "PILOT - Coolant Ignition (mostly)", effect: "Fx_Spc_Boff_Pilot_Coolantinjection_Ignite,Fx_Spc_Boff_Pilot_Coolantinjection_Costumefx" },
-        { label: "PILOT - Deploy Countermeasures", effect: "Fx_Spc_Boff_Pilot_Deploycm" },
-        { label: "PILOT - Fly her apart", effect: "Cfx_Spc_Boff_Pilot_Flyapart_Dot" },
-        { label: "PILOT - Form Up (mostly)", effect: "Fx_Spc_Boff_Pilot_Formup_Teleport,Fx_Spc_Boff_Pilot_Formup_Buff_Wepbuff" },
-        { label: "PILOT - hold Together", effect: "Cfx_Spc_Boff_Pilot_Holdtogether" },
-        { label: "PILOT - Lambda", effect: "Fx_Ship_Mod_Damage_Buff,Fx_Spc_Boff_Pilot_Aplambda_Bufffx,Fx_Spc_Boff_Pilot_Aplambda" },
-        { label: "PILOT - Lock Trajectory", effect: "Fx_Spc_Boff_Pilot_Flares_Switch,Cfx_Spc_Boff_Pilot_Locktrajectory" },
-        { label: "PILOT - Pilot Team", effect: "Cfx_Spc_Boff_Pilot_Pilotteam_Buff" },
-        { label: "PILOT - Reroute Reserves to Weapons", effect: "Fx_Spc_Boff_Pilot_Reroute_Wepbuff,Fx_Spc_Boff_Pilot_Reroute_Activate" },
-        { label: "PILOT - Subspace Boom", effect: "Cfx_Spc_Boff_Pilot_Ssboom_Costumefx_Neverdie,Fx_Spc_Boff_Pilot_Ssboom_Boom" },
-        { label: "Plasma Storm", effect: "Cfx_Ship_Cp_Cb27_Generate_Plasma_Storm_Costumefx" },
-        { label: "Rally Point Marker", effect: "Cfx_Ships_Boff_Cmd_Rallypoint_Marker" },
-        { label: "Reverse Shield Polarity", effect: "Cfx_Ship_Eng_Reverseshieldpolarity_Buff" },
-        { label: "Scattering Field", effect: "Cfx_Ship_Sci_Dampeningfield_Aoe,Cfx_Ship_Sci_Dampeningfield_Shield_Buff" },
-        { label: "Science Team", effect: "Cfx_Ship_Crewteam_Scienceteam_Buff" },
-        { label: "Science Fleet III", effect: "Fx_Ship_Boff_Fleet_Capt_Science_Teambuff" },
-        { label: "Soliton Wave Generator (uses 4 effects)", effect: "Cfx_Ship_Risa_Loot_Soliton_Wave_Suckfx_Target,Cfx_Ship_Risa_Loot_Soliton_Wave_Suckfx,Cfx_Ship_Risa_Loot_Soliton_Wave_Out,Cfx_Ship_Risa_Loot_Soliton_Wave_In" },
-        { label: "Spore Infused Anomalies", effect: "Fx_Trait_Powers_Ship_T6_Somerville_Sia_Blast" },
-        { label: "Subspace Vortex Teleport Effect", effect: "Fx_Ship_Xindi_Lockboxcb15_Subspace_Vortex_Teleport" },
-        { label: "Suppression Barrage", effect: "Cfx_Ships_Boff_Cmd_Sbarrage_Buff" },
-        { label: "Surgical Strikes", effect: "Fx_Spc_Boffpowers_Int_Sstrikes_Buff" },
-        { label: "Tactical Fleet III", effect: "Fx_Ship_Boff_Fleet_Capt_Tactical_Teambuff" },
-        { label: "Tactical Initiative", effect: "Fx_Bop_Tacticalinitiative" },
-        { label: "Tactical Team", effect: "Cfx_Ship_Crewteam_Tacticalteam_Buff" },
-        { label: "Target Rich Environment", effect: "Fx_Ship_Trait_Cb20_Targetrichenvironment" },
-        { label: "Temporal Anchor", effect: "Cfx_Ship_Trait_Temporal_Anchor_Costumefx" },
-        { label: "Temporal Vortex Probe", effect: "C1_Eventreward_Fcd_Temporal_Vortex_Costumefx,Fx_Eventreward_Fcd_Temporal_Vortex_Blast" },
-        { label: "Timeline Collapse (5 effects!)", effect: "Cfx_Ship_Temp_Tcollapse_Costume,Fx_Ship_Temp_Tcollapse_Hitfx,Fx_Ship_Temp_Tcollapse_Explode,Fx_Ship_Temp_Tcollapse_Beamhitfx,Fx_Ship_Temp_Tcollapse" },
-        { label: "V'Ger Torpedo (Volatile Digital Transformation)", effect: "Fx_Ship_Torpedo_Plasma_Vger_Anniv_Explode,Cfx_Ship_Torpedo_Vger_Disintegrate_In_Tintable" },
-        { label: "Viral Impulse Burst", effect: "Fx_Spc_Boffpowers_int_Viralimpulse" },
-        { label: "Vulcan Jelly Fish Eject Red Matter", effect: "Cfx_ship_jellyfish_eject_red_matter_costumefx" },
-        { label: "Vulnerability Assessment Sweep", effect: "Fx_Capt_Powers_Ship_Tac_Vulnerability_Assessment_Sweep" }
-    ],
-    ground: [
-        { label: "Agony Field Generator", effect: "Fx_Ground_Lockboxfx_Cb29_Agony_Field_Generator" },
-        { label: "Anti-time ground", effect: "Cfx_Rep_Temp_Char_Kit_Sci_Antitime_Entanglement_Field_Costumefx" },
-        { label: "Ball Lightning", effect: "Cfx_Char_Kit_Univ_Sum_Ball_Lightning_Costumefx" },
-        { label: "Chaos Blaze", effect: "Cfx_Char_Chaos_Blaze_Aoe" },
-        { label: "Conussive Tachyon Emission", effect: "fx_Char_Delta_Rep_Cte_Aoe" },
-        { label: "Disco Ball (Party Bomb)", effect: "Cfx_Char_Device_Partybomb" },
-        { label: "Dot-7 Drone Support Field", effect: "Cfx_Er_Bbs_char_Dot7_Drone_support_Field" },
-        { label: "Eng Proficiency (Character Glow)", effect: "Cfx_Ground_Kit_Eng_Engineeringproficiency" },
-        { label: "Ever Watchful", effect: "Cfx_Ground_Kit_Tac_Overwatch_Bufffx,Fx_Ground_Kit_Tac_Overwatch_Activatefx" },
-        { label: "Herald AP Beam Projector ground weapon", effect: "Fx_Char_Icoenergy_Rifle_Energyblast,Fx_Char_Icoenergy_Assault_Beam_Lockbox" },
-        { label: "Lava Floor", effect: "Cfx_Char_Kit_Univ_Sum_The_Floor_Is_Lava_Costumefx,Cfx_Char_Kit_Univ_Sum_The_Floor_Is_Lava_Geyser" },
-        { label: "Less Obvious Loot Drop Common", effect: "Cfx_Gnd_Loot_Drop_Common_Costumefx" },
-        { label: "Less Obvious Loot Drop Uncommon", effect: "Cfx_Gnd_Loot_Drop_Uncommon_Costumefx" },
-        { label: "Less Obvious Loot Drop Rare", effect: "Cfx_Gnd_Loot_Drop_Rare_Costumefx" },
-        { label: "Less Obvious Loot Drop Very Rare", effect: "Cfx_Gnd_Loot_Drop_Veryrare_Costumefx" },
-        { label: "Less Obvious Loot Drop Lock Box", effect: "Cfx_Gnd_Loot_Drop_Chancebox_Costumefx" },
-        { label: "Less Obvious Loot Drop Dilithium", effect: "Cfx_Gnd_Loot_Drop_Dilithium_Costumefx" },
-        { label: "Motivation (Tac Kit Module)", effect: "Cfx_Ground_Kit_Tac_Motivation_Buff,Fx_Ground_Kit_Tac_Motivation" },
-        { label: "Orbital Devastation", effect: "Fx_Char_Voth_Orbitalstrike_Chasebeam" },
-        { label: "Pahvan Crystal Prism noisy tether", effect: "Cfx_Er_Tfo_Pahvan_Crystal_Prism_Tether_Beam" },
-        { label: "Rally Cry", effect: "Fx_Ground_Kit_Tac_Rallycry" },
-        { label: "Red Riker Gun Sound effect", effect: "Cfx_Ep_Winterevent_Redriker_Sniper_Chargefx" },
-        { label: "Scientific Aptitude (character glow)", effect: "Cfx_Ground_Kit_Sci_Scientificaptitude" },
-        { label: "Solar Gateway", effect: "Fx_Char_Ico_Capt_Portal,Fx_Char_Ico_Capt_Portal_Sunbeam" },
-        { label: "Smoke Grenade", effect: "Fx_Char_Grenade_smoke_costume,Fx_Char_Grenade_Smoke_Explode" },
-        { label: "Sompek Energy Rebounder", effect: "Fx_Env_Gnd_Qadhos_Arena_Phaserhazard_Cylinder_Turret" },
-        { label: "Strike Team III (character red glow)", effect: "Cfx_Ground_Kit_Tac_Striketeam" },
-        { label: "Symphony of Lightning Char Glow", effect: "Fx_Er_Featured_Char_Kuumaarke_Wristgun_Tir_bufffx" },
-        { label: "Symphony of Lightning Drone AoE", effect: "Cfx_Er_Featured_Char_Kuumaarke_Set_Symphony_Of_Lightning_Drone_Aoe" },
-        { label: "Symphony of Lightning STRIKE", effect: "Fx_Er_Featured_Char_Kuumaarke_Set_Symphony_Of_Lightning_Strike" },
-        { label: "Trajectory Bending", effect: "Cfx_Char_Xindi_Cb15_Tac_Kit_Trajectory_Bending" },
-        { label: "Visual Dampening Field", effect: "Cfx_Char_Trait_Mirror_Vdfield" }
-    ]
-};
+  space: [
+    {
+      label: 'Advanced inhibiting turret shield bubble',
+      effect: 'Fx_Rep_Temporal_Ship_Chroniton_Stabilization_Proc',
+    },
+    {
+      label: 'Approaching Agony',
+      effect: 'Cfx_Lockboxfx_Cb29_Ship_Agony_Field',
+    },
+    { label: 'Attack Pattern Alpha', effect: 'Fx_Ship_Tac_Attackpatternalpha' },
+    { label: 'Attack Pattern Beta', effect: 'Fx_Ship_Tac_Attackpatternbeta' },
+    { label: 'Attack Pattern Delta', effect: 'Fx_Ship_Tac_Attackpatterndelta' },
+    { label: 'Attack Pattern Omega', effect: 'Fx_Ship_Tac_Attackpatternomega' },
+    { label: 'Beacon of Kahless', effect: 'Fx_Er_Bbs_Beacon_Of_Kahless_Flash' },
+    {
+      label: 'Boost Morale',
+      effect:
+        'Fx_Ship_Spec_Powers_Command_Boost_Morale_Bufffx,Cfx_Ship_Spec_Powers_Command_Boost_Morale_Activate',
+    },
+    {
+      label: 'Brace for Impact',
+      effect: 'Fx_Bop_Braceforimpact,Cfx_Ship_Sci_Hazardemitter_Buff',
+    },
+    {
+      label: 'Breath of the Dragon',
+      effect: 'Fx_Ship_Cp_T6_Hysperian_Dragonbreath',
+    },
+    {
+      label: 'Call Emergency Artillery',
+      effect:
+        'Fx_Ships_Boffs_Cmd_Callartillery_Activate,Fx_Ships_Boffs_Cmd_Callartillery_Explosion',
+    },
+    {
+      label: 'Competitive Engine Buff Effect',
+      effect: 'Fx_Ship_Mod_Haste_Buff_Gen',
+    },
+    {
+      label: 'Co-opt Energy Weapons',
+      effect:
+        'Fx_Capt_Powers_Ship_Sci_Coopt_Energy_Wep_Aoe,Cfx_Capt_Powers_Ship_Sci_Coopt_Energy_Wep_Area',
+    },
+    {
+      label: 'Concentrate Fire Power',
+      effect:
+        'Fx_Ships_Boff_Cmd_Confire_Activatefx,Cfx_Ships_Boff_Cmd_Confire_Mark',
+    },
+    {
+      label: 'Cnidarian Jellyfish AoE',
+      effect: 'Cfx_Ship_Sp_T6_Jellyfish_Cnidarian_Defense_Aoe',
+    },
+    {
+      label: 'Dark Matter Anomaly',
+      effect: 'Cfx_Ship_Console_Dark_Matter_Anamoly_Costumefx',
+    },
+    { label: 'Delphic Tear', effect: 'Fx_Ships_Consoles_Cb21_Delphictear' },
+    {
+      label: 'Destabilising Resonance Beam',
+      effect: 'P_Er_Ship_Destabilizing_Resonance_Beam_Aoe_Particles',
+    },
+    {
+      label: 'Elachi Walker Combat Pet (3 effects)',
+      effect:
+        'Soundfx_Elachiwalker_Footstep_Pet,Fx_Er_Tfo_Elachi_Walker_Combat_Pet_Deathfx,Soundfx_Elachiwalker_Petsummon',
+    },
+    {
+      label: 'Electrified Anomalies Trait',
+      effect:
+        'Fx_Tp_Ship_T6_Risian_Science_Electrified_Anomalies_Arc_Foe,Fx_Tp_Ship_T6_Risian_Science_Electrified_Anomalies_Arc_Friend',
+    },
+    {
+      label: 'Emergency Pwr to Shields',
+      effect: 'Fx_Ship_Eng_Emergencypowershields',
+    },
+    {
+      label: 'Emergency Pwr to Wep',
+      effect: 'Fx_Ship_Eng_Emergencypowerweapons',
+    },
+    {
+      label: 'Engineering Fleet III',
+      effect: 'Fx_Ship_Boff_Fleet_Capt_Engineering_Teambuff',
+    },
+    {
+      label: 'Engineering Team',
+      effect: 'Cfx_Ship_Crewteam_Engineeringteam_Buff',
+    },
+    {
+      label: 'EPS Power Transfer',
+      effect: 'Cfx_Ship_Eng_Epspowertransfer_Target',
+    },
+    { label: 'Focus Frenzy', effect: 'Fx_Skilltree_Ship_Ffrenzy_Activatefx' },
+    { label: 'Go Down Fighting', effect: 'Fx_Bop_Godownfighting' },
+    { label: 'Hangar Pet Rank Up', effect: 'Fx_Ship_Levelup_Fighter_Rankup' },
+    { label: 'Hazard Emitters', effect: 'Cfx_Ship_Sci_Hazardemitter_Buff' },
+    {
+      label: 'Intel Fleet III',
+      effect: 'Fx_Ship_Boff_Fleet_Capt_Intel_Teambuff',
+    },
+    {
+      label: 'Intel Team (uses 3 effects)',
+      effect:
+        'Cfx_Ship_Cruiser_Auras_Taunt,Cfx_Spc_Boffpowers_Intel_Intelteam_Buff,Fx_Ships_Intel_Lyinginwait',
+    },
+    {
+      label: 'Kemocite on ship animation',
+      effect: 'C1_E_Ship_Xindi_Lockboxcb15_Kemocite_Weaponry_Bufffx',
+    },
+    {
+      label: 'Kemocite HitFX ring',
+      effect: 'Fx_Ship_Xindi_Lockboxcb15_Kemocite_Weaponry_Aoe_Proc',
+    },
+    {
+      label: 'Kentari Ferocity Weapons Glow',
+      effect: 'P_Trait_Powers_Ship_Lukari_Colony_Kentari_Ferocity_Weapons_Glow',
+    },
+    {
+      label: 'Kobayashi Maru powerup silenced',
+      effect:
+        'Fx_Evr_Kmaru_Ship_Dev_Resupply_Drop_Powerup_Bufffx,Fx_Evr_Kmaru_Ship_Dev_Resupply_Drop_Powerup',
+    },
+    {
+      label: 'Less Obvious Loot Drop Common',
+      effect: 'Cfx_Space_Loot_Drop_Common_Costumefx',
+    },
+    {
+      label: 'Less Obvious Loot Drop Uncommon',
+      effect: 'Cfx_Space_Loot_Drop_Uncommon_Costumefx',
+    },
+    {
+      label: 'Less Obvious Loot Drop Rare',
+      effect: 'Cfx_Space_Loot_Drop_Rare_Costumefx',
+    },
+    {
+      label: 'Less Obvious Loot Drop Very Rare',
+      effect: 'Cfx_Space_Loot_Drop_Veryrare_Costumefx',
+    },
+    {
+      label: 'Less Obvious Loot Drop Lock Box',
+      effect: 'Cfx_Space_Loot_Drop_Chancebox_Costumefx',
+    },
+    {
+      label: 'Less Obvious Loot Drop Dilithium',
+      effect: 'Cfx_Space_Loot_Drop_Dilithium_Costumefx',
+    },
+    { label: 'Miraculous Repairs', effect: 'Fx_Bop_Miracleworker' },
+    {
+      label: 'MW - Align Shield Frequencies',
+      effect: 'Fx_Spc_Boffpowers_Miracleworker_Alignshieldfrequencies_Hitfx',
+    },
+    {
+      label: 'MW - Destabilize Warp Core',
+      effect: 'Fx_Spc_Boffpowers_Miracleworker_Destabilizewarpcore',
+    },
+    {
+      label: 'MW - Exceed rated limits',
+      effect:
+        'Fx_Spc_Boffpowers_Miracleworker_Energyweaponsexceedratedlimits_Dot_Hitfx,Fx_Spc_Boffpowers_Miracleworker_Energyweaponsexceedratedlimits',
+    },
+    {
+      label: 'MW - Fix em up (and other green glows)',
+      effect: 'Fx_Ship_Mod_Damage_Buff',
+    },
+    {
+      label: 'MW - Mixed Armaments Synergy',
+      effect: 'Fx_Spc_Boffpowers_Miracleworker_Mixedarmamentssynergy',
+    },
+    {
+      label: 'MW - Narrow Sensor Bands',
+      effect: 'Fx_Spc_Boffpowers_Miracleworker_Narrowsensorbands',
+    },
+    {
+      label: 'MW - Null Pointer Flood',
+      effect: 'Fx_Spc_Boffpowers_Miracleworker_Nullpointerflood',
+    },
+    {
+      label: 'MW - Reroute shilds to Hull containment',
+      effect:
+        'Fx_Spc_Boffpowers_Miracleworker_Rerouteshieldstohullcontainment,Cfx_Spc_Boffpowers_Miracleworker_Rerouteshieldstohullcontainment',
+    },
+    { label: 'Nadion Inversion', effect: 'Fx_Bop_Nadioinversion' },
+    {
+      label: 'Nanoprobe Shield Generator (Dyson Rep)',
+      effect: 'Cfx_Rp_Dyson_Ship_Reactive_Shielding',
+    },
+    {
+      label: 'Neutronic Eddies',
+      effect: 'Cfx_Ships_Cp_T6_Risian_Science_Neutronic_Edides_Costumefx',
+    },
+    {
+      label: 'Overwhelm Emitters',
+      effect: 'Fx_Ships_Boff_Cmd_Owemitters_Activatefx',
+    },
+    { label: 'Photonic Officer', effect: 'Fx_Bop_Photonicofficer_activate' },
+    {
+      label: 'PILOT - Clean Getaway',
+      effect: 'Fx_Spc_Boff_Pilot_Cleangetaway_Activate',
+    },
+    {
+      label: 'PILOT - Coolant Ignition (mostly)',
+      effect:
+        'Fx_Spc_Boff_Pilot_Coolantinjection_Ignite,Fx_Spc_Boff_Pilot_Coolantinjection_Costumefx',
+    },
+    {
+      label: 'PILOT - Deploy Countermeasures',
+      effect: 'Fx_Spc_Boff_Pilot_Deploycm',
+    },
+    {
+      label: 'PILOT - Fly her apart',
+      effect: 'Cfx_Spc_Boff_Pilot_Flyapart_Dot',
+    },
+    {
+      label: 'PILOT - Form Up (mostly)',
+      effect:
+        'Fx_Spc_Boff_Pilot_Formup_Teleport,Fx_Spc_Boff_Pilot_Formup_Buff_Wepbuff',
+    },
+    {
+      label: 'PILOT - hold Together',
+      effect: 'Cfx_Spc_Boff_Pilot_Holdtogether',
+    },
+    {
+      label: 'PILOT - Lambda',
+      effect:
+        'Fx_Ship_Mod_Damage_Buff,Fx_Spc_Boff_Pilot_Aplambda_Bufffx,Fx_Spc_Boff_Pilot_Aplambda',
+    },
+    {
+      label: 'PILOT - Lock Trajectory',
+      effect:
+        'Fx_Spc_Boff_Pilot_Flares_Switch,Cfx_Spc_Boff_Pilot_Locktrajectory',
+    },
+    {
+      label: 'PILOT - Pilot Team',
+      effect: 'Cfx_Spc_Boff_Pilot_Pilotteam_Buff',
+    },
+    {
+      label: 'PILOT - Reroute Reserves to Weapons',
+      effect:
+        'Fx_Spc_Boff_Pilot_Reroute_Wepbuff,Fx_Spc_Boff_Pilot_Reroute_Activate',
+    },
+    {
+      label: 'PILOT - Subspace Boom',
+      effect:
+        'Cfx_Spc_Boff_Pilot_Ssboom_Costumefx_Neverdie,Fx_Spc_Boff_Pilot_Ssboom_Boom',
+    },
+    {
+      label: 'Plasma Storm',
+      effect: 'Cfx_Ship_Cp_Cb27_Generate_Plasma_Storm_Costumefx',
+    },
+    {
+      label: 'Rally Point Marker',
+      effect: 'Cfx_Ships_Boff_Cmd_Rallypoint_Marker',
+    },
+    {
+      label: 'Reverse Shield Polarity',
+      effect: 'Cfx_Ship_Eng_Reverseshieldpolarity_Buff',
+    },
+    {
+      label: 'Scattering Field',
+      effect:
+        'Cfx_Ship_Sci_Dampeningfield_Aoe,Cfx_Ship_Sci_Dampeningfield_Shield_Buff',
+    },
+    { label: 'Science Team', effect: 'Cfx_Ship_Crewteam_Scienceteam_Buff' },
+    {
+      label: 'Science Fleet III',
+      effect: 'Fx_Ship_Boff_Fleet_Capt_Science_Teambuff',
+    },
+    {
+      label: 'Soliton Wave Generator (uses 4 effects)',
+      effect:
+        'Cfx_Ship_Risa_Loot_Soliton_Wave_Suckfx_Target,Cfx_Ship_Risa_Loot_Soliton_Wave_Suckfx,Cfx_Ship_Risa_Loot_Soliton_Wave_Out,Cfx_Ship_Risa_Loot_Soliton_Wave_In',
+    },
+    {
+      label: 'Spore Infused Anomalies',
+      effect: 'Fx_Trait_Powers_Ship_T6_Somerville_Sia_Blast',
+    },
+    {
+      label: 'Subspace Vortex Teleport Effect',
+      effect: 'Fx_Ship_Xindi_Lockboxcb15_Subspace_Vortex_Teleport',
+    },
+    {
+      label: 'Suppression Barrage',
+      effect: 'Cfx_Ships_Boff_Cmd_Sbarrage_Buff',
+    },
+    {
+      label: 'Surgical Strikes',
+      effect: 'Fx_Spc_Boffpowers_Int_Sstrikes_Buff',
+    },
+    {
+      label: 'Tactical Fleet III',
+      effect: 'Fx_Ship_Boff_Fleet_Capt_Tactical_Teambuff',
+    },
+    { label: 'Tactical Initiative', effect: 'Fx_Bop_Tacticalinitiative' },
+    { label: 'Tactical Team', effect: 'Cfx_Ship_Crewteam_Tacticalteam_Buff' },
+    {
+      label: 'Target Rich Environment',
+      effect: 'Fx_Ship_Trait_Cb20_Targetrichenvironment',
+    },
+    {
+      label: 'Temporal Anchor',
+      effect: 'Cfx_Ship_Trait_Temporal_Anchor_Costumefx',
+    },
+    {
+      label: 'Temporal Vortex Probe',
+      effect:
+        'C1_Eventreward_Fcd_Temporal_Vortex_Costumefx,Fx_Eventreward_Fcd_Temporal_Vortex_Blast',
+    },
+    {
+      label: 'Timeline Collapse (5 effects!)',
+      effect:
+        'Cfx_Ship_Temp_Tcollapse_Costume,Fx_Ship_Temp_Tcollapse_Hitfx,Fx_Ship_Temp_Tcollapse_Explode,Fx_Ship_Temp_Tcollapse_Beamhitfx,Fx_Ship_Temp_Tcollapse',
+    },
+    {
+      label: "V'Ger Torpedo (Volatile Digital Transformation)",
+      effect:
+        'Fx_Ship_Torpedo_Plasma_Vger_Anniv_Explode,Cfx_Ship_Torpedo_Vger_Disintegrate_In_Tintable',
+    },
+    {
+      label: 'Viral Impulse Burst',
+      effect: 'Fx_Spc_Boffpowers_int_Viralimpulse',
+    },
+    {
+      label: 'Vulcan Jelly Fish Eject Red Matter',
+      effect: 'Cfx_ship_jellyfish_eject_red_matter_costumefx',
+    },
+    {
+      label: 'Vulnerability Assessment Sweep',
+      effect: 'Fx_Capt_Powers_Ship_Tac_Vulnerability_Assessment_Sweep',
+    },
+  ],
+  ground: [
+    {
+      label: 'Agony Field Generator',
+      effect: 'Fx_Ground_Lockboxfx_Cb29_Agony_Field_Generator',
+    },
+    {
+      label: 'Anti-time ground',
+      effect: 'Cfx_Rep_Temp_Char_Kit_Sci_Antitime_Entanglement_Field_Costumefx',
+    },
+    {
+      label: 'Ball Lightning',
+      effect: 'Cfx_Char_Kit_Univ_Sum_Ball_Lightning_Costumefx',
+    },
+    { label: 'Chaos Blaze', effect: 'Cfx_Char_Chaos_Blaze_Aoe' },
+    {
+      label: 'Conussive Tachyon Emission',
+      effect: 'fx_Char_Delta_Rep_Cte_Aoe',
+    },
+    { label: 'Disco Ball (Party Bomb)', effect: 'Cfx_Char_Device_Partybomb' },
+    {
+      label: 'Dot-7 Drone Support Field',
+      effect: 'Cfx_Er_Bbs_char_Dot7_Drone_support_Field',
+    },
+    {
+      label: 'Eng Proficiency (Character Glow)',
+      effect: 'Cfx_Ground_Kit_Eng_Engineeringproficiency',
+    },
+    {
+      label: 'Ever Watchful',
+      effect:
+        'Cfx_Ground_Kit_Tac_Overwatch_Bufffx,Fx_Ground_Kit_Tac_Overwatch_Activatefx',
+    },
+    {
+      label: 'Herald AP Beam Projector ground weapon',
+      effect:
+        'Fx_Char_Icoenergy_Rifle_Energyblast,Fx_Char_Icoenergy_Assault_Beam_Lockbox',
+    },
+    {
+      label: 'Lava Floor',
+      effect:
+        'Cfx_Char_Kit_Univ_Sum_The_Floor_Is_Lava_Costumefx,Cfx_Char_Kit_Univ_Sum_The_Floor_Is_Lava_Geyser',
+    },
+    {
+      label: 'Less Obvious Loot Drop Common',
+      effect: 'Cfx_Gnd_Loot_Drop_Common_Costumefx',
+    },
+    {
+      label: 'Less Obvious Loot Drop Uncommon',
+      effect: 'Cfx_Gnd_Loot_Drop_Uncommon_Costumefx',
+    },
+    {
+      label: 'Less Obvious Loot Drop Rare',
+      effect: 'Cfx_Gnd_Loot_Drop_Rare_Costumefx',
+    },
+    {
+      label: 'Less Obvious Loot Drop Very Rare',
+      effect: 'Cfx_Gnd_Loot_Drop_Veryrare_Costumefx',
+    },
+    {
+      label: 'Less Obvious Loot Drop Lock Box',
+      effect: 'Cfx_Gnd_Loot_Drop_Chancebox_Costumefx',
+    },
+    {
+      label: 'Less Obvious Loot Drop Dilithium',
+      effect: 'Cfx_Gnd_Loot_Drop_Dilithium_Costumefx',
+    },
+    {
+      label: 'Motivation (Tac Kit Module)',
+      effect: 'Cfx_Ground_Kit_Tac_Motivation_Buff,Fx_Ground_Kit_Tac_Motivation',
+    },
+    {
+      label: 'Orbital Devastation',
+      effect: 'Fx_Char_Voth_Orbitalstrike_Chasebeam',
+    },
+    {
+      label: 'Pahvan Crystal Prism noisy tether',
+      effect: 'Cfx_Er_Tfo_Pahvan_Crystal_Prism_Tether_Beam',
+    },
+    { label: 'Rally Cry', effect: 'Fx_Ground_Kit_Tac_Rallycry' },
+    {
+      label: 'Red Riker Gun Sound effect',
+      effect: 'Cfx_Ep_Winterevent_Redriker_Sniper_Chargefx',
+    },
+    {
+      label: 'Scientific Aptitude (character glow)',
+      effect: 'Cfx_Ground_Kit_Sci_Scientificaptitude',
+    },
+    {
+      label: 'Solar Gateway',
+      effect: 'Fx_Char_Ico_Capt_Portal,Fx_Char_Ico_Capt_Portal_Sunbeam',
+    },
+    {
+      label: 'Smoke Grenade',
+      effect: 'Fx_Char_Grenade_smoke_costume,Fx_Char_Grenade_Smoke_Explode',
+    },
+    {
+      label: 'Sompek Energy Rebounder',
+      effect: 'Fx_Env_Gnd_Qadhos_Arena_Phaserhazard_Cylinder_Turret',
+    },
+    {
+      label: 'Strike Team III (character red glow)',
+      effect: 'Cfx_Ground_Kit_Tac_Striketeam',
+    },
+    {
+      label: 'Symphony of Lightning Char Glow',
+      effect: 'Fx_Er_Featured_Char_Kuumaarke_Wristgun_Tir_bufffx',
+    },
+    {
+      label: 'Symphony of Lightning Drone AoE',
+      effect:
+        'Cfx_Er_Featured_Char_Kuumaarke_Set_Symphony_Of_Lightning_Drone_Aoe',
+    },
+    {
+      label: 'Symphony of Lightning STRIKE',
+      effect: 'Fx_Er_Featured_Char_Kuumaarke_Set_Symphony_Of_Lightning_Strike',
+    },
+    {
+      label: 'Trajectory Bending',
+      effect: 'Cfx_Char_Xindi_Cb15_Tac_Kit_Trajectory_Bending',
+    },
+    {
+      label: 'Visual Dampening Field',
+      effect: 'Cfx_Char_Trait_Mirror_Vdfield',
+    },
+  ],
+}
 
 // Vertigo management class
 export default class VertigoManager {
-    constructor() {
-        this.selectedEffects = {
-            space: new Set(),
-            ground: new Set()
-        };
-        this.showPlayerSay = false;
+  constructor() {
+    this.selectedEffects = {
+      space: new Set(),
+      ground: new Set(),
+    }
+    this.showPlayerSay = false
+  }
+
+  // Generate the alias command for the given environment
+  generateAlias(environment) {
+    if (!this.selectedEffects[environment]) {
+      throw new InvalidEnvironmentError(environment)
     }
 
-    // Generate the alias command for the given environment
-    generateAlias(environment) {
-        if (!this.selectedEffects[environment]) {
-            throw new InvalidEnvironmentError(environment);
-        }
-        
-        const effects = Array.from(this.selectedEffects[environment]);
-        if (effects.length === 0) return '';
+    const effects = Array.from(this.selectedEffects[environment])
+    if (effects.length === 0) return ''
 
-        let aliasName = `dynFxSetFXExlusionList_${environment.charAt(0).toUpperCase() + environment.slice(1)}`;
-        let command = `alias ${aliasName} <& dynFxSetFXExlusionList ${effects.join(',')}`;
-        
-        if (this.showPlayerSay) {
-            command += ' $$ PlayerSay VFX Supression Loaded';
-        }
-        
-        command += ' &>';
-        return command;
+    let aliasName = `dynFxSetFXExlusionList_${environment.charAt(0).toUpperCase() + environment.slice(1)}`
+    let command = `alias ${aliasName} <& dynFxSetFXExlusionList ${effects.join(',')}`
+
+    if (this.showPlayerSay) {
+      command += ' $$ PlayerSay VFX Supression Loaded'
     }
 
-    // Get selected effects for an environment
-    getSelectedEffects(environment) {
-        if (!this.selectedEffects[environment]) {
-            throw new InvalidEnvironmentError(environment);
-        }
-        return Array.from(this.selectedEffects[environment]);
+    command += ' &>'
+    return command
+  }
+
+  // Get selected effects for an environment
+  getSelectedEffects(environment) {
+    if (!this.selectedEffects[environment]) {
+      throw new InvalidEnvironmentError(environment)
+    }
+    return Array.from(this.selectedEffects[environment])
+  }
+
+  // Toggle an effect
+  toggleEffect(environment, effectName) {
+    if (!this.selectedEffects[environment]) {
+      throw new InvalidEnvironmentError(environment)
     }
 
-    // Toggle an effect
-    toggleEffect(environment, effectName) {
-        if (!this.selectedEffects[environment]) {
-            throw new InvalidEnvironmentError(environment);
-        }
-        
-        if (!effectName) {
-            throw new InvalidEffectError(effectName, environment);
-        }
-        
-        if (this.selectedEffects[environment].has(effectName)) {
-            this.selectedEffects[environment].delete(effectName);
-        } else {
-            this.selectedEffects[environment].add(effectName);
-        }
+    if (!effectName) {
+      throw new InvalidEffectError(effectName, environment)
     }
 
-    // Clear all selected effects
-    clearAllEffects() {
-        this.selectedEffects.space.clear();
-        this.selectedEffects.ground.clear();
+    if (this.selectedEffects[environment].has(effectName)) {
+      this.selectedEffects[environment].delete(effectName)
+    } else {
+      this.selectedEffects[environment].add(effectName)
+    }
+  }
+
+  // Clear all selected effects
+  clearAllEffects() {
+    this.selectedEffects.space.clear()
+    this.selectedEffects.ground.clear()
+  }
+
+  // Set all effects for an environment
+  selectAllEffects(environment) {
+    if (!VFX_EFFECTS[environment]) {
+      throw new InvalidEnvironmentError(environment)
     }
 
-    // Set all effects for an environment
-    selectAllEffects(environment) {
-        if (!VFX_EFFECTS[environment]) {
-            throw new InvalidEnvironmentError(environment);
-        }
-        
-        if (!this.selectedEffects[environment]) {
-            throw new InvalidEnvironmentError(environment);
-        }
-        
-        VFX_EFFECTS[environment].forEach(effect => {
-            this.selectedEffects[environment].add(effect.effect);
-        });
+    if (!this.selectedEffects[environment]) {
+      throw new InvalidEnvironmentError(environment)
     }
 
-    // Get effect count for an environment
-    getEffectCount(environment) {
-        if (!this.selectedEffects[environment]) {
-            throw new InvalidEnvironmentError(environment);
-        }
-        return this.selectedEffects[environment].size;
+    VFX_EFFECTS[environment].forEach((effect) => {
+      this.selectedEffects[environment].add(effect.effect)
+    })
+  }
+
+  // Get effect count for an environment
+  getEffectCount(environment) {
+    if (!this.selectedEffects[environment]) {
+      throw new InvalidEnvironmentError(environment)
+    }
+    return this.selectedEffects[environment].size
+  }
+
+  // Check if effect is selected
+  isEffectSelected(environment, effectName) {
+    if (!this.selectedEffects[environment]) {
+      throw new InvalidEnvironmentError(environment)
+    }
+    return this.selectedEffects[environment].has(effectName)
+  }
+
+  // Save state to current profile
+  saveState(profile) {
+    if (!profile.vertigoSettings) {
+      profile.vertigoSettings = {}
     }
 
-    // Check if effect is selected
-    isEffectSelected(environment, effectName) {
-        if (!this.selectedEffects[environment]) {
-            throw new InvalidEnvironmentError(environment);
-        }
-        return this.selectedEffects[environment].has(effectName);
+    profile.vertigoSettings = {
+      selectedEffects: {
+        space: Array.from(this.selectedEffects.space),
+        ground: Array.from(this.selectedEffects.ground),
+      },
+      showPlayerSay: this.showPlayerSay,
     }
+  }
 
-    // Save state to current profile
-    saveState(profile) {
-        if (!profile.vertigoSettings) {
-            profile.vertigoSettings = {};
-        }
-        
-        profile.vertigoSettings = {
-            selectedEffects: {
-                space: Array.from(this.selectedEffects.space),
-                ground: Array.from(this.selectedEffects.ground)
-            },
-            showPlayerSay: this.showPlayerSay
-        };
-    }
+  // Load state from current profile
+  loadState(profile) {
+    if (profile && profile.vertigoSettings) {
+      const settings = profile.vertigoSettings
 
-    // Load state from current profile
-    loadState(profile) {
-        if (profile && profile.vertigoSettings) {
-            const settings = profile.vertigoSettings;
-            
-            // Restore selected effects
-            this.selectedEffects.space = new Set(settings.selectedEffects?.space || []);
-            this.selectedEffects.ground = new Set(settings.selectedEffects?.ground || []);
-            
-            // Restore PlayerSay setting
-            this.showPlayerSay = settings.showPlayerSay || false;
-        } else {
-            // Reset to defaults if no saved state
-            this.selectedEffects.space.clear();
-            this.selectedEffects.ground.clear();
-            this.showPlayerSay = false;
-        }
+      // Restore selected effects
+      this.selectedEffects.space = new Set(
+        settings.selectedEffects?.space || []
+      )
+      this.selectedEffects.ground = new Set(
+        settings.selectedEffects?.ground || []
+      )
+
+      // Restore PlayerSay setting
+      this.showPlayerSay = settings.showPlayerSay || false
+    } else {
+      // Reset to defaults if no saved state
+      this.selectedEffects.space.clear()
+      this.selectedEffects.ground.clear()
+      this.showPlayerSay = false
     }
+  }
 }
 
 // Global vertigo manager instance

--- a/src/styles.css
+++ b/src/styles.css
@@ -24,16 +24,19 @@
   --text-muted: #64748b;
   --text-light: #94a3b8;
   --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  --shadow-md:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-lg:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  --shadow-xl:
+    0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
   --radius: 0.375rem;
   --radius-lg: 0.5rem;
   --transition: all 0.2s ease-in-out;
 }
 
 /* Dark theme variables */
-[data-theme="dark"] {
+[data-theme='dark'] {
   --primary: #3b82f6;
   --primary-hover: #2563eb;
   --primary-light: #60a5fa;
@@ -58,52 +61,55 @@
   --text-muted: #94a3b8;
   --text-light: #64748b;
   --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3), 0 1px 2px 0 rgba(0, 0, 0, 0.2);
-  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
-  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.3), 0 4px 6px -2px rgba(0, 0, 0, 0.2);
-  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.3), 0 10px 10px -5px rgba(0, 0, 0, 0.2);
+  --shadow-md:
+    0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
+  --shadow-lg:
+    0 10px 15px -3px rgba(0, 0, 0, 0.3), 0 4px 6px -2px rgba(0, 0, 0, 0.2);
+  --shadow-xl:
+    0 20px 25px -5px rgba(0, 0, 0, 0.3), 0 10px 10px -5px rgba(0, 0, 0, 0.2);
 }
 
 /* Improved dark mode styles */
-[data-theme="dark"] {
+[data-theme='dark'] {
   color-scheme: dark;
 }
 
-[data-theme="dark"] .command-warning {
+[data-theme='dark'] .command-warning {
   background: rgba(251, 191, 36, 0.15);
   border-color: rgba(251, 191, 36, 0.3);
   color: #fbbf24;
 }
 
-[data-theme="dark"] input:focus,
-[data-theme="dark"] textarea:focus,
-[data-theme="dark"] select:focus {
+[data-theme='dark'] input:focus,
+[data-theme='dark'] textarea:focus,
+[data-theme='dark'] select:focus {
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.5);
 }
 
-[data-theme="dark"] .toast {
+[data-theme='dark'] .toast {
   background: var(--surface-darker);
   border: 1px solid var(--border-dark);
 }
 
-[data-theme="dark"] .modal-content {
+[data-theme='dark'] .modal-content {
   background: var(--surface);
   border: 1px solid var(--border);
 }
 
-[data-theme="dark"] .dropdown-menu {
+[data-theme='dark'] .dropdown-menu {
   background: var(--surface-dark);
   border: 1px solid var(--border-dark);
 }
 
-[data-theme="dark"] ::-webkit-scrollbar-track {
+[data-theme='dark'] ::-webkit-scrollbar-track {
   background: var(--surface-dark);
 }
 
-[data-theme="dark"] ::-webkit-scrollbar-thumb {
+[data-theme='dark'] ::-webkit-scrollbar-thumb {
   background: var(--border-dark);
 }
 
-[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
+[data-theme='dark'] ::-webkit-scrollbar-thumb:hover {
   background: var(--text-muted);
 }
 
@@ -118,7 +124,11 @@
 *,
 *::before,
 *::after {
-  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+  transition:
+    background-color 0.3s ease,
+    color 0.3s ease,
+    border-color 0.3s ease,
+    box-shadow 0.3s ease;
 }
 
 html {
@@ -127,7 +137,9 @@ html {
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
+    Cantarell, sans-serif;
   background-color: var(--background);
   color: var(--text);
   line-height: 1.6;
@@ -360,8 +372,13 @@ body {
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.7; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
 }
 
 /* Main content layout */
@@ -484,19 +501,19 @@ body {
 }
 
 /* Dynamic font sizing based on label length */
-.key-item[data-length="short"] .key-label {
+.key-item[data-length='short'] .key-label {
   font-size: 0.75rem;
 }
 
-.key-item[data-length="medium"] .key-label {
+.key-item[data-length='medium'] .key-label {
   font-size: 0.65rem;
 }
 
-.key-item[data-length="long"] .key-label {
+.key-item[data-length='long'] .key-label {
   font-size: 0.55rem;
 }
 
-.key-item[data-length="extra-long"] .key-label {
+.key-item[data-length='extra-long'] .key-label {
   font-size: 0.45rem;
 }
 
@@ -584,15 +601,15 @@ body {
 }
 
 /* Dynamic font sizing for categorized view keys */
-.command-item[data-key][data-length="short"] .key-label {
+.command-item[data-key][data-length='short'] .key-label {
   font-size: 0.875rem;
 }
 
-.command-item[data-key][data-length="medium"] .key-label {
+.command-item[data-key][data-length='medium'] .key-label {
   font-size: 0.8rem;
 }
 
-.command-item[data-key][data-length="long"] .key-label {
+.command-item[data-key][data-length='long'] .key-label {
   font-size: 0.75rem;
 }
 
@@ -782,8 +799,13 @@ body {
 }
 
 @keyframes warning-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.6; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
 }
 
 .generated-command {
@@ -808,7 +830,9 @@ body {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 0.75rem;
-  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
+  font-family:
+    'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New',
+    monospace;
   font-size: 0.85rem;
   word-break: break-all;
   color: var(--primary);
@@ -1154,7 +1178,7 @@ body {
   color: var(--primary);
 }
 
-.checkbox-label input[type="checkbox"] {
+.checkbox-label input[type='checkbox'] {
   width: 16px;
   height: 16px;
   margin: 0;
@@ -1510,8 +1534,12 @@ body {
 }
 
 @keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* Tooltip */
@@ -1549,15 +1577,33 @@ body {
 }
 
 /* Command type styling */
-.command-type.targeting { background: var(--success); }
-.command-type.combat { background: var(--danger); }
-.command-type.tray { background: var(--primary); }
-.command-type.power { background: var(--warning); }
-.command-type.movement { background: var(--accent); }
-.command-type.camera { background: #06b6d4; }
-.command-type.communication { background: #8b5cf6; }
-.command-type.system { background: var(--secondary); }
-.command-type.alias { background: linear-gradient(135deg, var(--accent), #fbbf24); }
+.command-type.targeting {
+  background: var(--success);
+}
+.command-type.combat {
+  background: var(--danger);
+}
+.command-type.tray {
+  background: var(--primary);
+}
+.command-type.power {
+  background: var(--warning);
+}
+.command-type.movement {
+  background: var(--accent);
+}
+.command-type.camera {
+  background: #06b6d4;
+}
+.command-type.communication {
+  background: #8b5cf6;
+}
+.command-type.system {
+  background: var(--secondary);
+}
+.command-type.alias {
+  background: linear-gradient(135deg, var(--accent), #fbbf24);
+}
 
 /* Command builder styles */
 .command-builder {
@@ -1736,7 +1782,7 @@ body {
   flex-shrink: 0;
 }
 
-[data-theme="dark"] .command-warning {
+[data-theme='dark'] .command-warning {
   background: #332800;
   border-color: #ffd60a;
   color: #f9f9f9;
@@ -1819,7 +1865,7 @@ body {
     grid-template-columns: 280px 1fr;
     grid-template-rows: auto 1fr;
   }
-  
+
   .command-library {
     grid-column: 1 / -1;
   }
@@ -1832,53 +1878,53 @@ body {
     gap: 0.75rem;
     padding: 0.75rem;
   }
-  
+
   .app-header {
     padding: 0.75rem 1rem;
     flex-wrap: wrap;
     gap: 1rem;
   }
-  
+
   .header-right {
     order: 3;
     width: 100%;
     justify-content: flex-end;
   }
-  
+
   .profile-bar {
     flex-direction: column;
     gap: 1rem;
     align-items: flex-start;
     padding: 1rem;
   }
-  
+
   .profile-actions {
     margin-left: 0;
     flex-wrap: wrap;
   }
-  
+
   .key-grid {
     grid-template-columns: repeat(auto-fill, minmax(50px, 1fr));
   }
-  
+
   .command-item-row {
     grid-template-columns: auto 1fr auto;
     gap: 0.5rem;
   }
-  
+
   .command-actions {
     flex-direction: column;
   }
-  
+
   .chain-bottom-actions {
     grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   }
-  
+
   .modal-content {
     width: 95vw;
     margin: 1rem;
   }
-  
+
   .large-modal .modal-content {
     width: 95vw;
   }
@@ -1889,22 +1935,22 @@ body {
     grid-template-columns: repeat(auto-fill, minmax(45px, 1fr));
     gap: 0.375rem;
   }
-  
+
   .key-item {
     padding: 0.5rem 0.25rem;
     font-size: 0.8rem;
     min-height: 50px;
   }
-  
+
   .command-item-row {
     grid-template-columns: 1fr auto;
     gap: 0.5rem;
   }
-  
+
   .command-number {
     display: none;
   }
-  
+
   .chain-header {
     flex-direction: column;
     align-items: flex-start;
@@ -1952,24 +1998,24 @@ body {
 }
 
 @keyframes fadeIn {
-  from { 
-    opacity: 0; 
-    transform: translateY(10px); 
+  from {
+    opacity: 0;
+    transform: translateY(10px);
   }
-  to { 
-    opacity: 1; 
-    transform: translateY(0); 
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 
 @keyframes slideUp {
-  from { 
-    transform: translateY(20px); 
-    opacity: 0; 
+  from {
+    transform: translateY(20px);
+    opacity: 0;
   }
-  to { 
-    transform: translateY(0); 
-    opacity: 1; 
+  to {
+    transform: translateY(0);
+    opacity: 1;
   }
 }
 
@@ -2011,7 +2057,7 @@ body {
   margin-bottom: 1rem;
 }
 
-#parameterInputs input[type="number"] {
+#parameterInputs input[type='number'] {
   width: 120px;
 }
 
@@ -2057,7 +2103,7 @@ body {
 }
 
 .command-item-row[data-parameters] .command-text::after {
-  content: "⚙️";
+  content: '⚙️';
   position: absolute;
   right: -1.2rem;
   top: 50%;
@@ -2088,16 +2134,16 @@ body {
   .toast-container {
     display: none !important;
   }
-  
+
   .main-content {
     grid-template-columns: 1fr !important;
     gap: 1rem !important;
   }
-  
+
   .command-chain-container {
     break-inside: avoid;
   }
-} 
+}
 
 /* Key Selection Modal Styles */
 .key-selection-content {
@@ -2283,20 +2329,20 @@ body {
     grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
     gap: 0.5rem;
   }
-  
+
   .key-button {
     padding: 0.5rem;
     min-height: 50px;
   }
-  
+
   .key-button .key-name {
     font-size: 0.8rem;
   }
-  
+
   .key-button .key-desc {
     font-size: 0.7rem;
   }
-  
+
   .key-category-content {
     grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
     gap: 0.5rem;
@@ -2307,7 +2353,7 @@ body {
   .common-keys-grid {
     grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
   }
-  
+
   .key-category-content {
     grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
   }
@@ -2432,7 +2478,7 @@ body {
     flex-direction: column;
     align-items: stretch;
   }
-  
+
   .input-with-button .insert-target-btn,
   .textarea-with-button .insert-target-btn {
     margin-top: 0.5rem;
@@ -2535,7 +2581,7 @@ body {
   border-color: var(--border-dark);
 }
 
-.effect-item input[type="checkbox"] {
+.effect-item input[type='checkbox'] {
   margin: 0;
   cursor: pointer;
 }
@@ -2608,13 +2654,13 @@ body {
     grid-template-columns: 1fr;
     gap: 1rem;
   }
-  
+
   .environment-header {
     flex-direction: column;
     align-items: stretch;
     gap: 0.5rem;
   }
-  
+
   .environment-controls {
     justify-content: space-between;
   }
@@ -2626,11 +2672,11 @@ body {
     align-items: stretch;
     gap: 1rem;
   }
-  
+
   .effects-list {
     max-height: 300px;
   }
-  
+
   .effect-item {
     padding: 0.75rem 0.5rem;
   }
@@ -2692,4 +2738,4 @@ body {
   white-space: pre-wrap;
   font-family: monospace;
   font-size: 0.8rem;
-} 
+}

--- a/tests/browser-setup.js
+++ b/tests/browser-setup.js
@@ -15,7 +15,7 @@ globalThis.testUtils = {
       if (element && element.offsetParent !== null) {
         return element
       }
-      await new Promise(resolve => setTimeout(resolve, 100))
+      await new Promise((resolve) => setTimeout(resolve, 100))
     }
     throw new Error(`Element ${selector} not found within ${timeout}ms`)
   },
@@ -29,13 +29,16 @@ globalThis.testUtils = {
         // For modal elements, check if the element exists and is not display:none
         const computedStyle = window.getComputedStyle(element)
         const parentModal = element.closest('.modal')
-        
+
         // If element exists and parent modal is active, consider it found
-        if (computedStyle.display !== 'none' || (parentModal && parentModal.classList.contains('active'))) {
+        if (
+          computedStyle.display !== 'none' ||
+          (parentModal && parentModal.classList.contains('active'))
+        ) {
           return element
         }
       }
-      await new Promise(resolve => setTimeout(resolve, 100))
+      await new Promise((resolve) => setTimeout(resolve, 100))
     }
     throw new Error(`Modal element ${selector} not found within ${timeout}ms`)
   },
@@ -48,7 +51,7 @@ globalThis.testUtils = {
       if (!element || element.offsetParent === null) {
         return
       }
-      await new Promise(resolve => setTimeout(resolve, 100))
+      await new Promise((resolve) => setTimeout(resolve, 100))
     }
     throw new Error(`Element ${selector} still visible after ${timeout}ms`)
   },
@@ -57,16 +60,16 @@ globalThis.testUtils = {
   typeIntoElement: async (selector, text, delay = 50) => {
     const element = document.querySelector(selector)
     if (!element) throw new Error(`Element ${selector} not found`)
-    
+
     element.focus()
     element.value = ''
-    
+
     for (const char of text) {
       element.value += char
       element.dispatchEvent(new Event('input', { bubbles: true }))
-      await new Promise(resolve => setTimeout(resolve, delay))
+      await new Promise((resolve) => setTimeout(resolve, delay))
     }
-    
+
     element.dispatchEvent(new Event('change', { bubbles: true }))
   },
 
@@ -74,9 +77,9 @@ globalThis.testUtils = {
   clickElement: async (selector, delay = 100) => {
     const element = document.querySelector(selector)
     if (!element) throw new Error(`Element ${selector} not found`)
-    
+
     element.click()
-    await new Promise(resolve => setTimeout(resolve, delay))
+    await new Promise((resolve) => setTimeout(resolve, delay))
   },
 
   // Load test data into localStorage
@@ -101,25 +104,25 @@ globalThis.testUtils = {
     await testUtils.waitForElement('.app-container')
     await testUtils.waitForElement('#appVersion')
     // Give app time to finish initialization
-    await new Promise(resolve => setTimeout(resolve, 500))
-  }
+    await new Promise((resolve) => setTimeout(resolve, 500))
+  },
 }
 
 // Function to load application HTML and scripts
 async function loadApplication() {
   if (window.app) return // Already loaded
-  
+
   // First, load the HTML structure
   try {
     const response = await fetch('/src/index.html')
     const htmlText = await response.text()
-    
+
     // Extract the body content (everything between <body> and </body>)
     const bodyMatch = htmlText.match(/<body[^>]*>([\s\S]*)<\/body>/i)
     if (bodyMatch) {
       // Clear current body and inject app HTML
       document.body.innerHTML = bodyMatch[1]
-      
+
       // Also inject any stylesheets
       const styleMatch = htmlText.match(/<link[^>]*href="styles\.css"[^>]*>/i)
       if (styleMatch) {
@@ -128,17 +131,18 @@ async function loadApplication() {
         link.href = '/src/styles.css'
         document.head.appendChild(link)
       }
-      
+
       // Add Font Awesome
       const fontAwesome = document.createElement('link')
       fontAwesome.rel = 'stylesheet'
-      fontAwesome.href = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css'
+      fontAwesome.href =
+        'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css'
       document.head.appendChild(fontAwesome)
     }
   } catch (error) {
     console.warn('Failed to load HTML structure:', error)
   }
-  
+
   // Then load the main ES module bundle
   await new Promise((resolve, reject) => {
     const script = document.createElement('script')
@@ -170,15 +174,17 @@ beforeEach(async () => {
   // Clear all storage
   localStorage.clear()
   sessionStorage.clear()
-  
+
   // Clear cookies
-  document.cookie.split(";").forEach((c) => {
-    document.cookie = c.replace(/^ +/, "").replace(/=.*/, "=;expires=" + new Date().toUTCString() + ";path=/")
+  document.cookie.split(';').forEach((c) => {
+    document.cookie = c
+      .replace(/^ +/, '')
+      .replace(/=.*/, '=;expires=' + new Date().toUTCString() + ';path=/')
   })
-  
+
   // Load application HTML and scripts if not already loaded
   await loadApplication()
-  
+
   // Wait for app initialization
   if (window.app && typeof window.app.init === 'function') {
     try {
@@ -193,16 +199,16 @@ beforeEach(async () => {
 afterEach(async () => {
   // Clear any remaining modals or overlays
   const modals = document.querySelectorAll('.modal, .overlay, .dropdown-menu')
-  modals.forEach(modal => {
+  modals.forEach((modal) => {
     if (modal.style.display !== 'none') {
       modal.style.display = 'none'
     }
   })
-  
+
   // Clear any toast notifications
   const toasts = document.querySelectorAll('.toast')
-  toasts.forEach(toast => toast.remove())
-  
+  toasts.forEach((toast) => toast.remove())
+
   // Reset any global app state
   if (window.stoKeybindManager) {
     // Reset app if it has a reset method
@@ -220,41 +226,41 @@ export async function waitForAppReady() {
   return new Promise((resolve) => {
     // If app is already ready
     if (window.app && window.app.initialized) {
-      console.log('App already initialized');
-      resolve();
-      return;
+      console.log('App already initialized')
+      resolve()
+      return
     }
 
     // Listen for the app ready event
     const handleAppReady = () => {
-      console.log('App ready event received');
-      eventBus.off('sto-app-ready', handleAppReady);
-      resolve();
-    };
+      console.log('App ready event received')
+      eventBus.off('sto-app-ready', handleAppReady)
+      resolve()
+    }
 
-    eventBus.on('sto-app-ready', handleAppReady);
-    
+    eventBus.on('sto-app-ready', handleAppReady)
+
     // Fallback timeout
     setTimeout(() => {
-      console.log('App ready timeout - checking globals');
-      eventBus.off('sto-app-ready', handleAppReady);
-      resolve();
-    }, 10000);
-  });
+      console.log('App ready timeout - checking globals')
+      eventBus.off('sto-app-ready', handleAppReady)
+      resolve()
+    }, 10000)
+  })
 }
 
 // Global setup that runs before all tests
 export default async function setup() {
-  console.log('Browser setup starting...');
-  
+  console.log('Browser setup starting...')
+
   // Wait for the application to be ready
-  await waitForAppReady();
-  
-  console.log('Browser setup complete');
+  await waitForAppReady()
+
+  console.log('Browser setup complete')
   console.log('Available globals:', {
     app: !!window.app,
     COMMANDS: !!window.COMMANDS,
     stoStorage: !!window.stoStorage,
-    stoUI: !!window.stoUI
-  });
-} 
+    stoUI: !!window.stoUI,
+  })
+}

--- a/tests/browser/check-elements.test.js
+++ b/tests/browser/check-elements.test.js
@@ -3,40 +3,45 @@ import { describe, it, expect, beforeEach } from 'vitest'
 describe('Check DOM Elements', () => {
   beforeEach(async () => {
     localStorage.clear()
-    
+
     // The setup should load the application automatically
     // Wait a bit for everything to render
-    await new Promise(resolve => setTimeout(resolve, 500))
+    await new Promise((resolve) => setTimeout(resolve, 500))
   })
 
   it('should have key elements in the DOM', () => {
     console.log('=== Checking DOM Elements ===')
-    
+
     // Check for main containers
     const appContainer = document.querySelector('.app-container')
     console.log('App container:', !!appContainer)
-    
+
     const keyGrid = document.querySelector('#keyGrid')
     console.log('Key grid:', !!keyGrid)
-    
+
     // Check for key elements
     const keyElements = document.querySelectorAll('[data-key]')
     console.log('Key elements found:', keyElements.length)
-    
+
     if (keyElements.length > 0) {
-      console.log('First few keys:', Array.from(keyElements).slice(0, 5).map(el => el.getAttribute('data-key')))
+      console.log(
+        'First few keys:',
+        Array.from(keyElements)
+          .slice(0, 5)
+          .map((el) => el.getAttribute('data-key'))
+      )
     }
-    
+
     // Check for other important elements
     const addCommandBtn = document.querySelector('#addCommandBtn')
     console.log('Add command button:', !!addCommandBtn)
-    
+
     const commandSearch = document.querySelector('#commandSearch')
     console.log('Command search:', !!commandSearch)
-    
+
     const profileSelect = document.querySelector('#profileSelect')
     console.log('Profile select:', !!profileSelect)
-    
+
     // Basic assertions
     expect(appContainer).toBeTruthy()
     expect(keyGrid).toBeTruthy()
@@ -45,24 +50,24 @@ describe('Check DOM Elements', () => {
 
   it('should be able to interact with a key', () => {
     const keyElements = document.querySelectorAll('[data-key]')
-    
+
     if (keyElements.length > 0) {
       const firstKey = keyElements[0]
       const keyName = firstKey.getAttribute('data-key')
-      
+
       console.log('Testing interaction with key:', keyName)
       console.log('Key element classes:', firstKey.className)
       console.log('App selected key before click:', window.app?.selectedKey)
-      
+
       // Try clicking the key
       firstKey.click()
-      
+
       console.log('App selected key after click:', window.app?.selectedKey)
-      
+
       // The key should be selected in the app
       expect(window.app.selectedKey).toBe(keyName)
     } else {
       throw new Error('No key elements found for interaction test')
     }
   })
-}) 
+})

--- a/tests/browser/environment-switching.test.js
+++ b/tests/browser/environment-switching.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import eventBus from '../../src/js/eventBus.js'
 
 /**
@@ -8,710 +8,741 @@ import eventBus from '../../src/js/eventBus.js'
  */
 
 describe('Environment Switching Tests', () => {
-    let app, stoStorage, stoUI;
+  let app, stoStorage, stoUI
 
-    beforeEach(async () => {
-        // Clear localStorage first
-        localStorage.clear()
-        
-        // Simple mock setup
-        if (typeof window !== 'undefined') {
-            window.alert = vi.fn()
-            window.confirm = vi.fn(() => true)
-            window.prompt = vi.fn(() => 'test input')
-        }
-        
-        // Wait for DOM to be ready with timeout
-        const waitForDOM = () => {
-            return new Promise((resolve, reject) => {
-                const timeout = setTimeout(() => {
-                    reject(new Error('DOM ready timeout'))
-                }, 5000)
-                
-                if (document.readyState === 'complete') {
-                    clearTimeout(timeout)
-                    resolve()
-                } else {
-                    document.addEventListener('DOMContentLoaded', () => {
-                        clearTimeout(timeout)
-                        resolve()
-                    }, { once: true })
-                }
-            })
-        }
-        
-        await waitForDOM()
-        
-        // Wait for the application to be fully loaded using the ready event
-        const waitForApp = () => {
-            return new Promise((resolve, reject) => {
-                // Set a timeout in case the event never fires
-                const timeout = setTimeout(() => {
-                    reject(new Error('App ready event timeout'))
-                }, 10000)
-                
-                // Listen for the app ready event
-                const handleReady = (payload) => {
-                    clearTimeout(timeout)
-                    eventBus.off('sto-app-ready', handleReady)
-                    resolve(payload.app)
-                }
+  beforeEach(async () => {
+    // Clear localStorage first
+    localStorage.clear()
 
-                const handleError = (payload) => {
-                    clearTimeout(timeout)
-                    eventBus.off('sto-app-ready', handleReady)
-                    eventBus.off('sto-app-error', handleError)
-                    reject(payload.error)
-                }
-                
-                // Check if already loaded (in case event fired before we started listening)
-                if (window.app && window.COMMANDS && window.stoStorage && window.stoUI) {
-                    clearTimeout(timeout)
-                    resolve(window.app)
-                    return
-                }
-                
-                eventBus.on('sto-app-ready', handleReady)
-                eventBus.on('sto-app-error', handleError)
-            })
-        }
+    // Simple mock setup
+    if (typeof window !== 'undefined') {
+      window.alert = vi.fn()
+      window.confirm = vi.fn(() => true)
+      window.prompt = vi.fn(() => 'test input')
+    }
 
-        try {
-            app = await waitForApp()
-            
-            // Get instances
-            stoStorage = window.stoStorage
-            stoUI = window.stoUI
-        } catch (error) {
-            console.error('Failed to wait for app:', error)
-            throw error
-        }
-        
-        // Reset to clean state and force space mode
-        if (app?.resetApplication) {
-            app.resetApplication();
-        }
-        
-        if (app) {
-            app.switchMode('space');
-            await new Promise(resolve => setTimeout(resolve, 50));
-        }
-    });
+    // Wait for DOM to be ready with timeout
+    const waitForDOM = () => {
+      return new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error('DOM ready timeout'))
+        }, 5000)
 
-    afterEach(async () => {
-        // Clean up using browser test utilities
-        if (typeof testUtils !== 'undefined') {
-            testUtils.clearAppData()
+        if (document.readyState === 'complete') {
+          clearTimeout(timeout)
+          resolve()
         } else {
-            // Fallback cleanup
-            localStorage.clear()
-            sessionStorage.clear()
+          document.addEventListener(
+            'DOMContentLoaded',
+            () => {
+              clearTimeout(timeout)
+              resolve()
+            },
+            { once: true }
+          )
         }
-        
-        // Restore original functions if we mocked them
-        if (typeof vi !== 'undefined' && vi.isMockFunction && vi.isMockFunction(window.alert)) {
-            vi.restoreAllMocks()
+      })
+    }
+
+    await waitForDOM()
+
+    // Wait for the application to be fully loaded using the ready event
+    const waitForApp = () => {
+      return new Promise((resolve, reject) => {
+        // Set a timeout in case the event never fires
+        const timeout = setTimeout(() => {
+          reject(new Error('App ready event timeout'))
+        }, 10000)
+
+        // Listen for the app ready event
+        const handleReady = (payload) => {
+          clearTimeout(timeout)
+          eventBus.off('sto-app-ready', handleReady)
+          resolve(payload.app)
         }
-    });
 
-    describe('Complete User Workflows', () => {
-        describe('UI Button Integration', () => {
-            it('should have space and ground mode buttons in DOM', () => {
-                // Test that mode buttons exist and are properly labeled
-                const spaceBtn = document.querySelector('[data-mode="space"]');
-                const groundBtn = document.querySelector('[data-mode="ground"]');
-                
-                expect(spaceBtn).toBeDefined();
-                expect(groundBtn).toBeDefined();
-                expect(spaceBtn.textContent.toLowerCase()).toContain('space');
-                expect(groundBtn.textContent.toLowerCase()).toContain('ground');
-            });
+        const handleError = (payload) => {
+          clearTimeout(timeout)
+          eventBus.off('sto-app-ready', handleReady)
+          eventBus.off('sto-app-error', handleError)
+          reject(payload.error)
+        }
 
-            it('should show space mode as active by default', () => {
-                // Test initial button state reflects space mode
-                const spaceBtn = document.querySelector('[data-mode="space"]');
-                const groundBtn = document.querySelector('[data-mode="ground"]');
-                
-                expect(spaceBtn.classList.contains('active')).toBe(true);
-                expect(groundBtn.classList.contains('active')).toBe(false);
-                expect(window.app.currentEnvironment).toBe('space');
-            });
+        // Check if already loaded (in case event fired before we started listening)
+        if (
+          window.app &&
+          window.COMMANDS &&
+          window.stoStorage &&
+          window.stoUI
+        ) {
+          clearTimeout(timeout)
+          resolve(window.app)
+          return
+        }
 
-            it('should switch button active state when clicked', () => {
-                // Test button visual state changes on click
-                const spaceBtn = document.querySelector('[data-mode="space"]');
-                const groundBtn = document.querySelector('[data-mode="ground"]');
-                
-                // Click ground button
-                groundBtn.click();
-                
-                expect(spaceBtn.classList.contains('active')).toBe(false);
-                expect(groundBtn.classList.contains('active')).toBe(true);
-                
-                // Click space button
-                spaceBtn.click();
-                
-                expect(spaceBtn.classList.contains('active')).toBe(true);
-                expect(groundBtn.classList.contains('active')).toBe(false);
-            });
+        eventBus.on('sto-app-ready', handleReady)
+        eventBus.on('sto-app-error', handleError)
+      })
+    }
 
-            it('should update application environment when button clicked', () => {
-                // Test that button clicks trigger environment changes
-                const groundBtn = document.querySelector('[data-mode="ground"]');
-                
-                expect(window.app.currentEnvironment).toBe('space');
-                
-                groundBtn.click();
-                
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
+    try {
+      app = await waitForApp()
 
-            it('should show toast notification when switching modes', async () => {
-                // Test user feedback for mode switches
-                const toastContainer = document.getElementById('toastContainer') || document.createElement('div');
-                toastContainer.id = 'toastContainer';
-                document.body.appendChild(toastContainer);
-                
-                const groundBtn = document.querySelector('[data-mode="ground"]');
-                
-                // Clear existing toasts
-                toastContainer.innerHTML = '';
-                
-                groundBtn.click();
-                
-                // Wait for toast to appear
-                await new Promise(resolve => setTimeout(resolve, 100));
-                
-                const toasts = toastContainer.querySelectorAll('.toast');
-                expect(toasts.length).toBeGreaterThan(0);
-                
-                // Check if toast contains mode switch message
-                const toastMessages = Array.from(toasts).map(toast => 
-                    toast.querySelector('.toast-message')?.textContent || ''
-                );
-                expect(toastMessages.some(msg => msg.includes('ground'))).toBe(true);
-            });
+      // Get instances
+      stoStorage = window.stoStorage
+      stoUI = window.stoUI
+    } catch (error) {
+      console.error('Failed to wait for app:', error)
+      throw error
+    }
 
-            it('should maintain button state after page interactions', () => {
-                // Test button state persistence during app usage
-                const groundBtn = document.querySelector('[data-mode="ground"]');
-                
-                groundBtn.click();
-                expect(window.app.currentEnvironment).toBe('ground');
-                
-                // Simulate other interactions
-                const keyElement = document.querySelector('[data-key]');
-                if (keyElement) {
-                    keyElement.click();
-                }
-                
-                // Environment should still be ground
-                expect(window.app.currentEnvironment).toBe('ground');
-                expect(groundBtn.classList.contains('active')).toBe(true);
-            });
-        });
+    // Reset to clean state and force space mode
+    if (app?.resetApplication) {
+      app.resetApplication()
+    }
 
-        describe('Command Library Filtering Integration', () => {
-            it('should filter command library when switching to space mode', () => {
-                // Test command visibility changes for space environment
-                window.app.switchMode('space');
-                
-                // Check that space commands are visible
-                const commandElements = document.querySelectorAll('.command-library .command-item');
-                expect(commandElements.length).toBeGreaterThan(0);
-                
-                // The filtering logic should be applied
-                expect(window.app.currentEnvironment).toBe('space');
-            });
+    if (app) {
+      app.switchMode('space')
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  })
 
-            it('should filter command library when switching to ground mode', () => {
-                // Test command visibility changes for ground environment
-                window.app.switchMode('ground');
-                
-                // Check that ground commands are visible
-                const commandElements = document.querySelectorAll('.command-library .command-item');
-                expect(commandElements.length).toBeGreaterThan(0);
-                
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
+  afterEach(async () => {
+    // Clean up using browser test utilities
+    if (typeof testUtils !== 'undefined') {
+      testUtils.clearAppData()
+    } else {
+      // Fallback cleanup
+      localStorage.clear()
+      sessionStorage.clear()
+    }
 
-            it('should show space-specific commands only in space mode', () => {
-                // Test space command filtering (fire_all, shields, etc.)
-                window.app.switchMode('space');
-                
-                // In a real implementation, we'd check for specific space commands
-                // For now, just verify the environment is set correctly
-                expect(window.app.currentEnvironment).toBe('space');
-            });
+    // Restore original functions if we mocked them
+    if (
+      typeof vi !== 'undefined' &&
+      vi.isMockFunction &&
+      vi.isMockFunction(window.alert)
+    ) {
+      vi.restoreAllMocks()
+    }
+  })
 
-            it('should show ground-specific commands only in ground mode', () => {
-                // Test ground command filtering (movement, ground combat)
-                window.app.switchMode('ground');
-                
-                // In a real implementation, we'd check for specific ground commands
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
+  describe('Complete User Workflows', () => {
+    describe('UI Button Integration', () => {
+      it('should have space and ground mode buttons in DOM', () => {
+        // Test that mode buttons exist and are properly labeled
+        const spaceBtn = document.querySelector('[data-mode="space"]')
+        const groundBtn = document.querySelector('[data-mode="ground"]')
 
-            it('should show universal commands in both modes', () => {
-                // Test targeting/system commands visible in both modes
-                window.app.switchMode('space');
-                let commandCount1 = document.querySelectorAll('.command-library .command-item').length;
-                
-                window.app.switchMode('ground');
-                let commandCount2 = document.querySelectorAll('.command-library .command-item').length;
-                
-                // Both should have some commands (universal ones)
-                expect(commandCount1).toBeGreaterThan(0);
-                expect(commandCount2).toBeGreaterThan(0);
-            });
+        expect(spaceBtn).toBeDefined()
+        expect(groundBtn).toBeDefined()
+        expect(spaceBtn.textContent.toLowerCase()).toContain('space')
+        expect(groundBtn.textContent.toLowerCase()).toContain('ground')
+      })
 
-            it('should update command search results based on environment', () => {
-                // Test search filtering respects environment
-                const searchInput = document.querySelector('#commandSearch');
-                if (searchInput) {
-                    window.app.switchMode('space');
-                    searchInput.value = 'fire';
-                    searchInput.dispatchEvent(new Event('input'));
-                    
-                    // Environment should affect search results
-                    expect(window.app.currentEnvironment).toBe('space');
-                } else {
-                    // If no search input, just verify environment switching works
-                    expect(window.app.currentEnvironment).toBe('space');
-                }
-            });
+      it('should show space mode as active by default', () => {
+        // Test initial button state reflects space mode
+        const spaceBtn = document.querySelector('[data-mode="space"]')
+        const groundBtn = document.querySelector('[data-mode="ground"]')
 
-            it('should maintain command selection state during environment switch', () => {
-                // Test selected commands persist through environment changes
-                const selectedKey = window.app.selectedKey;
-                
-                window.app.switchMode('ground');
-                window.app.switchMode('space');
-                
-                // Selected key should persist (if any was selected)
-                if (selectedKey) {
-                    expect(window.app.selectedKey).toBe(selectedKey);
-                }
-                expect(true).toBe(true); // Test passes if no errors
-            });
-        });
+        expect(spaceBtn.classList.contains('active')).toBe(true)
+        expect(groundBtn.classList.contains('active')).toBe(false)
+        expect(window.app.currentEnvironment).toBe('space')
+      })
 
-        describe('Profile Build Management Integration', () => {
-            it('should save current build before switching environments', () => {
-                // Test build persistence during environment switches
-                const profile = window.app.getCurrentProfile();
-                const initialKeys = Object.keys(profile.keys || {}).length;
-                
-                window.app.switchMode('ground');
-                
-                // Build should be saved before switching
-                expect(window.app.currentEnvironment).toBe('ground');
-                expect(true).toBe(true); // Test passes if no errors during switch
-            });
+      it('should switch button active state when clicked', () => {
+        // Test button visual state changes on click
+        const spaceBtn = document.querySelector('[data-mode="space"]')
+        const groundBtn = document.querySelector('[data-mode="ground"]')
 
-            it('should load appropriate build after environment switch', () => {
-                // Test build loading for new environment
-                window.app.switchMode('space');
-                const spaceBuild = window.app.getCurrentProfile();
-                
-                window.app.switchMode('ground');
-                const groundBuild = window.app.getCurrentProfile();
-                
-                // Builds can be different or same, but should load without error
-                expect(spaceBuild).toBeDefined();
-                expect(groundBuild).toBeDefined();
-            });
+        // Click ground button
+        groundBtn.click()
 
-            it('should maintain separate keybinds for space and ground', () => {
-                // Test space/ground build separation
-                window.app.switchMode('space');
-                const spaceKeys = Object.keys(window.app.getCurrentProfile().keys || {});
-                
-                window.app.switchMode('ground');
-                const groundKeys = Object.keys(window.app.getCurrentProfile().keys || {});
-                
-                // Keys can be same or different, test passes if no errors
-                expect(Array.isArray(spaceKeys)).toBe(true);
-                expect(Array.isArray(groundKeys)).toBe(true);
-            });
+        expect(spaceBtn.classList.contains('active')).toBe(false)
+        expect(groundBtn.classList.contains('active')).toBe(true)
 
-            it('should maintain separate aliases for space and ground', () => {
-                // Test alias separation between environments
-                window.app.switchMode('space');
-                const spaceAliases = window.app.getCurrentProfile().aliases || {};
-                
-                window.app.switchMode('ground');
-                const groundAliases = window.app.getCurrentProfile().aliases || {};
-                
-                expect(typeof spaceAliases).toBe('object');
-                expect(typeof groundAliases).toBe('object');
-            });
+        // Click space button
+        spaceBtn.click()
 
-            it('should update key grid display when switching environments', () => {
-                // Test key grid reflects current environment's build
-                window.app.switchMode('space');
-                const spaceKeyElements = document.querySelectorAll('.key-grid .key-item').length;
-                
-                window.app.switchMode('ground');
-                const groundKeyElements = document.querySelectorAll('.key-grid .key-item').length;
-                
-                // Grid should update (may have same or different number of keys)
-                expect(spaceKeyElements).toBeGreaterThanOrEqual(0);
-                expect(groundKeyElements).toBeGreaterThanOrEqual(0);
-            });
+        expect(spaceBtn.classList.contains('active')).toBe(true)
+        expect(groundBtn.classList.contains('active')).toBe(false)
+      })
 
-            it('should show unsaved changes warning when switching with modifications', () => {
-                // Test dirty state handling during environment switches
-                // For now, just test that switching works without errors
-                window.app.setModified(true);
-                window.app.switchMode('ground');
-                
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
+      it('should update application environment when button clicked', () => {
+        // Test that button clicks trigger environment changes
+        const groundBtn = document.querySelector('[data-mode="ground"]')
 
-            it('should preserve profile metadata during environment switches', () => {
-                // Test profile name, description, etc. remain unchanged
-                const profile = window.app.getCurrentProfile();
-                const originalName = profile.name;
-                
-                window.app.switchMode('ground');
-                window.app.switchMode('space');
-                
-                const finalProfile = window.app.getCurrentProfile();
-                expect(finalProfile.name).toBe(originalName);
-            });
-        });
+        expect(window.app.currentEnvironment).toBe('space')
 
-        describe('Multi-Profile Environment Switching', () => {
-            it('should remember environment per profile', () => {
-                // Test each profile remembers its last active environment
-                const currentProfile = window.app.currentProfile;
-                
-                window.app.switchMode('ground');
-                expect(window.app.currentEnvironment).toBe('ground');
-                
-                // Environment should be remembered for this profile
-                window.app.switchMode('space');
-                expect(window.app.currentEnvironment).toBe('space');
-            });
+        groundBtn.click()
 
-            it('should switch to correct environment when loading profile', () => {
-                // Test profile loading sets appropriate environment
-                if (stoStorage && stoStorage.data && stoStorage.data.profiles) {
-                    const profiles = Object.keys(stoStorage.data.profiles);
-                    if (profiles.length > 0) {
-                        app.switchProfile(profiles[0]);
-                        expect(app.currentEnvironment).toBeDefined();
-                    } else {
-                        expect(true).toBe(true); // No profiles to test with
-                    }
-                } else {
-                    // Storage not available, just test that environment is defined
-                    expect(app.currentEnvironment).toBeDefined();
-                }
-            });
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
 
-            it('should handle environment switching across different profiles', () => {
-                // Test switching profiles with different environments
-                window.app.switchMode('space');
-                expect(window.app.currentEnvironment).toBe('space');
-                
-                window.app.switchMode('ground');
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
+      it('should show toast notification when switching modes', async () => {
+        // Test user feedback for mode switches
+        const toastContainer =
+          document.getElementById('toastContainer') ||
+          document.createElement('div')
+        toastContainer.id = 'toastContainer'
+        document.body.appendChild(toastContainer)
 
-            it('should maintain environment state during profile operations', () => {
-                // Test environment persists during profile create/delete/rename
-                window.app.switchMode('ground');
-                const environment = window.app.currentEnvironment;
-                
-                // Simulate profile operations (without actually creating/deleting)
-                window.app.renderProfiles();
-                
-                expect(window.app.currentEnvironment).toBe(environment);
-            });
-        });
+        const groundBtn = document.querySelector('[data-mode="ground"]')
 
-        describe('Environment-Specific UI Updates', () => {
-            it('should update page title to reflect current environment', () => {
-                // Test page title includes environment indicator
-                window.app.switchMode('space');
-                expect(window.app.currentEnvironment).toBe('space');
-                
-                window.app.switchMode('ground');
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
+        // Clear existing toasts
+        toastContainer.innerHTML = ''
 
-            it('should update navigation breadcrumbs with environment', () => {
-                // Test breadcrumb shows current environment
-                window.app.switchMode('space');
-                expect(window.app.currentEnvironment).toBe('space');
-            });
+        groundBtn.click()
 
-            it('should show environment-specific help text', () => {
-                // Test help content adapts to environment
-                window.app.switchMode('ground');
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
+        // Wait for toast to appear
+        await new Promise((resolve) => setTimeout(resolve, 100))
 
-            it('should update export options based on environment', () => {
-                // Test export shows environment-appropriate options
-                window.app.switchMode('space');
-                expect(window.app.currentEnvironment).toBe('space');
-            });
+        const toasts = toastContainer.querySelectorAll('.toast')
+        expect(toasts.length).toBeGreaterThan(0)
 
-            it('should show environment warnings for incompatible operations', () => {
-                // Test warnings for environment-specific actions
-                window.app.switchMode('ground');
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
-        });
+        // Check if toast contains mode switch message
+        const toastMessages = Array.from(toasts).map(
+          (toast) => toast.querySelector('.toast-message')?.textContent || ''
+        )
+        expect(toastMessages.some((msg) => msg.includes('ground'))).toBe(true)
+      })
 
-        describe('Keyboard Shortcuts for Environment Switching', () => {
-            it('should support keyboard shortcut for space mode', () => {
-                // Test keyboard shortcut to switch to space
-                window.app.switchMode('space');
-                expect(window.app.currentEnvironment).toBe('space');
-            });
+      it('should maintain button state after page interactions', () => {
+        // Test button state persistence during app usage
+        const groundBtn = document.querySelector('[data-mode="ground"]')
 
-            it('should support keyboard shortcut for ground mode', () => {
-                // Test keyboard shortcut to switch to ground
-                window.app.switchMode('ground');
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
+        groundBtn.click()
+        expect(window.app.currentEnvironment).toBe('ground')
 
-            it('should support keyboard shortcut to toggle between modes', () => {
-                // Test toggle shortcut between space/ground
-                window.app.switchMode('space');
-                expect(window.app.currentEnvironment).toBe('space');
-                
-                window.app.switchMode('ground');
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
+        // Simulate other interactions
+        const keyElement = document.querySelector('[data-key]')
+        if (keyElement) {
+          keyElement.click()
+        }
 
-            it('should show keyboard shortcuts in tooltips', () => {
-                // Test tooltips display keyboard shortcuts
-                const spaceBtn = document.querySelector('[data-mode="space"]');
-                const groundBtn = document.querySelector('[data-mode="ground"]');
-                
-                // Buttons should exist (tooltips are optional)
-                expect(spaceBtn).toBeDefined();
-                expect(groundBtn).toBeDefined();
-            });
-        });
-    });
+        // Environment should still be ground
+        expect(window.app.currentEnvironment).toBe('ground')
+        expect(groundBtn.classList.contains('active')).toBe(true)
+      })
+    })
 
-    describe('Data Integrity', () => {
-        describe('Build Data Preservation', () => {
-            it('should preserve keybind data when switching environments', () => {
-                // Test keybind data integrity through environment switches
-                const profile = window.app.getCurrentProfile();
-                const originalKeys = JSON.stringify(profile.keys || {});
-                
-                window.app.switchMode('ground');
-                window.app.switchMode('space');
-                
-                const finalKeys = JSON.stringify(window.app.getCurrentProfile().keys || {});
-                
-                // Keys should be preserved (though they may be different per environment)
-                expect(typeof finalKeys).toBe('string');
-                expect(true).toBe(true); // Test passes if no errors
-            });
+    describe('Command Library Filtering Integration', () => {
+      it('should filter command library when switching to space mode', () => {
+        // Test command visibility changes for space environment
+        window.app.switchMode('space')
 
-            it('should preserve alias data when switching environments', () => {
-                // Test alias data integrity through environment switches
-                const profile = window.app.getCurrentProfile();
-                const originalAliases = profile.aliases || {};
-                
-                window.app.switchMode('ground');
-                window.app.switchMode('space');
-                
-                const finalAliases = window.app.getCurrentProfile().aliases || {};
-                
-                expect(typeof originalAliases).toBe('object');
-                expect(typeof finalAliases).toBe('object');
-            });
+        // Check that space commands are visible
+        const commandElements = document.querySelectorAll(
+          '.command-library .command-item'
+        )
+        expect(commandElements.length).toBeGreaterThan(0)
 
-            it('should preserve command parameters when switching environments', () => {
-                // Test parameterized commands survive environment switches
-                window.app.switchMode('space');
-                window.app.switchMode('ground');
-                
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
+        // The filtering logic should be applied
+        expect(window.app.currentEnvironment).toBe('space')
+      })
 
-            it('should handle empty builds gracefully', () => {
-                // Test switching to environment with no configured keybinds
-                window.app.switchMode('space');
-                window.app.switchMode('ground');
-                
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
+      it('should filter command library when switching to ground mode', () => {
+        // Test command visibility changes for ground environment
+        window.app.switchMode('ground')
 
-            it('should handle corrupted build data gracefully', () => {
-                // Test error recovery for corrupted environment data
-                window.app.switchMode('space');
-                expect(window.app.currentEnvironment).toBe('space');
-            });
-        });
+        // Check that ground commands are visible
+        const commandElements = document.querySelectorAll(
+          '.command-library .command-item'
+        )
+        expect(commandElements.length).toBeGreaterThan(0)
 
-        describe('Profile Structure Migration', () => {
-            it('should migrate old profile format to new builds structure', () => {
-                // Test migration from legacy profile format
-                expect(window.app.currentEnvironment).toBeDefined();
-            });
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
 
-            it('should preserve data during migration', () => {
-                // Test no data loss during profile format migration
-                expect(window.app.getCurrentProfile()).toBeDefined();
-            });
+      it('should show space-specific commands only in space mode', () => {
+        // Test space command filtering (fire_all, shields, etc.)
+        window.app.switchMode('space')
 
-            it('should handle mixed profile formats in same project', () => {
-                // Test compatibility with mixed old/new profile formats
-                expect(window.stoStorage).toBeDefined();
-            });
+        // In a real implementation, we'd check for specific space commands
+        // For now, just verify the environment is set correctly
+        expect(window.app.currentEnvironment).toBe('space')
+      })
 
-            it('should maintain backwards compatibility', () => {
-                // Test legacy profiles continue to work
-                expect(window.app.currentEnvironment).toBeDefined();
-            });
-        });
+      it('should show ground-specific commands only in ground mode', () => {
+        // Test ground command filtering (movement, ground combat)
+        window.app.switchMode('ground')
 
-        describe('Storage Synchronization', () => {
-            it('should synchronize build changes to localStorage', () => {
-                // Test localStorage updates when builds change
-                window.app.switchMode('ground');
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
+        // In a real implementation, we'd check for specific ground commands
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
 
-            it('should handle localStorage quota exceeded gracefully', () => {
-                // Test error handling for storage limits
-                expect(window.stoStorage).toBeDefined();
-            });
+      it('should show universal commands in both modes', () => {
+        // Test targeting/system commands visible in both modes
+        window.app.switchMode('space')
+        let commandCount1 = document.querySelectorAll(
+          '.command-library .command-item'
+        ).length
 
-            it('should recover from localStorage corruption', () => {
-                // Test recovery when localStorage data is corrupted
-                expect(window.app.currentEnvironment).toBeDefined();
-            });
+        window.app.switchMode('ground')
+        let commandCount2 = document.querySelectorAll(
+          '.command-library .command-item'
+        ).length
 
-            it('should maintain data consistency across browser tabs', () => {
-                // Test multi-tab data synchronization
-                if (stoStorage && stoStorage.data) {
-                    expect(stoStorage.data).toBeDefined();
-                } else {
-                    // Storage may not be fully initialized, just check that stoStorage exists
-                    expect(stoStorage).toBeDefined();
-                }
-            });
-        });
-    });
+        // Both should have some commands (universal ones)
+        expect(commandCount1).toBeGreaterThan(0)
+        expect(commandCount2).toBeGreaterThan(0)
+      })
 
-    describe('Performance', () => {
-        describe('Switching Performance', () => {
-            it('should switch environments within acceptable time', () => {
-                // Test environment switching performance
-                const startTime = performance.now();
-                window.app.switchMode('ground');
-                const endTime = performance.now();
-                
-                expect(endTime - startTime).toBeLessThan(1000); // Should be under 1 second
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
+      it('should update command search results based on environment', () => {
+        // Test search filtering respects environment
+        const searchInput = document.querySelector('#commandSearch')
+        if (searchInput) {
+          window.app.switchMode('space')
+          searchInput.value = 'fire'
+          searchInput.dispatchEvent(new Event('input'))
 
-            it('should not block UI during environment switch', () => {
-                // Test UI remains responsive during switches
-                window.app.switchMode('ground');
-                
-                // UI should still be responsive
-                expect(document.querySelector('body')).toBeDefined();
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
+          // Environment should affect search results
+          expect(window.app.currentEnvironment).toBe('space')
+        } else {
+          // If no search input, just verify environment switching works
+          expect(window.app.currentEnvironment).toBe('space')
+        }
+      })
 
-            it('should handle rapid environment switching gracefully', () => {
-                // Test rapid clicking doesn't cause issues
-                window.app.switchMode('ground');
-                window.app.switchMode('space');
-                window.app.switchMode('ground');
-                window.app.switchMode('space');
-                
-                expect(window.app.currentEnvironment).toBe('space');
-            });
+      it('should maintain command selection state during environment switch', () => {
+        // Test selected commands persist through environment changes
+        const selectedKey = window.app.selectedKey
 
-            it('should debounce rapid environment switch requests', () => {
-                // Test debouncing prevents excessive switching
-                for (let i = 0; i < 5; i++) {
-                    window.app.switchMode(i % 2 === 0 ? 'space' : 'ground');
-                }
-                
-                expect(['space', 'ground']).toContain(window.app.currentEnvironment);
-            });
-        });
+        window.app.switchMode('ground')
+        window.app.switchMode('space')
 
-        describe('Memory Management', () => {
-            it('should not leak memory during environment switches', () => {
-                // Test memory usage doesn't grow with switches
-                for (let i = 0; i < 10; i++) {
-                    window.app.switchMode(i % 2 === 0 ? 'space' : 'ground');
-                }
-                
-                expect(['space', 'ground']).toContain(window.app.currentEnvironment);
-            });
+        // Selected key should persist (if any was selected)
+        if (selectedKey) {
+          expect(window.app.selectedKey).toBe(selectedKey)
+        }
+        expect(true).toBe(true) // Test passes if no errors
+      })
+    })
 
-            it('should clean up event listeners when switching', () => {
-                // Test proper cleanup of environment-specific listeners
-                window.app.switchMode('ground');
-                window.app.switchMode('space');
-                
-                expect(window.app.currentEnvironment).toBe('space');
-            });
+    describe('Profile Build Management Integration', () => {
+      it('should save current build before switching environments', () => {
+        // Test build persistence during environment switches
+        const profile = window.app.getCurrentProfile()
+        const initialKeys = Object.keys(profile.keys || {}).length
 
-            it('should handle large profiles efficiently during switches', () => {
-                // Test performance with large keybind sets
-                window.app.switchMode('ground');
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
-        });
+        window.app.switchMode('ground')
 
-        describe('UI Responsiveness', () => {
-            it('should provide immediate visual feedback on button click', () => {
-                // Test button click provides instant feedback
-                const groundBtn = document.querySelector('[data-mode="ground"]');
-                if (groundBtn) {
-                    groundBtn.click();
-                    expect(groundBtn.classList.contains('active')).toBe(true);
-                } else {
-                    expect(true).toBe(true); // No button found, test passes
-                }
-            });
+        // Build should be saved before switching
+        expect(window.app.currentEnvironment).toBe('ground')
+        expect(true).toBe(true) // Test passes if no errors during switch
+      })
 
-            it('should show loading state for slow environment switches', () => {
-                // Test loading indicators for slow operations
-                window.app.switchMode('ground');
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
+      it('should load appropriate build after environment switch', () => {
+        // Test build loading for new environment
+        window.app.switchMode('space')
+        const spaceBuild = window.app.getCurrentProfile()
 
-            it('should maintain scroll position during environment switch', () => {
-                // Test UI state preservation during switches
-                const scrollY = window.scrollY;
-                window.app.switchMode('ground');
-                
-                // Scroll position may or may not be preserved, test passes if no errors
-                expect(window.app.currentEnvironment).toBe('ground');
-            });
+        window.app.switchMode('ground')
+        const groundBuild = window.app.getCurrentProfile()
 
-            it('should preserve form input during environment switch', () => {
-                // Test form data preserved through environment changes
-                const searchInput = document.querySelector('#commandSearch');
-                if (searchInput) {
-                    searchInput.value = 'test';
-                    window.app.switchMode('ground');
-                    
-                    // Input may or may not be preserved, test passes if no errors
-                    expect(window.app.currentEnvironment).toBe('ground');
-                } else {
-                    expect(true).toBe(true); // No search input found
-                }
-            });
-        });
-    });
-}); 
+        // Builds can be different or same, but should load without error
+        expect(spaceBuild).toBeDefined()
+        expect(groundBuild).toBeDefined()
+      })
+
+      it('should maintain separate keybinds for space and ground', () => {
+        // Test space/ground build separation
+        window.app.switchMode('space')
+        const spaceKeys = Object.keys(window.app.getCurrentProfile().keys || {})
+
+        window.app.switchMode('ground')
+        const groundKeys = Object.keys(
+          window.app.getCurrentProfile().keys || {}
+        )
+
+        // Keys can be same or different, test passes if no errors
+        expect(Array.isArray(spaceKeys)).toBe(true)
+        expect(Array.isArray(groundKeys)).toBe(true)
+      })
+
+      it('should maintain separate aliases for space and ground', () => {
+        // Test alias separation between environments
+        window.app.switchMode('space')
+        const spaceAliases = window.app.getCurrentProfile().aliases || {}
+
+        window.app.switchMode('ground')
+        const groundAliases = window.app.getCurrentProfile().aliases || {}
+
+        expect(typeof spaceAliases).toBe('object')
+        expect(typeof groundAliases).toBe('object')
+      })
+
+      it('should update key grid display when switching environments', () => {
+        // Test key grid reflects current environment's build
+        window.app.switchMode('space')
+        const spaceKeyElements = document.querySelectorAll(
+          '.key-grid .key-item'
+        ).length
+
+        window.app.switchMode('ground')
+        const groundKeyElements = document.querySelectorAll(
+          '.key-grid .key-item'
+        ).length
+
+        // Grid should update (may have same or different number of keys)
+        expect(spaceKeyElements).toBeGreaterThanOrEqual(0)
+        expect(groundKeyElements).toBeGreaterThanOrEqual(0)
+      })
+
+      it('should show unsaved changes warning when switching with modifications', () => {
+        // Test dirty state handling during environment switches
+        // For now, just test that switching works without errors
+        window.app.setModified(true)
+        window.app.switchMode('ground')
+
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
+
+      it('should preserve profile metadata during environment switches', () => {
+        // Test profile name, description, etc. remain unchanged
+        const profile = window.app.getCurrentProfile()
+        const originalName = profile.name
+
+        window.app.switchMode('ground')
+        window.app.switchMode('space')
+
+        const finalProfile = window.app.getCurrentProfile()
+        expect(finalProfile.name).toBe(originalName)
+      })
+    })
+
+    describe('Multi-Profile Environment Switching', () => {
+      it('should remember environment per profile', () => {
+        // Test each profile remembers its last active environment
+        const currentProfile = window.app.currentProfile
+
+        window.app.switchMode('ground')
+        expect(window.app.currentEnvironment).toBe('ground')
+
+        // Environment should be remembered for this profile
+        window.app.switchMode('space')
+        expect(window.app.currentEnvironment).toBe('space')
+      })
+
+      it('should switch to correct environment when loading profile', () => {
+        // Test profile loading sets appropriate environment
+        if (stoStorage && stoStorage.data && stoStorage.data.profiles) {
+          const profiles = Object.keys(stoStorage.data.profiles)
+          if (profiles.length > 0) {
+            app.switchProfile(profiles[0])
+            expect(app.currentEnvironment).toBeDefined()
+          } else {
+            expect(true).toBe(true) // No profiles to test with
+          }
+        } else {
+          // Storage not available, just test that environment is defined
+          expect(app.currentEnvironment).toBeDefined()
+        }
+      })
+
+      it('should handle environment switching across different profiles', () => {
+        // Test switching profiles with different environments
+        window.app.switchMode('space')
+        expect(window.app.currentEnvironment).toBe('space')
+
+        window.app.switchMode('ground')
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
+
+      it('should maintain environment state during profile operations', () => {
+        // Test environment persists during profile create/delete/rename
+        window.app.switchMode('ground')
+        const environment = window.app.currentEnvironment
+
+        // Simulate profile operations (without actually creating/deleting)
+        window.app.renderProfiles()
+
+        expect(window.app.currentEnvironment).toBe(environment)
+      })
+    })
+
+    describe('Environment-Specific UI Updates', () => {
+      it('should update page title to reflect current environment', () => {
+        // Test page title includes environment indicator
+        window.app.switchMode('space')
+        expect(window.app.currentEnvironment).toBe('space')
+
+        window.app.switchMode('ground')
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
+
+      it('should update navigation breadcrumbs with environment', () => {
+        // Test breadcrumb shows current environment
+        window.app.switchMode('space')
+        expect(window.app.currentEnvironment).toBe('space')
+      })
+
+      it('should show environment-specific help text', () => {
+        // Test help content adapts to environment
+        window.app.switchMode('ground')
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
+
+      it('should update export options based on environment', () => {
+        // Test export shows environment-appropriate options
+        window.app.switchMode('space')
+        expect(window.app.currentEnvironment).toBe('space')
+      })
+
+      it('should show environment warnings for incompatible operations', () => {
+        // Test warnings for environment-specific actions
+        window.app.switchMode('ground')
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
+    })
+
+    describe('Keyboard Shortcuts for Environment Switching', () => {
+      it('should support keyboard shortcut for space mode', () => {
+        // Test keyboard shortcut to switch to space
+        window.app.switchMode('space')
+        expect(window.app.currentEnvironment).toBe('space')
+      })
+
+      it('should support keyboard shortcut for ground mode', () => {
+        // Test keyboard shortcut to switch to ground
+        window.app.switchMode('ground')
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
+
+      it('should support keyboard shortcut to toggle between modes', () => {
+        // Test toggle shortcut between space/ground
+        window.app.switchMode('space')
+        expect(window.app.currentEnvironment).toBe('space')
+
+        window.app.switchMode('ground')
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
+
+      it('should show keyboard shortcuts in tooltips', () => {
+        // Test tooltips display keyboard shortcuts
+        const spaceBtn = document.querySelector('[data-mode="space"]')
+        const groundBtn = document.querySelector('[data-mode="ground"]')
+
+        // Buttons should exist (tooltips are optional)
+        expect(spaceBtn).toBeDefined()
+        expect(groundBtn).toBeDefined()
+      })
+    })
+  })
+
+  describe('Data Integrity', () => {
+    describe('Build Data Preservation', () => {
+      it('should preserve keybind data when switching environments', () => {
+        // Test keybind data integrity through environment switches
+        const profile = window.app.getCurrentProfile()
+        const originalKeys = JSON.stringify(profile.keys || {})
+
+        window.app.switchMode('ground')
+        window.app.switchMode('space')
+
+        const finalKeys = JSON.stringify(
+          window.app.getCurrentProfile().keys || {}
+        )
+
+        // Keys should be preserved (though they may be different per environment)
+        expect(typeof finalKeys).toBe('string')
+        expect(true).toBe(true) // Test passes if no errors
+      })
+
+      it('should preserve alias data when switching environments', () => {
+        // Test alias data integrity through environment switches
+        const profile = window.app.getCurrentProfile()
+        const originalAliases = profile.aliases || {}
+
+        window.app.switchMode('ground')
+        window.app.switchMode('space')
+
+        const finalAliases = window.app.getCurrentProfile().aliases || {}
+
+        expect(typeof originalAliases).toBe('object')
+        expect(typeof finalAliases).toBe('object')
+      })
+
+      it('should preserve command parameters when switching environments', () => {
+        // Test parameterized commands survive environment switches
+        window.app.switchMode('space')
+        window.app.switchMode('ground')
+
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
+
+      it('should handle empty builds gracefully', () => {
+        // Test switching to environment with no configured keybinds
+        window.app.switchMode('space')
+        window.app.switchMode('ground')
+
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
+
+      it('should handle corrupted build data gracefully', () => {
+        // Test error recovery for corrupted environment data
+        window.app.switchMode('space')
+        expect(window.app.currentEnvironment).toBe('space')
+      })
+    })
+
+    describe('Profile Structure Migration', () => {
+      it('should migrate old profile format to new builds structure', () => {
+        // Test migration from legacy profile format
+        expect(window.app.currentEnvironment).toBeDefined()
+      })
+
+      it('should preserve data during migration', () => {
+        // Test no data loss during profile format migration
+        expect(window.app.getCurrentProfile()).toBeDefined()
+      })
+
+      it('should handle mixed profile formats in same project', () => {
+        // Test compatibility with mixed old/new profile formats
+        expect(window.stoStorage).toBeDefined()
+      })
+
+      it('should maintain backwards compatibility', () => {
+        // Test legacy profiles continue to work
+        expect(window.app.currentEnvironment).toBeDefined()
+      })
+    })
+
+    describe('Storage Synchronization', () => {
+      it('should synchronize build changes to localStorage', () => {
+        // Test localStorage updates when builds change
+        window.app.switchMode('ground')
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
+
+      it('should handle localStorage quota exceeded gracefully', () => {
+        // Test error handling for storage limits
+        expect(window.stoStorage).toBeDefined()
+      })
+
+      it('should recover from localStorage corruption', () => {
+        // Test recovery when localStorage data is corrupted
+        expect(window.app.currentEnvironment).toBeDefined()
+      })
+
+      it('should maintain data consistency across browser tabs', () => {
+        // Test multi-tab data synchronization
+        if (stoStorage && stoStorage.data) {
+          expect(stoStorage.data).toBeDefined()
+        } else {
+          // Storage may not be fully initialized, just check that stoStorage exists
+          expect(stoStorage).toBeDefined()
+        }
+      })
+    })
+  })
+
+  describe('Performance', () => {
+    describe('Switching Performance', () => {
+      it('should switch environments within acceptable time', () => {
+        // Test environment switching performance
+        const startTime = performance.now()
+        window.app.switchMode('ground')
+        const endTime = performance.now()
+
+        expect(endTime - startTime).toBeLessThan(1000) // Should be under 1 second
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
+
+      it('should not block UI during environment switch', () => {
+        // Test UI remains responsive during switches
+        window.app.switchMode('ground')
+
+        // UI should still be responsive
+        expect(document.querySelector('body')).toBeDefined()
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
+
+      it('should handle rapid environment switching gracefully', () => {
+        // Test rapid clicking doesn't cause issues
+        window.app.switchMode('ground')
+        window.app.switchMode('space')
+        window.app.switchMode('ground')
+        window.app.switchMode('space')
+
+        expect(window.app.currentEnvironment).toBe('space')
+      })
+
+      it('should debounce rapid environment switch requests', () => {
+        // Test debouncing prevents excessive switching
+        for (let i = 0; i < 5; i++) {
+          window.app.switchMode(i % 2 === 0 ? 'space' : 'ground')
+        }
+
+        expect(['space', 'ground']).toContain(window.app.currentEnvironment)
+      })
+    })
+
+    describe('Memory Management', () => {
+      it('should not leak memory during environment switches', () => {
+        // Test memory usage doesn't grow with switches
+        for (let i = 0; i < 10; i++) {
+          window.app.switchMode(i % 2 === 0 ? 'space' : 'ground')
+        }
+
+        expect(['space', 'ground']).toContain(window.app.currentEnvironment)
+      })
+
+      it('should clean up event listeners when switching', () => {
+        // Test proper cleanup of environment-specific listeners
+        window.app.switchMode('ground')
+        window.app.switchMode('space')
+
+        expect(window.app.currentEnvironment).toBe('space')
+      })
+
+      it('should handle large profiles efficiently during switches', () => {
+        // Test performance with large keybind sets
+        window.app.switchMode('ground')
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
+    })
+
+    describe('UI Responsiveness', () => {
+      it('should provide immediate visual feedback on button click', () => {
+        // Test button click provides instant feedback
+        const groundBtn = document.querySelector('[data-mode="ground"]')
+        if (groundBtn) {
+          groundBtn.click()
+          expect(groundBtn.classList.contains('active')).toBe(true)
+        } else {
+          expect(true).toBe(true) // No button found, test passes
+        }
+      })
+
+      it('should show loading state for slow environment switches', () => {
+        // Test loading indicators for slow operations
+        window.app.switchMode('ground')
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
+
+      it('should maintain scroll position during environment switch', () => {
+        // Test UI state preservation during switches
+        const scrollY = window.scrollY
+        window.app.switchMode('ground')
+
+        // Scroll position may or may not be preserved, test passes if no errors
+        expect(window.app.currentEnvironment).toBe('ground')
+      })
+
+      it('should preserve form input during environment switch', () => {
+        // Test form data preserved through environment changes
+        const searchInput = document.querySelector('#commandSearch')
+        if (searchInput) {
+          searchInput.value = 'test'
+          window.app.switchMode('ground')
+
+          // Input may or may not be preserved, test passes if no errors
+          expect(window.app.currentEnvironment).toBe('ground')
+        } else {
+          expect(true).toBe(true) // No search input found
+        }
+      })
+    })
+  })
+})

--- a/tests/browser/file-operations.test.js
+++ b/tests/browser/file-operations.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import eventBus from '../../src/js/eventBus.js'
 
 /**
@@ -8,725 +8,779 @@ import eventBus from '../../src/js/eventBus.js'
  */
 
 describe('File Import/Export Operations', () => {
-    let app, stoStorage, stoUI, stoExport, stoKeybinds;
+  let app, stoStorage, stoUI, stoExport, stoKeybinds
 
-    beforeEach(async () => {
-        // Clear localStorage first
-        localStorage.clear()
-        
-        // Simple mock setup
-        if (typeof window !== 'undefined') {
-            window.alert = vi.fn()
-            window.confirm = vi.fn(() => true)
-            window.prompt = vi.fn(() => 'test input')
-        }
-        
-        // Wait for DOM to be ready with timeout
-        const waitForDOM = () => {
-            return new Promise((resolve, reject) => {
-                const timeout = setTimeout(() => {
-                    reject(new Error('DOM ready timeout'))
-                }, 5000)
-                
-                if (document.readyState === 'complete') {
-                    clearTimeout(timeout)
-                    resolve()
-                } else {
-                    document.addEventListener('DOMContentLoaded', () => {
-                        clearTimeout(timeout)
-                        resolve()
-                    }, { once: true })
-                }
-            })
-        }
-        
-        await waitForDOM()
-        
-        // Wait for the application to be fully loaded using the ready event
-        const waitForApp = () => {
-            return new Promise((resolve, reject) => {
-                // Set a timeout in case the event never fires
-                const timeout = setTimeout(() => {
-                    reject(new Error('App ready event timeout'))
-                }, 10000)
-                
-                // Listen for the app ready event
-                const handleReady = (payload) => {
-                    clearTimeout(timeout)
-                    eventBus.off('sto-app-ready', handleReady)
-                    resolve(payload.app)
-                }
+  beforeEach(async () => {
+    // Clear localStorage first
+    localStorage.clear()
 
-                const handleError = (payload) => {
-                    clearTimeout(timeout)
-                    eventBus.off('sto-app-ready', handleReady)
-                    eventBus.off('sto-app-error', handleError)
-                    reject(payload.error)
-                }
-                
-                // Check if already loaded (in case event fired before we started listening)
-                if (window.app && window.COMMANDS && window.stoStorage && window.stoUI) {
-                    clearTimeout(timeout)
-                    resolve(window.app)
-                    return
-                }
-                
-                eventBus.on('sto-app-ready', handleReady)
-                eventBus.on('sto-app-error', handleError)
-            })
-        }
+    // Simple mock setup
+    if (typeof window !== 'undefined') {
+      window.alert = vi.fn()
+      window.confirm = vi.fn(() => true)
+      window.prompt = vi.fn(() => 'test input')
+    }
 
-        try {
-            app = await waitForApp()
-            
-            // Get instances
-            stoStorage = window.stoStorage
-            stoUI = window.stoUI
-            stoExport = window.stoExport
-            stoKeybinds = window.stoKeybinds
-        } catch (error) {
-            console.error('Failed to wait for app:', error)
-            throw error
-        }
-        
-        // Reset application state
-        if (app?.resetApplication) {
-            app.resetApplication();
-        }
-    });
+    // Wait for DOM to be ready with timeout
+    const waitForDOM = () => {
+      return new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error('DOM ready timeout'))
+        }, 5000)
 
-    afterEach(async () => {
-        // Clean up using browser test utilities
-        if (typeof testUtils !== 'undefined') {
-            testUtils.clearAppData()
+        if (document.readyState === 'complete') {
+          clearTimeout(timeout)
+          resolve()
         } else {
-            // Fallback cleanup
-            localStorage.clear()
-            sessionStorage.clear()
+          document.addEventListener(
+            'DOMContentLoaded',
+            () => {
+              clearTimeout(timeout)
+              resolve()
+            },
+            { once: true }
+          )
         }
-        
-        // Restore original functions if we mocked them
-        if (typeof vi !== 'undefined' && vi.isMockFunction && vi.isMockFunction(window.alert)) {
-            vi.restoreAllMocks()
-        }
-    });
+      })
+    }
 
-    describe('STO Keybind File Import', () => {
-        it('should import real STO bind file and create profile', () => {
-            // Create a test profile first
-            const profileId = app.createProfile('Import Test Profile');
-            app.switchProfile(profileId);
-            
-            // Sample STO bind file content
-            const bindFileContent = `; STO Keybind File
+    await waitForDOM()
+
+    // Wait for the application to be fully loaded using the ready event
+    const waitForApp = () => {
+      return new Promise((resolve, reject) => {
+        // Set a timeout in case the event never fires
+        const timeout = setTimeout(() => {
+          reject(new Error('App ready event timeout'))
+        }, 10000)
+
+        // Listen for the app ready event
+        const handleReady = (payload) => {
+          clearTimeout(timeout)
+          eventBus.off('sto-app-ready', handleReady)
+          resolve(payload.app)
+        }
+
+        const handleError = (payload) => {
+          clearTimeout(timeout)
+          eventBus.off('sto-app-ready', handleReady)
+          eventBus.off('sto-app-error', handleError)
+          reject(payload.error)
+        }
+
+        // Check if already loaded (in case event fired before we started listening)
+        if (
+          window.app &&
+          window.COMMANDS &&
+          window.stoStorage &&
+          window.stoUI
+        ) {
+          clearTimeout(timeout)
+          resolve(window.app)
+          return
+        }
+
+        eventBus.on('sto-app-ready', handleReady)
+        eventBus.on('sto-app-error', handleError)
+      })
+    }
+
+    try {
+      app = await waitForApp()
+
+      // Get instances
+      stoStorage = window.stoStorage
+      stoUI = window.stoUI
+      stoExport = window.stoExport
+      stoKeybinds = window.stoKeybinds
+    } catch (error) {
+      console.error('Failed to wait for app:', error)
+      throw error
+    }
+
+    // Reset application state
+    if (app?.resetApplication) {
+      app.resetApplication()
+    }
+  })
+
+  afterEach(async () => {
+    // Clean up using browser test utilities
+    if (typeof testUtils !== 'undefined') {
+      testUtils.clearAppData()
+    } else {
+      // Fallback cleanup
+      localStorage.clear()
+      sessionStorage.clear()
+    }
+
+    // Restore original functions if we mocked them
+    if (
+      typeof vi !== 'undefined' &&
+      vi.isMockFunction &&
+      vi.isMockFunction(window.alert)
+    ) {
+      vi.restoreAllMocks()
+    }
+  })
+
+  describe('STO Keybind File Import', () => {
+    it('should import real STO bind file and create profile', () => {
+      // Create a test profile first
+      const profileId = app.createProfile('Import Test Profile')
+      app.switchProfile(profileId)
+
+      // Sample STO bind file content
+      const bindFileContent = `; STO Keybind File
 alias test_alias "say Hello World"
 bind Space "+STOTrayExecByTray 0 0$$+STOTrayExecByTray 1 0"
 bind F1 "GenSendMessage HUD_Root FireAll"
 bind W "+forward"
-bind Button4 "GenSendMessage HUD_Root FireAll"`;
-            
-            // Test import functionality
-            if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
-                const result = stoKeybinds.importKeybindFile(bindFileContent);
-                
-                // Verify import was successful
-                expect(result).toBeDefined();
-                
-                // Check that profile has imported data
-                const profile = app.getCurrentProfile();
-                expect(profile).toBeDefined();
-                
-                // Check for keys in various possible locations
-                const hasKeys = (profile.keys && Object.keys(profile.keys).length > 0) ||
-                               (profile.builds?.space?.keys && Object.keys(profile.builds.space.keys).length > 0) ||
-                               (profile.builds?.ground?.keys && Object.keys(profile.builds.ground.keys).length > 0);
-                
-                // If no keys found, at least verify the import function was called
-                if (!hasKeys) {
-                    expect(result).toBeDefined();
-                } else {
-                    expect(hasKeys).toBe(true);
-                }
-            } else {
-                // Test passes if import function exists
-                expect(stoKeybinds).toBeDefined();
-            }
-        });
+bind Button4 "GenSendMessage HUD_Root FireAll"`
 
-        it('should parse complex command chains correctly', () => {
-            const profileId = app.createProfile('Complex Command Test');
-            app.switchProfile(profileId);
-            
-            // Complex SPACE key binding with multiple commands
-            const complexBinding = `bind Space "+STOTrayExecByTray 0 0$$+STOTrayExecByTray 1 0$$+STOTrayExecByTray 2 0"`;
-            
-            if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
-                stoKeybinds.importKeybindFile(complexBinding);
-                
-                const profile = app.getCurrentProfile();
-                const spaceKey = profile.keys?.Space || profile.builds?.space?.keys?.Space;
-                
-                if (spaceKey) {
-                    expect(spaceKey).toBeDefined();
-                    // Should contain multiple tray execution commands
-                    expect(Array.isArray(spaceKey)).toBe(true);
-                }
-            }
-            
-            expect(true).toBe(true); // Test passes if no errors
-        });
+      // Test import functionality
+      if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
+        const result = stoKeybinds.importKeybindFile(bindFileContent)
 
-        it('should handle modifier key combinations in import', () => {
-            const profileId = app.createProfile('Modifier Test');
-            app.switchProfile(profileId);
-            
-            const modifierBindings = `bind Ctrl+F1 "say Ctrl F1 pressed"
+        // Verify import was successful
+        expect(result).toBeDefined()
+
+        // Check that profile has imported data
+        const profile = app.getCurrentProfile()
+        expect(profile).toBeDefined()
+
+        // Check for keys in various possible locations
+        const hasKeys =
+          (profile.keys && Object.keys(profile.keys).length > 0) ||
+          (profile.builds?.space?.keys &&
+            Object.keys(profile.builds.space.keys).length > 0) ||
+          (profile.builds?.ground?.keys &&
+            Object.keys(profile.builds.ground.keys).length > 0)
+
+        // If no keys found, at least verify the import function was called
+        if (!hasKeys) {
+          expect(result).toBeDefined()
+        } else {
+          expect(hasKeys).toBe(true)
+        }
+      } else {
+        // Test passes if import function exists
+        expect(stoKeybinds).toBeDefined()
+      }
+    })
+
+    it('should parse complex command chains correctly', () => {
+      const profileId = app.createProfile('Complex Command Test')
+      app.switchProfile(profileId)
+
+      // Complex SPACE key binding with multiple commands
+      const complexBinding = `bind Space "+STOTrayExecByTray 0 0$$+STOTrayExecByTray 1 0$$+STOTrayExecByTray 2 0"`
+
+      if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
+        stoKeybinds.importKeybindFile(complexBinding)
+
+        const profile = app.getCurrentProfile()
+        const spaceKey =
+          profile.keys?.Space || profile.builds?.space?.keys?.Space
+
+        if (spaceKey) {
+          expect(spaceKey).toBeDefined()
+          // Should contain multiple tray execution commands
+          expect(Array.isArray(spaceKey)).toBe(true)
+        }
+      }
+
+      expect(true).toBe(true) // Test passes if no errors
+    })
+
+    it('should handle modifier key combinations in import', () => {
+      const profileId = app.createProfile('Modifier Test')
+      app.switchProfile(profileId)
+
+      const modifierBindings = `bind Ctrl+F1 "say Ctrl F1 pressed"
 bind Alt+F2 "say Alt F2 pressed"
-bind Shift+F3 "say Shift F3 pressed"`;
-            
-            if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
-                stoKeybinds.importKeybindFile(modifierBindings);
-                
-                const profile = app.getCurrentProfile();
-                expect(profile).toBeDefined();
-                
-                // Check for modifier key bindings
-                const keys = profile.keys || profile.builds?.space?.keys || {};
-                const hasModifierKeys = Object.keys(keys).some(key => 
-                    key.includes('Ctrl+') || key.includes('Alt+') || key.includes('Shift+')
-                );
-                
-                // Should have processed modifier combinations
-                expect(Object.keys(keys).length).toBeGreaterThanOrEqual(0);
-            }
-            
-            expect(true).toBe(true);
-        });
+bind Shift+F3 "say Shift F3 pressed"`
 
-        it('should parse mouse button bindings correctly', () => {
-            const profileId = app.createProfile('Mouse Test');
-            app.switchProfile(profileId);
-            
-            const mouseBindings = `bind Button4 "GenSendMessage HUD_Root FireAll"
+      if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
+        stoKeybinds.importKeybindFile(modifierBindings)
+
+        const profile = app.getCurrentProfile()
+        expect(profile).toBeDefined()
+
+        // Check for modifier key bindings
+        const keys = profile.keys || profile.builds?.space?.keys || {}
+        const hasModifierKeys = Object.keys(keys).some(
+          (key) =>
+            key.includes('Ctrl+') ||
+            key.includes('Alt+') ||
+            key.includes('Shift+')
+        )
+
+        // Should have processed modifier combinations
+        expect(Object.keys(keys).length).toBeGreaterThanOrEqual(0)
+      }
+
+      expect(true).toBe(true)
+    })
+
+    it('should parse mouse button bindings correctly', () => {
+      const profileId = app.createProfile('Mouse Test')
+      app.switchProfile(profileId)
+
+      const mouseBindings = `bind Button4 "GenSendMessage HUD_Root FireAll"
 bind Button5 "GenSendMessage HUD_Root FirePhasers"
-bind Middleclick "target_enemy_near"`;
-            
-            if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
-                stoKeybinds.importKeybindFile(mouseBindings);
-                
-                const profile = app.getCurrentProfile();
-                const keys = profile.keys || profile.builds?.space?.keys || {};
-                
-                // Should have mouse button bindings
-                expect(Object.keys(keys).length).toBeGreaterThanOrEqual(0);
-            }
-            
-            expect(true).toBe(true);
-        });
+bind Middleclick "target_enemy_near"`
 
-        it('should parse wheel bindings correctly', () => {
-            const profileId = app.createProfile('Wheel Test');
-            app.switchProfile(profileId);
-            
-            const wheelBindings = `bind Wheelplus "throttleadjust 0.25"
-bind Wheelminus "throttleadjust -0.25"`;
-            
-            if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
-                stoKeybinds.importKeybindFile(wheelBindings);
-                
-                const profile = app.getCurrentProfile();
-                expect(profile).toBeDefined();
-            }
-            
-            expect(true).toBe(true);
-        });
+      if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
+        stoKeybinds.importKeybindFile(mouseBindings)
 
-        it('should handle commented lines during import', () => {
-            const profileId = app.createProfile('Comment Test');
-            app.switchProfile(profileId);
-            
-            const commentedBindings = `; This is a comment and should be ignored
+        const profile = app.getCurrentProfile()
+        const keys = profile.keys || profile.builds?.space?.keys || {}
+
+        // Should have mouse button bindings
+        expect(Object.keys(keys).length).toBeGreaterThanOrEqual(0)
+      }
+
+      expect(true).toBe(true)
+    })
+
+    it('should parse wheel bindings correctly', () => {
+      const profileId = app.createProfile('Wheel Test')
+      app.switchProfile(profileId)
+
+      const wheelBindings = `bind Wheelplus "throttleadjust 0.25"
+bind Wheelminus "throttleadjust -0.25"`
+
+      if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
+        stoKeybinds.importKeybindFile(wheelBindings)
+
+        const profile = app.getCurrentProfile()
+        expect(profile).toBeDefined()
+      }
+
+      expect(true).toBe(true)
+    })
+
+    it('should handle commented lines during import', () => {
+      const profileId = app.createProfile('Comment Test')
+      app.switchProfile(profileId)
+
+      const commentedBindings = `; This is a comment and should be ignored
 bind F1 "GenSendMessage HUD_Root FireAll"
 ; Another comment
 ; bind F2 "this should be ignored"
-bind F3 "say Hello"`;
-            
-            if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
-                stoKeybinds.importKeybindFile(commentedBindings);
-                
-                const profile = app.getCurrentProfile();
-                const keys = profile.keys || profile.builds?.space?.keys || {};
-                
-                // Should only have F1 and F3, not F2 (commented out)
-                expect(Object.keys(keys).length).toBeGreaterThanOrEqual(0);
-            }
-            
-            expect(true).toBe(true);
-        });
+bind F3 "say Hello"`
 
-        it('should validate imported commands against STO syntax', () => {
-            const profileId = app.createProfile('Validation Test');
-            app.switchProfile(profileId);
-            
-            const mixedBindings = `bind F1 "GenSendMessage HUD_Root FireAll"
+      if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
+        stoKeybinds.importKeybindFile(commentedBindings)
+
+        const profile = app.getCurrentProfile()
+        const keys = profile.keys || profile.builds?.space?.keys || {}
+
+        // Should only have F1 and F3, not F2 (commented out)
+        expect(Object.keys(keys).length).toBeGreaterThanOrEqual(0)
+      }
+
+      expect(true).toBe(true)
+    })
+
+    it('should validate imported commands against STO syntax', () => {
+      const profileId = app.createProfile('Validation Test')
+      app.switchProfile(profileId)
+
+      const mixedBindings = `bind F1 "GenSendMessage HUD_Root FireAll"
 bind F2 "invalid_command_that_does_not_exist"
-bind F3 "say Valid command"`;
-            
-            if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
-                const result = stoKeybinds.importKeybindFile(mixedBindings);
-                
-                // Import should complete but may have validation warnings
-                expect(result).toBeDefined();
-            }
-            
-            expect(true).toBe(true);
-        });
+bind F3 "say Valid command"`
 
-        it('should create profile with correct environment assignment', () => {
-            const profileId = app.createProfile('Environment Test');
-            app.switchProfile(profileId);
-            
-            const spaceGroundBindings = `bind Space "+STOTrayExecByTray 0 0"
+      if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
+        const result = stoKeybinds.importKeybindFile(mixedBindings)
+
+        // Import should complete but may have validation warnings
+        expect(result).toBeDefined()
+      }
+
+      expect(true).toBe(true)
+    })
+
+    it('should create profile with correct environment assignment', () => {
+      const profileId = app.createProfile('Environment Test')
+      app.switchProfile(profileId)
+
+      const spaceGroundBindings = `bind Space "+STOTrayExecByTray 0 0"
 bind W "+forward"
-bind F1 "GenSendMessage HUD_Root FireAll"`;
-            
-            if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
-                stoKeybinds.importKeybindFile(spaceGroundBindings);
-                
-                const profile = app.getCurrentProfile();
-                expect(profile).toBeDefined();
-                
-                // Should have builds structure for space/ground separation
-                if (profile.builds) {
-                    expect(profile.builds.space || profile.builds.ground).toBeDefined();
-                }
-            }
-            
-            expect(true).toBe(true);
-        });
+bind F1 "GenSendMessage HUD_Root FireAll"`
 
-        it('should preserve original command syntax during import', () => {
-            const profileId = app.createProfile('Syntax Test');
-            app.switchProfile(profileId);
-            
-            const originalCommand = `bind F1 "say \\"Hello World\\" with quotes"`;
-            
-            if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
-                stoKeybinds.importKeybindFile(originalCommand);
-                
-                const profile = app.getCurrentProfile();
-                expect(profile).toBeDefined();
-                
-                // Command syntax should be preserved
-                const keys = profile.keys || profile.builds?.space?.keys || {};
-                expect(Object.keys(keys).length).toBeGreaterThanOrEqual(0);
-            }
-            
-            expect(true).toBe(true);
-        });
+      if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
+        stoKeybinds.importKeybindFile(spaceGroundBindings)
 
-        it('should handle import errors gracefully with user feedback', () => {
-            const profileId = app.createProfile('Error Test');
-            app.switchProfile(profileId);
-            
-            // Malformed bind file content
-            const malformedContent = `bind
+        const profile = app.getCurrentProfile()
+        expect(profile).toBeDefined()
+
+        // Should have builds structure for space/ground separation
+        if (profile.builds) {
+          expect(profile.builds.space || profile.builds.ground).toBeDefined()
+        }
+      }
+
+      expect(true).toBe(true)
+    })
+
+    it('should preserve original command syntax during import', () => {
+      const profileId = app.createProfile('Syntax Test')
+      app.switchProfile(profileId)
+
+      const originalCommand = `bind F1 "say \\"Hello World\\" with quotes"`
+
+      if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
+        stoKeybinds.importKeybindFile(originalCommand)
+
+        const profile = app.getCurrentProfile()
+        expect(profile).toBeDefined()
+
+        // Command syntax should be preserved
+        const keys = profile.keys || profile.builds?.space?.keys || {}
+        expect(Object.keys(keys).length).toBeGreaterThanOrEqual(0)
+      }
+
+      expect(true).toBe(true)
+    })
+
+    it('should handle import errors gracefully with user feedback', () => {
+      const profileId = app.createProfile('Error Test')
+      app.switchProfile(profileId)
+
+      // Malformed bind file content
+      const malformedContent = `bind
 invalid line without proper format
-bind F1`;
-            
-            if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
-                // Should not throw an error, but handle gracefully
-                expect(() => {
-                    stoKeybinds.importKeybindFile(malformedContent);
-                }).not.toThrow();
-            }
-            
-            expect(true).toBe(true);
-        });
-    });
+bind F1`
 
-    describe('STO Keybind File Export', () => {
-        it('should export profile as valid STO keybind file', () => {
-            // Create a test profile with some keybinds
-            const profileId = app.createProfile('Export Test Profile');
-            app.switchProfile(profileId);
-            
-            // Add some test keybinds
-            app.selectKey('F1');
-            app.addCommand('F1', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
-            app.selectKey('W');
-            app.addCommand('W', { command: '+forward', type: 'movement' });
-            
-            // Test export functionality
-            if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
-                // Mock the download function to capture the content
-                const originalDownload = stoExport.downloadFile;
-                let exportedContent = '';
-                stoExport.downloadFile = (content, filename, mimeType) => {
-                    exportedContent = content;
-                };
-                
-                stoExport.exportSTOKeybindFile(app.getCurrentProfile());
-                
-                // Verify export content
-                expect(exportedContent).toBeDefined();
-                expect(exportedContent.length).toBeGreaterThan(0);
-                expect(exportedContent).toContain('bind');
-                
-                // Restore original function
-                stoExport.downloadFile = originalDownload;
-            } else if (stoKeybinds && typeof stoKeybinds.exportProfile === 'function') {
-                // Alternative export method
-                const exportedContent = stoKeybinds.exportProfile(app.getCurrentProfile());
-                expect(exportedContent).toBeDefined();
-                expect(exportedContent.length).toBeGreaterThan(0);
-            }
-            
-            expect(true).toBe(true);
-        });
+      if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
+        // Should not throw an error, but handle gracefully
+        expect(() => {
+          stoKeybinds.importKeybindFile(malformedContent)
+        }).not.toThrow()
+      }
 
-        it('should generate proper file header with metadata', () => {
-            const profileId = app.createProfile('Header Test Profile');
-            app.switchProfile(profileId);
-            
-            if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
-                const originalDownload = stoExport.downloadFile;
-                let exportedContent = '';
-                stoExport.downloadFile = (content) => { exportedContent = content; };
-                
-                stoExport.exportSTOKeybindFile(app.getCurrentProfile());
-                
-                // Check for header comments
-                expect(exportedContent).toContain(';');
-                expect(exportedContent).toContain('Header Test Profile');
-                
-                stoExport.downloadFile = originalDownload;
-            }
-            
-            expect(true).toBe(true);
-        });
+      expect(true).toBe(true)
+    })
+  })
 
-        it('should include aliases section when aliases exist', () => {
-            const profileId = app.createProfile('Alias Test Profile');
-            app.switchProfile(profileId);
-            
-            // Add an alias
-            if (app.addAlias) {
-                app.addAlias('test_alias', 'say Hello World');
-            }
-            
-            if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
-                const originalDownload = stoExport.downloadFile;
-                let exportedContent = '';
-                stoExport.downloadFile = (content) => { exportedContent = content; };
-                
-                stoExport.exportSTOKeybindFile(app.getCurrentProfile());
-                
-                // Should contain alias if one was added
-                if (app.getCurrentProfile().aliases && Object.keys(app.getCurrentProfile().aliases).length > 0) {
-                    expect(exportedContent).toContain('alias');
-                }
-                
-                stoExport.downloadFile = originalDownload;
-            }
-            
-            expect(true).toBe(true);
-        });
+  describe('STO Keybind File Export', () => {
+    it('should export profile as valid STO keybind file', () => {
+      // Create a test profile with some keybinds
+      const profileId = app.createProfile('Export Test Profile')
+      app.switchProfile(profileId)
 
-        it('should generate keybind commands in correct STO format', () => {
-            const profileId = app.createProfile('Format Test Profile');
-            app.switchProfile(profileId);
-            
-            // Add keybinds
-            app.selectKey('F1');
-            app.addCommand('F1', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
-            
-            if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
-                const originalDownload = stoExport.downloadFile;
-                let exportedContent = '';
-                stoExport.downloadFile = (content) => { exportedContent = content; };
-                
-                stoExport.exportSTOKeybindFile(app.getCurrentProfile());
-                
-                // Check for proper STO bind format (exported format is "F1 command" not "bind F1 command")
-                expect(exportedContent).toContain('F1 "GenSendMessage HUD_Root FireAll"');
-                expect(exportedContent).toContain('"');
-                
-                stoExport.downloadFile = originalDownload;
-            }
-            
-            expect(true).toBe(true);
-        });
+      // Add some test keybinds
+      app.selectKey('F1')
+      app.addCommand('F1', {
+        command: 'GenSendMessage HUD_Root FireAll',
+        type: 'space',
+      })
+      app.selectKey('W')
+      app.addCommand('W', { command: '+forward', type: 'movement' })
 
-        it('should include usage instructions in file footer', () => {
-            const profileId = app.createProfile('Footer Test Profile');
-            app.switchProfile(profileId);
-            
-            if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
-                const originalDownload = stoExport.downloadFile;
-                let exportedContent = '';
-                stoExport.downloadFile = (content) => { exportedContent = content; };
-                
-                stoExport.exportSTOKeybindFile(app.getCurrentProfile());
-                
-                // Should contain usage instructions
-                expect(exportedContent).toContain(';');
-                
-                stoExport.downloadFile = originalDownload;
-            }
-            
-            expect(true).toBe(true);
-        });
+      // Test export functionality
+      if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
+        // Mock the download function to capture the content
+        const originalDownload = stoExport.downloadFile
+        let exportedContent = ''
+        stoExport.downloadFile = (content, filename, mimeType) => {
+          exportedContent = content
+        }
 
-        it('should handle special characters in commands correctly', () => {
-            const profileId = app.createProfile('Special Char Test');
-            app.switchProfile(profileId);
-            
-            // Add command with special characters
-            app.selectKey('F1');
-            app.addCommand('F1', { command: 'say "Hello World" with quotes', type: 'chat' });
-            
-            if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
-                const originalDownload = stoExport.downloadFile;
-                let exportedContent = '';
-                stoExport.downloadFile = (content) => { exportedContent = content; };
-                
-                stoExport.exportSTOKeybindFile(app.getCurrentProfile());
-                
-                // Should properly escape special characters
-                expect(exportedContent).toBeDefined();
-                expect(exportedContent.length).toBeGreaterThan(0);
-                
-                stoExport.downloadFile = originalDownload;
-            }
-            
-            expect(true).toBe(true);
-        });
+        stoExport.exportSTOKeybindFile(app.getCurrentProfile())
 
-        it('should export environment-specific builds correctly', () => {
-            const profileId = app.createProfile('Environment Export Test');
-            app.switchProfile(profileId);
-            
-            // Switch to space mode and add space command
-            app.switchMode('space');
-            app.selectKey('F1');
-            app.addCommand('F1', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
-            
-            // Switch to ground mode and add ground command
-            app.switchMode('ground');
-            app.selectKey('W');
-            app.addCommand('W', { command: '+forward', type: 'movement' });
-            
-            if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
-                const originalDownload = stoExport.downloadFile;
-                let exportedContent = '';
-                stoExport.downloadFile = (content) => { exportedContent = content; };
-                
-                stoExport.exportSTOKeybindFile(app.getCurrentProfile());
-                
-                // Should contain both space and ground commands
-                expect(exportedContent).toBeDefined();
-                
-                stoExport.downloadFile = originalDownload;
-            }
-            
-            expect(true).toBe(true);
-        });
+        // Verify export content
+        expect(exportedContent).toBeDefined()
+        expect(exportedContent.length).toBeGreaterThan(0)
+        expect(exportedContent).toContain('bind')
 
-        it('should generate downloadable file with correct filename', () => {
-            const profileId = app.createProfile('Filename Test Profile');
-            app.switchProfile(profileId);
-            
-            if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
-                const originalDownload = stoExport.downloadFile;
-                let capturedFilename = '';
-                stoExport.downloadFile = (content, filename, mimeType) => {
-                    capturedFilename = filename;
-                };
-                
-                stoExport.exportSTOKeybindFile(app.getCurrentProfile());
-                
-                // Should generate appropriate filename
-                expect(capturedFilename).toBeDefined();
-                expect(capturedFilename.length).toBeGreaterThan(0);
-                expect(capturedFilename).toContain('.txt');
-                
-                stoExport.downloadFile = originalDownload;
-            }
-            
-            expect(true).toBe(true);
-        });
-    });
+        // Restore original function
+        stoExport.downloadFile = originalDownload
+      } else if (
+        stoKeybinds &&
+        typeof stoKeybinds.exportProfile === 'function'
+      ) {
+        // Alternative export method
+        const exportedContent = stoKeybinds.exportProfile(
+          app.getCurrentProfile()
+        )
+        expect(exportedContent).toBeDefined()
+        expect(exportedContent.length).toBeGreaterThan(0)
+      }
 
-    describe('Profile Export Formats', () => {
-        it('should export profile as JSON with complete data', () => {
-            // Test JSON export with all profile data preserved
-        });
+      expect(true).toBe(true)
+    })
 
-        it('should export project data with all profiles', () => {
-            // Test complete project export functionality
-        });
+    it('should generate proper file header with metadata', () => {
+      const profileId = app.createProfile('Header Test Profile')
+      app.switchProfile(profileId)
 
-        it('should export CSV data for analysis', () => {
-            // Test CSV export for keybind analysis
-        });
+      if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
+        const originalDownload = stoExport.downloadFile
+        let exportedContent = ''
+        stoExport.downloadFile = (content) => {
+          exportedContent = content
+        }
 
-        it('should export HTML report with formatting', () => {
-            // Test HTML report generation with proper styling
-        });
+        stoExport.exportSTOKeybindFile(app.getCurrentProfile())
 
-        it('should sanitize exported data for security', () => {
-            // Test data sanitization before export
-        });
-    });
+        // Check for header comments
+        expect(exportedContent).toContain(';')
+        expect(exportedContent).toContain('Header Test Profile')
 
-    describe('Round-trip Data Integrity', () => {
-        it('should maintain data integrity through export/import cycle', () => {
-            // Test that profile -> export -> import -> profile preserves data
-        });
+        stoExport.downloadFile = originalDownload
+      }
 
-        it('should preserve command parameters through round-trip', () => {
-            // Test parameterized commands survive export/import
-        });
+      expect(true).toBe(true)
+    })
 
-        it('should preserve aliases through round-trip', () => {
-            // Test alias preservation through export/import
-        });
+    it('should include aliases section when aliases exist', () => {
+      const profileId = app.createProfile('Alias Test Profile')
+      app.switchProfile(profileId)
 
-        it('should preserve environment assignments through round-trip', () => {
-            // Test space/ground assignments survive round-trip
-        });
-    });
-});
+      // Add an alias
+      if (app.addAlias) {
+        app.addAlias('test_alias', 'say Hello World')
+      }
+
+      if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
+        const originalDownload = stoExport.downloadFile
+        let exportedContent = ''
+        stoExport.downloadFile = (content) => {
+          exportedContent = content
+        }
+
+        stoExport.exportSTOKeybindFile(app.getCurrentProfile())
+
+        // Should contain alias if one was added
+        if (
+          app.getCurrentProfile().aliases &&
+          Object.keys(app.getCurrentProfile().aliases).length > 0
+        ) {
+          expect(exportedContent).toContain('alias')
+        }
+
+        stoExport.downloadFile = originalDownload
+      }
+
+      expect(true).toBe(true)
+    })
+
+    it('should generate keybind commands in correct STO format', () => {
+      const profileId = app.createProfile('Format Test Profile')
+      app.switchProfile(profileId)
+
+      // Add keybinds
+      app.selectKey('F1')
+      app.addCommand('F1', {
+        command: 'GenSendMessage HUD_Root FireAll',
+        type: 'space',
+      })
+
+      if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
+        const originalDownload = stoExport.downloadFile
+        let exportedContent = ''
+        stoExport.downloadFile = (content) => {
+          exportedContent = content
+        }
+
+        stoExport.exportSTOKeybindFile(app.getCurrentProfile())
+
+        // Check for proper STO bind format (exported format is "F1 command" not "bind F1 command")
+        expect(exportedContent).toContain(
+          'F1 "GenSendMessage HUD_Root FireAll"'
+        )
+        expect(exportedContent).toContain('"')
+
+        stoExport.downloadFile = originalDownload
+      }
+
+      expect(true).toBe(true)
+    })
+
+    it('should include usage instructions in file footer', () => {
+      const profileId = app.createProfile('Footer Test Profile')
+      app.switchProfile(profileId)
+
+      if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
+        const originalDownload = stoExport.downloadFile
+        let exportedContent = ''
+        stoExport.downloadFile = (content) => {
+          exportedContent = content
+        }
+
+        stoExport.exportSTOKeybindFile(app.getCurrentProfile())
+
+        // Should contain usage instructions
+        expect(exportedContent).toContain(';')
+
+        stoExport.downloadFile = originalDownload
+      }
+
+      expect(true).toBe(true)
+    })
+
+    it('should handle special characters in commands correctly', () => {
+      const profileId = app.createProfile('Special Char Test')
+      app.switchProfile(profileId)
+
+      // Add command with special characters
+      app.selectKey('F1')
+      app.addCommand('F1', {
+        command: 'say "Hello World" with quotes',
+        type: 'chat',
+      })
+
+      if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
+        const originalDownload = stoExport.downloadFile
+        let exportedContent = ''
+        stoExport.downloadFile = (content) => {
+          exportedContent = content
+        }
+
+        stoExport.exportSTOKeybindFile(app.getCurrentProfile())
+
+        // Should properly escape special characters
+        expect(exportedContent).toBeDefined()
+        expect(exportedContent.length).toBeGreaterThan(0)
+
+        stoExport.downloadFile = originalDownload
+      }
+
+      expect(true).toBe(true)
+    })
+
+    it('should export environment-specific builds correctly', () => {
+      const profileId = app.createProfile('Environment Export Test')
+      app.switchProfile(profileId)
+
+      // Switch to space mode and add space command
+      app.switchMode('space')
+      app.selectKey('F1')
+      app.addCommand('F1', {
+        command: 'GenSendMessage HUD_Root FireAll',
+        type: 'space',
+      })
+
+      // Switch to ground mode and add ground command
+      app.switchMode('ground')
+      app.selectKey('W')
+      app.addCommand('W', { command: '+forward', type: 'movement' })
+
+      if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
+        const originalDownload = stoExport.downloadFile
+        let exportedContent = ''
+        stoExport.downloadFile = (content) => {
+          exportedContent = content
+        }
+
+        stoExport.exportSTOKeybindFile(app.getCurrentProfile())
+
+        // Should contain both space and ground commands
+        expect(exportedContent).toBeDefined()
+
+        stoExport.downloadFile = originalDownload
+      }
+
+      expect(true).toBe(true)
+    })
+
+    it('should generate downloadable file with correct filename', () => {
+      const profileId = app.createProfile('Filename Test Profile')
+      app.switchProfile(profileId)
+
+      if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
+        const originalDownload = stoExport.downloadFile
+        let capturedFilename = ''
+        stoExport.downloadFile = (content, filename, mimeType) => {
+          capturedFilename = filename
+        }
+
+        stoExport.exportSTOKeybindFile(app.getCurrentProfile())
+
+        // Should generate appropriate filename
+        expect(capturedFilename).toBeDefined()
+        expect(capturedFilename.length).toBeGreaterThan(0)
+        expect(capturedFilename).toContain('.txt')
+
+        stoExport.downloadFile = originalDownload
+      }
+
+      expect(true).toBe(true)
+    })
+  })
+
+  describe('Profile Export Formats', () => {
+    it('should export profile as JSON with complete data', () => {
+      // Test JSON export with all profile data preserved
+    })
+
+    it('should export project data with all profiles', () => {
+      // Test complete project export functionality
+    })
+
+    it('should export CSV data for analysis', () => {
+      // Test CSV export for keybind analysis
+    })
+
+    it('should export HTML report with formatting', () => {
+      // Test HTML report generation with proper styling
+    })
+
+    it('should sanitize exported data for security', () => {
+      // Test data sanitization before export
+    })
+  })
+
+  describe('Round-trip Data Integrity', () => {
+    it('should maintain data integrity through export/import cycle', () => {
+      // Test that profile -> export -> import -> profile preserves data
+    })
+
+    it('should preserve command parameters through round-trip', () => {
+      // Test parameterized commands survive export/import
+    })
+
+    it('should preserve aliases through round-trip', () => {
+      // Test alias preservation through export/import
+    })
+
+    it('should preserve environment assignments through round-trip', () => {
+      // Test space/ground assignments survive round-trip
+    })
+  })
+})
 
 describe('Sample Bind File Processing', () => {
-    describe('Space Bind File Processing', () => {
-        it('should successfully parse space bind file content', () => {
-            // Test parsing of actual space bind file
-        });
+  describe('Space Bind File Processing', () => {
+    it('should successfully parse space bind file content', () => {
+      // Test parsing of actual space bind file
+    })
 
-        it('should extract SPACE key complex command chain', () => {
-            // Test parsing of complex SPACE key binding
-        });
+    it('should extract SPACE key complex command chain', () => {
+      // Test parsing of complex SPACE key binding
+    })
 
-        it('should extract movement key bindings', () => {
-            // Test parsing of W, A, S, D movement keys
-        });
+    it('should extract movement key bindings', () => {
+      // Test parsing of W, A, S, D movement keys
+    })
 
-        it('should extract tray execution bindings', () => {
-            // Test parsing of various tray execution commands
-        });
+    it('should extract tray execution bindings', () => {
+      // Test parsing of various tray execution commands
+    })
 
-        it('should extract numbered key bindings (1-9, 0)', () => {
-            // Test parsing of number key bindings
-        });
+    it('should extract numbered key bindings (1-9, 0)', () => {
+      // Test parsing of number key bindings
+    })
 
-        it('should extract function key bindings (F9-F12)', () => {
-            // Test parsing of function key bindings
-        });
+    it('should extract function key bindings (F9-F12)', () => {
+      // Test parsing of function key bindings
+    })
 
-        it('should extract modifier combinations', () => {
-            // Test parsing of Ctrl+, Alt+ combinations
-        });
+    it('should extract modifier combinations', () => {
+      // Test parsing of Ctrl+, Alt+ combinations
+    })
 
-        it('should extract mouse bindings', () => {
-            // Test parsing of mouse button bindings
-        });
+    it('should extract mouse bindings', () => {
+      // Test parsing of mouse button bindings
+    })
 
-        it('should create valid profile from parsed data', () => {
-            // Test profile creation from parsed bind file
-        });
-    });
+    it('should create valid profile from parsed data', () => {
+      // Test profile creation from parsed bind file
+    })
+  })
 
-    describe('Ground Bind File Processing', () => {
-        it('should successfully parse ground bind file content', () => {
-            // Test parsing of ground-specific bind file
-        });
+  describe('Ground Bind File Processing', () => {
+    it('should successfully parse ground bind file content', () => {
+      // Test parsing of ground-specific bind file
+    })
 
-        it('should identify ground-specific commands', () => {
-            // Test identification of ground movement/combat commands
-        });
+    it('should identify ground-specific commands', () => {
+      // Test identification of ground movement/combat commands
+    })
 
-        it('should create ground build from parsed data', () => {
-            // Test ground build creation from parsed file
-        });
-    });
+    it('should create ground build from parsed data', () => {
+      // Test ground build creation from parsed file
+    })
+  })
 
-    describe('Bind File Validation', () => {
-        it('should validate command syntax against STO patterns', () => {
-            // Test command syntax validation during parsing
-        });
+  describe('Bind File Validation', () => {
+    it('should validate command syntax against STO patterns', () => {
+      // Test command syntax validation during parsing
+    })
 
-        it('should identify invalid or deprecated commands', () => {
-            // Test identification of problematic commands
-        });
+    it('should identify invalid or deprecated commands', () => {
+      // Test identification of problematic commands
+    })
 
-        it('should provide warnings for potentially problematic bindings', () => {
-            // Test warning system for parsed commands
-        });
+    it('should provide warnings for potentially problematic bindings', () => {
+      // Test warning system for parsed commands
+    })
 
-        it('should handle malformed bind file gracefully', () => {
-            // Test error handling for corrupted bind files
-        });
-    });
-});
+    it('should handle malformed bind file gracefully', () => {
+      // Test error handling for corrupted bind files
+    })
+  })
+})
 
 describe('File Operation UI Integration', () => {
-    describe('Import UI Workflow', () => {
-        it('should trigger file picker when import button clicked', () => {
-            // Test file picker activation
-        });
+  describe('Import UI Workflow', () => {
+    it('should trigger file picker when import button clicked', () => {
+      // Test file picker activation
+    })
 
-        it('should show progress indicator during file processing', () => {
-            // Test loading states during import
-        });
+    it('should show progress indicator during file processing', () => {
+      // Test loading states during import
+    })
 
-        it('should display import results with statistics', () => {
-            // Test import summary display
-        });
+    it('should display import results with statistics', () => {
+      // Test import summary display
+    })
 
-        it('should show import errors with helpful messages', () => {
-            // Test error display for failed imports
-        });
+    it('should show import errors with helpful messages', () => {
+      // Test error display for failed imports
+    })
 
-        it('should allow user to review imported data before saving', () => {
-            // Test import preview functionality
-        });
-    });
+    it('should allow user to review imported data before saving', () => {
+      // Test import preview functionality
+    })
+  })
 
-    describe('Export UI Workflow', () => {
-        it('should show export format selection dialog', () => {
-            // Test export format selection UI
-        });
+  describe('Export UI Workflow', () => {
+    it('should show export format selection dialog', () => {
+      // Test export format selection UI
+    })
 
-        it('should show export progress for large profiles', () => {
-            // Test progress indication for export operations
-        });
+    it('should show export progress for large profiles', () => {
+      // Test progress indication for export operations
+    })
 
-        it('should trigger file download with proper filename', () => {
-            // Test file download initiation
-        });
+    it('should trigger file download with proper filename', () => {
+      // Test file download initiation
+    })
 
-        it('should show export success confirmation', () => {
-            // Test success feedback for exports
-        });
+    it('should show export success confirmation', () => {
+      // Test success feedback for exports
+    })
 
-        it('should handle export errors with user feedback', () => {
-            // Test error handling in export UI
-        });
-    });
+    it('should handle export errors with user feedback', () => {
+      // Test error handling in export UI
+    })
+  })
 
-    describe('File Operation Accessibility', () => {
-        it('should support keyboard navigation in file dialogs', () => {
-            // Test keyboard accessibility
-        });
+  describe('File Operation Accessibility', () => {
+    it('should support keyboard navigation in file dialogs', () => {
+      // Test keyboard accessibility
+    })
 
-        it('should provide screen reader announcements for file operations', () => {
-            // Test screen reader support
-        });
+    it('should provide screen reader announcements for file operations', () => {
+      // Test screen reader support
+    })
 
-        it('should show clear progress indicators for users with disabilities', () => {
-            // Test accessible progress indication
-        });
-    });
-}); 
+    it('should show clear progress indicators for users with disabilities', () => {
+      // Test accessible progress indication
+    })
+  })
+})

--- a/tests/browser/ui-interactions.test.js
+++ b/tests/browser/ui-interactions.test.js
@@ -7,35 +7,39 @@ describe('UI Interactions', () => {
   beforeEach(async () => {
     // Clear localStorage first
     localStorage.clear()
-    
+
     // Simple mock setup
     if (typeof window !== 'undefined') {
       window.alert = vi.fn()
       window.confirm = vi.fn(() => true)
       window.prompt = vi.fn(() => 'test input')
     }
-    
+
     // Wait for DOM to be ready with timeout
     const waitForDOM = () => {
       return new Promise((resolve, reject) => {
         const timeout = setTimeout(() => {
           reject(new Error('DOM ready timeout'))
         }, 5000)
-        
+
         if (document.readyState === 'complete') {
           clearTimeout(timeout)
           resolve()
         } else {
-          document.addEventListener('DOMContentLoaded', () => {
-            clearTimeout(timeout)
-            resolve()
-          }, { once: true })
+          document.addEventListener(
+            'DOMContentLoaded',
+            () => {
+              clearTimeout(timeout)
+              resolve()
+            },
+            { once: true }
+          )
         }
       })
     }
-    
+
     await waitForDOM()
-    
+
     // Wait for the application to be fully loaded using the ready event
     const waitForApp = () => {
       return new Promise((resolve, reject) => {
@@ -43,36 +47,41 @@ describe('UI Interactions', () => {
         const timeout = setTimeout(() => {
           reject(new Error('App ready event timeout'))
         }, 10000)
-        
+
         // Listen for the app ready event
         const handleReady = (payload) => {
           clearTimeout(timeout)
           eventBus.off('sto-app-ready', handleReady)
           resolve(payload.app)
         }
-        
+
         const handleError = (payload) => {
           clearTimeout(timeout)
           eventBus.off('sto-app-ready', handleReady)
           eventBus.off('sto-app-error', handleError)
           reject(payload.error)
         }
-        
+
         // Check if already loaded (in case event fired before we started listening)
-        if (window.app && window.COMMANDS && window.stoStorage && window.stoUI) {
+        if (
+          window.app &&
+          window.COMMANDS &&
+          window.stoStorage &&
+          window.stoUI
+        ) {
           clearTimeout(timeout)
           resolve(window.app)
           return
         }
-        
+
         eventBus.on('sto-app-ready', handleReady)
         eventBus.on('sto-app-error', handleError)
       })
     }
-    
+
     try {
       app = await waitForApp()
-      
+
       // Get instances
       stoStorage = window.stoStorage
       stoUI = window.stoUI
@@ -91,9 +100,13 @@ describe('UI Interactions', () => {
       localStorage.clear()
       sessionStorage.clear()
     }
-    
+
     // Restore original functions if we mocked them
-    if (typeof vi !== 'undefined' && vi.isMockFunction && vi.isMockFunction(window.alert)) {
+    if (
+      typeof vi !== 'undefined' &&
+      vi.isMockFunction &&
+      vi.isMockFunction(window.alert)
+    ) {
       vi.restoreAllMocks()
     }
   })
@@ -103,23 +116,23 @@ describe('UI Interactions', () => {
       // Create a test profile
       const profileId = app.createProfile('UI Test Profile')
       app.switchProfile(profileId)
-      
+
       // Get a key element
       const keyElement = document.querySelector('[data-key="F1"]')
       expect(keyElement).toBeDefined()
-      
+
       // Click on the key
       keyElement.click()
-      
+
       // Verify key gets selected
       expect(app.selectedKey).toBe('F1')
       // DOM class changes are handled by the app, test the app state instead
       expect(app.selectedKey).toBe('F1')
-      
+
       // Click on a different key
       const f2Element = document.querySelector('[data-key="F2"]')
       f2Element.click()
-      
+
       // Verify selection changes
       expect(app.selectedKey).toBe('F2')
     })
@@ -127,25 +140,25 @@ describe('UI Interactions', () => {
     it('should show key binding status visually', async () => {
       const profileId = app.createProfile('Visual Test Profile')
       app.switchProfile(profileId)
-      
+
       const keyElement = document.querySelector('[data-key="F1"]')
-      
+
       // Verify unbound key initially has no commands
       let profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F1']).toBeUndefined()
-      
+
       // Create keybind on key
       app.selectKey('F1')
       app.addCommand('F1', { command: 'say "test"', type: 'chat' })
-      
+
       // Verify bound key now has commands
       profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F1']).toBeDefined()
       expect(profile.builds.space.keys['F1']).toHaveLength(1)
-      
+
       // Add multiple commands
       app.addCommand('F1', { command: 'emote wave', type: 'emote' })
-      
+
       // Verify visual indication of multiple commands
       profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F1']).toHaveLength(2)
@@ -154,28 +167,28 @@ describe('UI Interactions', () => {
     it('should filter keys by search', async () => {
       const profileId = app.createProfile('Filter Test Profile')
       app.switchProfile(profileId)
-      
+
       // Get the key filter input
       const filterInput = document.getElementById('keyFilter')
       expect(filterInput).toBeDefined()
-      
+
       // Count visible keys initially
       const allKeys = document.querySelectorAll('[data-key]')
       const initialCount = allKeys.length
       expect(initialCount).toBeGreaterThan(0)
-      
+
       // Enter search term
       filterInput.value = 'F1'
       filterInput.dispatchEvent(new Event('input'))
-      
+
       // Verify filtering works by checking app method
       app.filterKeys('F1')
-      
+
       // Clear filter
       filterInput.value = ''
       filterInput.dispatchEvent(new Event('input'))
       app.showAllKeys()
-      
+
       // Verify all keys shown again
       expect(filterInput.value).toBe('')
     })
@@ -183,14 +196,14 @@ describe('UI Interactions', () => {
     it('should toggle between grid and list views', async () => {
       const profileId = app.createProfile('View Test Profile')
       app.switchProfile(profileId)
-      
+
       // Get the view toggle button (may not exist in DOM)
       const viewToggle = document.getElementById('toggleViewBtn')
-      
+
       // Verify default view
       const keyGrid = document.getElementById('keyGrid')
       expect(keyGrid).toBeDefined()
-      
+
       // Test view toggle functionality through app if button exists
       if (viewToggle) {
         viewToggle.click()
@@ -207,46 +220,48 @@ describe('UI Interactions', () => {
     it('should add commands via add button', async () => {
       const profileId = app.createProfile('Command Test Profile')
       app.switchProfile(profileId)
-      
+
       // Select a key
       app.selectKey('F1')
-      
+
       // Get add command button
       const addBtn = document.getElementById('addCommandBtn')
       expect(addBtn).toBeDefined()
-      
+
       // Click add command button
       addBtn.click()
-      
+
       // Verify modal or command addition interface appears
       // (In real app, this would open a modal)
       expect(window.alert).toHaveBeenCalledTimes(0) // No errors
-      
+
       // Add command directly via app method
       app.addCommand('F1', { command: 'say "test command"', type: 'chat' })
-      
+
       // Verify command appears in profile
       const profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F1']).toHaveLength(1)
-      expect(profile.builds.space.keys['F1'][0].command).toBe('say "test command"')
+      expect(profile.builds.space.keys['F1'][0].command).toBe(
+        'say "test command"'
+      )
     })
 
     it('should edit existing commands inline', async () => {
       const profileId = app.createProfile('Edit Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create initial command
       app.selectKey('F2')
       app.addCommand('F2', { command: 'say "original"', type: 'chat' })
-      
+
       // Verify command exists
       let profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F2'][0].command).toBe('say "original"')
-      
+
       // Simulate editing by replacing the command
       app.deleteKey('F2')
       app.addCommand('F2', { command: 'say "edited"', type: 'chat' })
-      
+
       // Verify command updated
       profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F2'][0].command).toBe('say "edited"')
@@ -255,18 +270,18 @@ describe('UI Interactions', () => {
     it('should delete commands with confirmation', async () => {
       const profileId = app.createProfile('Delete Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create command to delete
       app.selectKey('F3')
       app.addCommand('F3', { command: 'say "to delete"', type: 'chat' })
-      
+
       // Verify command exists
       let profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F3']).toHaveLength(1)
-      
+
       // Test deletion
       app.deleteKey('F3')
-      
+
       // Verify command removed
       profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F3']).toBeUndefined()
@@ -275,22 +290,22 @@ describe('UI Interactions', () => {
     it('should reorder commands via drag and drop', async () => {
       const profileId = app.createProfile('Reorder Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create multiple commands
       app.selectKey('F4')
       app.addCommand('F4', { command: 'say "first"', type: 'chat' })
       app.addCommand('F4', { command: 'say "second"', type: 'chat' })
       app.addCommand('F4', { command: 'say "third"', type: 'chat' })
-      
+
       // Verify initial order
       let profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F4'][0].command).toBe('say "first"')
       expect(profile.builds.space.keys['F4'][1].command).toBe('say "second"')
       expect(profile.builds.space.keys['F4'][2].command).toBe('say "third"')
-      
+
       // Simulate drag and drop reordering (move first to last)
       app.moveCommand('F4', 0, 2)
-      
+
       // Verify new order
       profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F4'][0].command).toBe('say "second"')
@@ -303,19 +318,19 @@ describe('UI Interactions', () => {
     it('should browse command categories', async () => {
       const profileId = app.createProfile('Library Test Profile')
       app.switchProfile(profileId)
-      
+
       // Test that command library data exists
       expect(window.COMMANDS).toBeDefined()
       expect(typeof window.COMMANDS).toBe('object')
-      
+
       // Get different categories
       const categories = Object.keys(window.COMMANDS)
       expect(categories.length).toBeGreaterThan(0)
-      
+
       // Verify categories have commands (use the first command's category)
       const firstCommand = Object.values(window.COMMANDS)[0]
-      const categoryCommands = Object.values(window.COMMANDS).filter(cmd => 
-        cmd.category === firstCommand.category
+      const categoryCommands = Object.values(window.COMMANDS).filter(
+        (cmd) => cmd.category === firstCommand.category
       )
       expect(categoryCommands.length).toBeGreaterThan(0)
     })
@@ -323,25 +338,27 @@ describe('UI Interactions', () => {
     it('should search and filter commands', async () => {
       const profileId = app.createProfile('Search Test Profile')
       app.switchProfile(profileId)
-      
+
       // Get command search input
       const searchInput = document.getElementById('commandSearch')
       expect(searchInput).toBeDefined()
-      
+
       // Test search functionality
       const searchTerm = 'fire'
       searchInput.value = searchTerm
       searchInput.dispatchEvent(new Event('input'))
-      
+
       // Verify filtering works
       const allCommands = Object.values(window.COMMANDS)
-      const filteredCommands = allCommands.filter(cmd =>
-        cmd.command.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        (cmd.description && cmd.description.toLowerCase().includes(searchTerm.toLowerCase()))
+      const filteredCommands = allCommands.filter(
+        (cmd) =>
+          cmd.command.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          (cmd.description &&
+            cmd.description.toLowerCase().includes(searchTerm.toLowerCase()))
       )
-      
+
       expect(filteredCommands.length).toBeGreaterThanOrEqual(0)
-      
+
       // Clear search
       searchInput.value = ''
       searchInput.dispatchEvent(new Event('input'))
@@ -350,48 +367,55 @@ describe('UI Interactions', () => {
     it('should add commands from library to key', async () => {
       const profileId = app.createProfile('Library Add Test Profile')
       app.switchProfile(profileId)
-      
+
       // Select a key
       app.selectKey('F5')
-      
+
       // Get a command from the library
       const commands = Object.values(window.COMMANDS)
       expect(commands.length).toBeGreaterThan(0)
-      
+
       const testCommand = commands[0]
-      
+
       // Add command from library to key
-      app.addCommand('F5', { command: testCommand.command, type: testCommand.category })
-      
+      app.addCommand('F5', {
+        command: testCommand.command,
+        type: testCommand.category,
+      })
+
       // Verify command added
       const profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F5']).toHaveLength(1)
-      expect(profile.builds.space.keys['F5'][0].command).toBe(testCommand.command)
+      expect(profile.builds.space.keys['F5'][0].command).toBe(
+        testCommand.command
+      )
     })
 
     it('should handle parameterized commands', async () => {
       const profileId = app.createProfile('Parameter Test Profile')
       app.switchProfile(profileId)
-      
+
       // Find a parameterized command
       const commands = Object.values(window.COMMANDS)
-      const paramCommand = commands.find(cmd => cmd.customizable && cmd.parameters)
-      
+      const paramCommand = commands.find(
+        (cmd) => cmd.customizable && cmd.parameters
+      )
+
       if (paramCommand) {
         // Test parameter handling
         const params = {}
-        Object.keys(paramCommand.parameters).forEach(paramName => {
+        Object.keys(paramCommand.parameters).forEach((paramName) => {
           params[paramName] = 'test_value'
         })
-        
+
         // Build parameterized command
         const builtCommand = app.buildParameterizedCommand(
-          paramCommand.category, 
-          paramCommand.key || 'test', 
-          paramCommand, 
+          paramCommand.category,
+          paramCommand.key || 'test',
+          paramCommand,
           params
         )
-        
+
         expect(builtCommand).toBeDefined()
         expect(builtCommand.command).toBeDefined()
       } else {
@@ -405,13 +429,13 @@ describe('UI Interactions', () => {
     it('should open and close modals properly', async () => {
       const profileId = app.createProfile('Modal Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create a test modal
       const testModal = document.createElement('div')
       testModal.id = 'testModal'
       testModal.className = 'modal'
       document.body.appendChild(testModal)
-      
+
       // Create modal overlay if it doesn't exist
       let modalOverlay = document.getElementById('modalOverlay')
       if (!modalOverlay) {
@@ -420,14 +444,14 @@ describe('UI Interactions', () => {
         modalOverlay.className = 'modal-overlay'
         document.body.appendChild(modalOverlay)
       }
-      
+
       // Show modal (test if method exists and works)
       if (typeof stoUI.showModal === 'function') {
         const result = stoUI.showModal('testModal')
         expect(result).toBe(true)
         expect(testModal.classList.contains('active')).toBe(true)
         expect(modalOverlay.classList.contains('active')).toBe(true)
-        
+
         // Hide modal
         const hideResult = stoUI.hideModal('testModal')
         expect(hideResult).toBe(true)
@@ -440,7 +464,7 @@ describe('UI Interactions', () => {
         testModal.classList.remove('active')
         expect(testModal.classList.contains('active')).toBe(false)
       }
-      
+
       // Clean up
       document.body.removeChild(testModal)
       if (modalOverlay && modalOverlay.parentNode) {
@@ -451,10 +475,10 @@ describe('UI Interactions', () => {
     it('should handle form validation in modals', async () => {
       const profileId = app.createProfile('Validation Test Profile')
       app.switchProfile(profileId)
-      
+
       // Test form validation through profile creation
       const profileName = ''
-      
+
       // Empty name should be handled gracefully
       try {
         const newProfileId = app.createProfile(profileName)
@@ -464,7 +488,7 @@ describe('UI Interactions', () => {
         // If it fails, that's also acceptable validation behavior
         expect(error).toBeDefined()
       }
-      
+
       // Valid name should work
       const validProfileId = app.createProfile('Valid Profile Name')
       expect(validProfileId).toBeDefined()
@@ -473,22 +497,24 @@ describe('UI Interactions', () => {
     it('should show confirmation dialogs for destructive actions', async () => {
       const profileId = app.createProfile('Confirmation Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create another profile to delete
       const deleteProfileId = app.createProfile('To Delete Profile')
-      
+
       // Mock confirm to return false (cancel)
       window.confirm = vi.fn(() => false)
-      
+
       // Attempt deletion (should be cancelled)
-      const profilesBefore = Object.keys(stoStorage.getAllData().profiles).length
-      
+      const profilesBefore = Object.keys(
+        stoStorage.getAllData().profiles
+      ).length
+
       // Reset confirm to return true
       window.confirm = vi.fn(() => true)
-      
+
       // Confirm deletion
       app.deleteProfile(deleteProfileId)
-      
+
       // Verify deletion occurred
       const profilesAfter = Object.keys(stoStorage.getAllData().profiles).length
       expect(profilesAfter).toBeLessThan(profilesBefore)
@@ -499,7 +525,7 @@ describe('UI Interactions', () => {
     it('should show success toasts for completed actions', async () => {
       const profileId = app.createProfile('Toast Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create toast container if it doesn't exist
       let toastContainer = document.getElementById('toastContainer')
       let createdContainer = false
@@ -510,26 +536,28 @@ describe('UI Interactions', () => {
         document.body.appendChild(toastContainer)
         createdContainer = true
       }
-      
+
       // Show success toast (test if method exists and works)
       if (typeof stoUI.showToast === 'function') {
         // Clear any existing toasts first
         const existingToasts = toastContainer.querySelectorAll('.toast')
-        existingToasts.forEach(toast => toast.remove())
-        
+        existingToasts.forEach((toast) => toast.remove())
+
         stoUI.showToast('Test success message', 'success')
-        
+
         // Wait a bit for the toast to be added
-        await new Promise(resolve => setTimeout(resolve, 50))
-        
+        await new Promise((resolve) => setTimeout(resolve, 50))
+
         // Verify toast appears
         const toasts = toastContainer.querySelectorAll('.toast')
         expect(toasts.length).toBeGreaterThan(0)
-        
+
         // Find the success toast specifically
-        const successToast = Array.from(toasts).find(toast => 
-          toast.classList.contains('toast-success') || 
-          toast.querySelector('.toast-message')?.textContent === 'Test success message'
+        const successToast = Array.from(toasts).find(
+          (toast) =>
+            toast.classList.contains('toast-success') ||
+            toast.querySelector('.toast-message')?.textContent ===
+              'Test success message'
         )
         expect(successToast).toBeDefined()
         expect(successToast.classList.contains('toast-success')).toBe(true)
@@ -539,11 +567,11 @@ describe('UI Interactions', () => {
         toast.className = 'toast toast-success'
         toast.textContent = 'Test success message'
         toastContainer.appendChild(toast)
-        
+
         const toasts = toastContainer.querySelectorAll('.toast')
         expect(toasts.length).toBeGreaterThan(0)
       }
-      
+
       // Clean up
       if (createdContainer && toastContainer.parentNode) {
         document.body.removeChild(toastContainer)
@@ -553,7 +581,7 @@ describe('UI Interactions', () => {
     it('should show error toasts for failed actions', async () => {
       const profileId = app.createProfile('Error Toast Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create toast container if it doesn't exist
       let toastContainer = document.getElementById('toastContainer')
       let createdContainer = false
@@ -564,26 +592,28 @@ describe('UI Interactions', () => {
         document.body.appendChild(toastContainer)
         createdContainer = true
       }
-      
+
       // Show error toast (test if method exists and works)
       if (typeof stoUI.showToast === 'function') {
         // Clear any existing toasts first
         const existingToasts = toastContainer.querySelectorAll('.toast')
-        existingToasts.forEach(toast => toast.remove())
-        
+        existingToasts.forEach((toast) => toast.remove())
+
         stoUI.showToast('Test error message', 'error')
-        
+
         // Wait a bit for the toast to be added
-        await new Promise(resolve => setTimeout(resolve, 50))
-        
+        await new Promise((resolve) => setTimeout(resolve, 50))
+
         // Verify toast appears
         const toasts = toastContainer.querySelectorAll('.toast')
         expect(toasts.length).toBeGreaterThan(0)
-        
+
         // Find the error toast specifically
-        const errorToast = Array.from(toasts).find(toast => 
-          toast.classList.contains('toast-error') || 
-          toast.querySelector('.toast-message')?.textContent === 'Test error message'
+        const errorToast = Array.from(toasts).find(
+          (toast) =>
+            toast.classList.contains('toast-error') ||
+            toast.querySelector('.toast-message')?.textContent ===
+              'Test error message'
         )
         expect(errorToast).toBeDefined()
         expect(errorToast.classList.contains('toast-error')).toBe(true)
@@ -593,11 +623,11 @@ describe('UI Interactions', () => {
         toast.className = 'toast toast-error'
         toast.textContent = 'Test error message'
         toastContainer.appendChild(toast)
-        
+
         const toasts = toastContainer.querySelectorAll('.toast')
         expect(toasts.length).toBeGreaterThan(0)
       }
-      
+
       // Clean up
       if (createdContainer && toastContainer.parentNode) {
         document.body.removeChild(toastContainer)
@@ -607,7 +637,7 @@ describe('UI Interactions', () => {
     it('should stack multiple toasts appropriately', async () => {
       const profileId = app.createProfile('Stack Toast Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create toast container if it doesn't exist
       let toastContainer = document.getElementById('toastContainer')
       let createdContainer = false
@@ -618,16 +648,16 @@ describe('UI Interactions', () => {
         document.body.appendChild(toastContainer)
         createdContainer = true
       }
-      
+
       // Show multiple toasts (test if method exists and works)
       if (typeof stoUI.showToast === 'function') {
         stoUI.showToast('First toast', 'info')
         stoUI.showToast('Second toast', 'success')
         stoUI.showToast('Third toast', 'warning')
-        
+
         // Wait a bit for the toasts to be added
-        await new Promise(resolve => setTimeout(resolve, 100))
-        
+        await new Promise((resolve) => setTimeout(resolve, 100))
+
         // Verify multiple toasts
         const toasts = toastContainer.querySelectorAll('.toast')
         expect(toasts.length).toBeGreaterThanOrEqual(2)
@@ -637,16 +667,16 @@ describe('UI Interactions', () => {
         toast1.className = 'toast toast-info'
         toast1.textContent = 'First toast'
         toastContainer.appendChild(toast1)
-        
+
         const toast2 = document.createElement('div')
         toast2.className = 'toast toast-success'
         toast2.textContent = 'Second toast'
         toastContainer.appendChild(toast2)
-        
+
         const toasts = toastContainer.querySelectorAll('.toast')
         expect(toasts.length).toBeGreaterThanOrEqual(2)
       }
-      
+
       // Clean up
       if (createdContainer && toastContainer.parentNode) {
         document.body.removeChild(toastContainer)
@@ -658,14 +688,14 @@ describe('UI Interactions', () => {
     it('should navigate using tab key', async () => {
       const profileId = app.createProfile('Tab Test Profile')
       app.switchProfile(profileId)
-      
+
       // Get focusable elements
       const focusableElements = document.querySelectorAll(
         'button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
       )
-      
+
       expect(focusableElements.length).toBeGreaterThan(0)
-      
+
       // Test that elements can receive focus
       if (focusableElements.length > 0) {
         focusableElements[0].focus()
@@ -676,28 +706,28 @@ describe('UI Interactions', () => {
     it('should support keyboard shortcuts', async () => {
       const profileId = app.createProfile('Shortcut Test Profile')
       app.switchProfile(profileId)
-      
+
       // Test Escape key handling
       const escapeEvent = new KeyboardEvent('keydown', {
         key: 'Escape',
         code: 'Escape',
-        keyCode: 27
+        keyCode: 27,
       })
-      
+
       document.dispatchEvent(escapeEvent)
-      
+
       // Test passes if no errors occur
       expect(true).toBe(true)
-      
+
       // Test Ctrl+S (save)
       const saveEvent = new KeyboardEvent('keydown', {
         key: 's',
         code: 'KeyS',
-        ctrlKey: true
+        ctrlKey: true,
       })
-      
+
       document.dispatchEvent(saveEvent)
-      
+
       // Test passes if no errors occur
       expect(true).toBe(true)
     })
@@ -705,7 +735,7 @@ describe('UI Interactions', () => {
     it('should handle Enter and Space for activation', async () => {
       const profileId = app.createProfile('Activation Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create test button
       const testButton = document.createElement('button')
       testButton.textContent = 'Test Button'
@@ -714,20 +744,20 @@ describe('UI Interactions', () => {
         buttonClicked = true
       })
       document.body.appendChild(testButton)
-      
+
       // Focus button
       testButton.focus()
-      
+
       // Test Enter activation
       const enterEvent = new KeyboardEvent('keydown', {
         key: 'Enter',
-        code: 'Enter'
+        code: 'Enter',
       })
       testButton.dispatchEvent(enterEvent)
-      
+
       // Clean up
       document.body.removeChild(testButton)
-      
+
       // Test passes if no errors occur
       expect(true).toBe(true)
     })
@@ -737,49 +767,47 @@ describe('UI Interactions', () => {
     it('should adapt to mobile viewport', async () => {
       const profileId = app.createProfile('Mobile Test Profile')
       app.switchProfile(profileId)
-      
+
       // Simulate mobile viewport
       Object.defineProperty(window, 'innerWidth', {
         writable: true,
         configurable: true,
-        value: 375
+        value: 375,
       })
-      
+
       Object.defineProperty(window, 'innerHeight', {
         writable: true,
         configurable: true,
-        value: 667
+        value: 667,
       })
-      
+
       // Dispatch resize event
       window.dispatchEvent(new Event('resize'))
-      
+
       // Test that app still functions
       expect(app.getCurrentProfile()).toBeDefined()
-      
+
       // Reset viewport
       Object.defineProperty(window, 'innerWidth', {
         writable: true,
         configurable: true,
-        value: 1024
+        value: 1024,
       })
     })
-
-
 
     it('should handle orientation changes', async () => {
       const profileId = app.createProfile('Orientation Test Profile')
       app.switchProfile(profileId)
-      
+
       // Simulate orientation change
       Object.defineProperty(screen, 'orientation', {
         writable: true,
         configurable: true,
-        value: { angle: 90 }
+        value: { angle: 90 },
       })
-      
+
       window.dispatchEvent(new Event('orientationchange'))
-      
+
       // Test that app still functions
       expect(app.getCurrentProfile()).toBeDefined()
     })
@@ -789,10 +817,12 @@ describe('UI Interactions', () => {
     it('should work with screen readers', async () => {
       const profileId = app.createProfile('Accessibility Test Profile')
       app.switchProfile(profileId)
-      
+
       // Check for ARIA labels
-      const elementsWithAria = document.querySelectorAll('[aria-label], [aria-labelledby], [role]')
-      
+      const elementsWithAria = document.querySelectorAll(
+        '[aria-label], [aria-labelledby], [role]'
+      )
+
       // Test passes if ARIA elements exist or if no errors occur
       expect(elementsWithAria.length).toBeGreaterThanOrEqual(0)
     })
@@ -800,13 +830,13 @@ describe('UI Interactions', () => {
     it('should support high contrast mode', async () => {
       const profileId = app.createProfile('Contrast Test Profile')
       app.switchProfile(profileId)
-      
+
       // Simulate high contrast mode
       document.body.classList.add('high-contrast')
-      
+
       // Test that app still functions
       expect(app.getCurrentProfile()).toBeDefined()
-      
+
       // Clean up
       document.body.classList.remove('high-contrast')
     })
@@ -814,11 +844,11 @@ describe('UI Interactions', () => {
     it('should handle reduced motion preferences', async () => {
       const profileId = app.createProfile('Motion Test Profile')
       app.switchProfile(profileId)
-      
+
       // Simulate reduced motion preference
       Object.defineProperty(window, 'matchMedia', {
         writable: true,
-        value: vi.fn().mockImplementation(query => ({
+        value: vi.fn().mockImplementation((query) => ({
           matches: query === '(prefers-reduced-motion: reduce)',
           media: query,
           onchange: null,
@@ -827,9 +857,9 @@ describe('UI Interactions', () => {
           addEventListener: vi.fn(),
           removeEventListener: vi.fn(),
           dispatchEvent: vi.fn(),
-        }))
+        })),
       })
-      
+
       // Test that app still functions
       expect(app.getCurrentProfile()).toBeDefined()
     })
@@ -839,24 +869,24 @@ describe('UI Interactions', () => {
     it('should provide visual feedback during drag', async () => {
       const profileId = app.createProfile('Drag Visual Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create test draggable element
       const dragElement = document.createElement('div')
       dragElement.draggable = true
       dragElement.textContent = 'Drag me'
       document.body.appendChild(dragElement)
-      
+
       // Simulate drag start (use MouseEvent since DragEvent not available)
       const dragStartEvent = new MouseEvent('dragstart', {
         bubbles: true,
-        cancelable: true
+        cancelable: true,
       })
-      
+
       dragElement.dispatchEvent(dragStartEvent)
-      
+
       // Test passes if no errors occur
       expect(true).toBe(true)
-      
+
       // Clean up
       document.body.removeChild(dragElement)
     })
@@ -864,22 +894,22 @@ describe('UI Interactions', () => {
     it('should handle drag cancel gracefully', async () => {
       const profileId = app.createProfile('Drag Cancel Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create test draggable element
       const dragElement = document.createElement('div')
       dragElement.draggable = true
       document.body.appendChild(dragElement)
-      
+
       // Simulate drag and cancel (use MouseEvent since DragEvent not available)
       const dragStartEvent = new MouseEvent('dragstart', { bubbles: true })
       const dragEndEvent = new MouseEvent('dragend', { bubbles: true })
-      
+
       dragElement.dispatchEvent(dragStartEvent)
       dragElement.dispatchEvent(dragEndEvent)
-      
+
       // Test passes if no errors occur
       expect(true).toBe(true)
-      
+
       // Clean up
       document.body.removeChild(dragElement)
     })
@@ -887,25 +917,25 @@ describe('UI Interactions', () => {
     it('should prevent invalid drops', async () => {
       const profileId = app.createProfile('Drop Validation Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create test elements
       const dragElement = document.createElement('div')
       const dropElement = document.createElement('div')
       dragElement.draggable = true
       document.body.appendChild(dragElement)
       document.body.appendChild(dropElement)
-      
+
       // Simulate invalid drop (use MouseEvent since DragEvent not available)
       const dropEvent = new MouseEvent('drop', {
         bubbles: true,
-        cancelable: true
+        cancelable: true,
       })
-      
+
       dropElement.dispatchEvent(dropEvent)
-      
+
       // Test passes if no errors occur
       expect(true).toBe(true)
-      
+
       // Clean up
       document.body.removeChild(dragElement)
       document.body.removeChild(dropElement)
@@ -916,19 +946,19 @@ describe('UI Interactions', () => {
     it('should show context menus on right click', async () => {
       const profileId = app.createProfile('Context Menu Test Profile')
       app.switchProfile(profileId)
-      
+
       // Get a key element
       const keyElement = document.querySelector('[data-key="F1"]')
       expect(keyElement).toBeDefined()
-      
+
       // Simulate right click
       const contextMenuEvent = new MouseEvent('contextmenu', {
         button: 2,
-        buttons: 2
+        buttons: 2,
       })
-      
+
       keyElement.dispatchEvent(contextMenuEvent)
-      
+
       // Test passes if no errors occur
       expect(true).toBe(true)
     })
@@ -936,22 +966,22 @@ describe('UI Interactions', () => {
     it('should handle context menu keyboard access', async () => {
       const profileId = app.createProfile('Context Keyboard Test Profile')
       app.switchProfile(profileId)
-      
+
       // Get a focusable element
       const keyElement = document.querySelector('[data-key="F1"]')
       expect(keyElement).toBeDefined()
-      
+
       // Focus element
       keyElement.focus()
-      
+
       // Simulate menu key
       const menuKeyEvent = new KeyboardEvent('keydown', {
         key: 'ContextMenu',
-        code: 'ContextMenu'
+        code: 'ContextMenu',
       })
-      
+
       keyElement.dispatchEvent(menuKeyEvent)
-      
+
       // Test passes if no errors occur
       expect(true).toBe(true)
     })
@@ -961,19 +991,21 @@ describe('UI Interactions', () => {
     it('should restore state after page reload', async () => {
       const profileId = app.createProfile('Persistence Test Profile')
       app.switchProfile(profileId)
-      
+
       // Make changes
       app.selectKey('F1')
       app.addCommand('F1', { command: 'say "persistent"', type: 'chat' })
-      
+
       // Verify changes are in profile
       const profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F1']).toBeDefined()
-      expect(profile.builds.space.keys['F1'][0].command).toBe('say "persistent"')
-      
+      expect(profile.builds.space.keys['F1'][0].command).toBe(
+        'say "persistent"'
+      )
+
       // Simulate reload by reinitializing
       await app.init()
-      
+
       // Verify state can be restored
       expect(app.getCurrentProfile()).toBeDefined()
     })
@@ -981,16 +1013,16 @@ describe('UI Interactions', () => {
     it('should handle browser back/forward', async () => {
       const profileId = app.createProfile('Navigation Test Profile')
       app.switchProfile(profileId)
-      
+
       // Simulate browser navigation
       const popStateEvent = new PopStateEvent('popstate', {
-        state: { profileId: profileId }
+        state: { profileId: profileId },
       })
-      
+
       window.dispatchEvent(popStateEvent)
-      
+
       // Test passes if no errors occur
       expect(true).toBe(true)
     })
   })
-}) 
+})

--- a/tests/browser/user-workflows.test.js
+++ b/tests/browser/user-workflows.test.js
@@ -2,40 +2,44 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import eventBus from '../../src/js/eventBus.js'
 
 describe('Complete User Workflows', () => {
-  let app, stoStorage, stoUI, stoExport, stoKeybinds;
+  let app, stoStorage, stoUI, stoExport, stoKeybinds
 
   beforeEach(async () => {
     // Clear localStorage first
     localStorage.clear()
-    
+
     // Simple mock setup
     if (typeof window !== 'undefined') {
       window.alert = vi.fn()
       window.confirm = vi.fn(() => true)
       window.prompt = vi.fn(() => 'test input')
     }
-    
+
     // Wait for DOM to be ready with timeout
     const waitForDOM = () => {
       return new Promise((resolve, reject) => {
         const timeout = setTimeout(() => {
           reject(new Error('DOM ready timeout'))
         }, 5000)
-        
+
         if (document.readyState === 'complete') {
           clearTimeout(timeout)
           resolve()
         } else {
-          document.addEventListener('DOMContentLoaded', () => {
-            clearTimeout(timeout)
-            resolve()
-          }, { once: true })
+          document.addEventListener(
+            'DOMContentLoaded',
+            () => {
+              clearTimeout(timeout)
+              resolve()
+            },
+            { once: true }
+          )
         }
       })
     }
-    
+
     await waitForDOM()
-    
+
     // Wait for the application to be fully loaded using the ready event
     const waitForApp = () => {
       return new Promise((resolve, reject) => {
@@ -43,7 +47,7 @@ describe('Complete User Workflows', () => {
         const timeout = setTimeout(() => {
           reject(new Error('App ready event timeout'))
         }, 10000)
-        
+
         // Listen for the app ready event
         const handleReady = (payload) => {
           clearTimeout(timeout)
@@ -57,14 +61,19 @@ describe('Complete User Workflows', () => {
           eventBus.off('sto-app-error', handleError)
           reject(payload.error)
         }
-        
+
         // Check if already loaded (in case event fired before we started listening)
-        if (window.app && window.COMMANDS && window.stoStorage && window.stoUI) {
+        if (
+          window.app &&
+          window.COMMANDS &&
+          window.stoStorage &&
+          window.stoUI
+        ) {
           clearTimeout(timeout)
           resolve(window.app)
           return
         }
-        
+
         eventBus.on('sto-app-ready', handleReady)
         eventBus.on('sto-app-error', handleError)
       })
@@ -72,7 +81,7 @@ describe('Complete User Workflows', () => {
 
     try {
       app = await waitForApp()
-      
+
       // Get instances
       stoStorage = window.stoStorage
       stoUI = window.stoUI
@@ -82,12 +91,12 @@ describe('Complete User Workflows', () => {
       console.error('Failed to wait for app:', error)
       throw error
     }
-    
+
     // Reset application state
     if (app?.resetApplication) {
-      app.resetApplication();
+      app.resetApplication()
     }
-  });
+  })
 
   afterEach(async () => {
     // Clean up using browser test utilities
@@ -98,394 +107,463 @@ describe('Complete User Workflows', () => {
       localStorage.clear()
       sessionStorage.clear()
     }
-    
+
     // Restore original functions if we mocked them
-    if (typeof vi !== 'undefined' && vi.isMockFunction && vi.isMockFunction(window.alert)) {
+    if (
+      typeof vi !== 'undefined' &&
+      vi.isMockFunction &&
+      vi.isMockFunction(window.alert)
+    ) {
       vi.restoreAllMocks()
     }
-  });
+  })
 
   describe('new user onboarding', () => {
     it('should guide new user through profile creation', async () => {
       // STUB: Test complete new user experience
       // This would test welcome/onboarding messages, but we don't have onboarding UI yet
-      expect(true).toBe(true);
+      expect(true).toBe(true)
     })
 
     it('should show helpful tooltips and hints', async () => {
       // STUB: Test new user guidance
       // This would test tooltips and hints, but we don't have tooltip system yet
-      expect(true).toBe(true);
+      expect(true).toBe(true)
     })
   })
 
   describe('profile management workflows', () => {
     it('should create, edit, and manage multiple profiles', async () => {
       // Create space combat profile
-      const spaceProfileId = app.createProfile('Space Combat');
-      app.switchProfile(spaceProfileId);
-      
+      const spaceProfileId = app.createProfile('Space Combat')
+      app.switchProfile(spaceProfileId)
+
       // Add multiple keybinds
-      app.selectKey('F1');
-      app.addCommand('F1', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
-      app.selectKey('Space');
-      app.addCommand('Space', { command: '+STOTrayExecByTray 0 0', type: 'space' });
-      
+      app.selectKey('F1')
+      app.addCommand('F1', {
+        command: 'GenSendMessage HUD_Root FireAll',
+        type: 'space',
+      })
+      app.selectKey('Space')
+      app.addCommand('Space', {
+        command: '+STOTrayExecByTray 0 0',
+        type: 'space',
+      })
+
       // Create ground combat profile
-      const groundProfileId = app.createProfile('Ground Combat');
-      app.switchProfile(groundProfileId);
-      
+      const groundProfileId = app.createProfile('Ground Combat')
+      app.switchProfile(groundProfileId)
+
       // Add ground-specific keybinds
-      app.selectKey('W');
-      app.addCommand('W', { command: '+forward', type: 'movement' });
-      app.selectKey('F1');
-      app.addCommand('F1', { command: 'GenSendMessage HUD_Root FirePhasers', type: 'ground' });
-      
+      app.selectKey('W')
+      app.addCommand('W', { command: '+forward', type: 'movement' })
+      app.selectKey('F1')
+      app.addCommand('F1', {
+        command: 'GenSendMessage HUD_Root FirePhasers',
+        type: 'ground',
+      })
+
       // Clone space profile for PvP variant (if clone functionality exists)
       if (app.cloneProfile) {
-        const pvpProfileId = app.cloneProfile(spaceProfileId, 'PvP Space');
-        expect(pvpProfileId).toBeDefined();
+        const pvpProfileId = app.cloneProfile(spaceProfileId, 'PvP Space')
+        expect(pvpProfileId).toBeDefined()
       }
-      
+
       // Rename profiles with descriptive names (if rename functionality exists)
       if (app.renameProfile) {
-        app.renameProfile(spaceProfileId, 'PvE Space Combat');
+        app.renameProfile(spaceProfileId, 'PvE Space Combat')
       }
-      
+
       // Switch between profiles
-      app.switchProfile(spaceProfileId);
-      const spaceProfile = app.getCurrentProfile();
-      expect(spaceProfile.name).toContain('Space');
-      
-      app.switchProfile(groundProfileId);
-      const groundProfile = app.getCurrentProfile();
-      expect(groundProfile.name).toContain('Ground');
-      
+      app.switchProfile(spaceProfileId)
+      const spaceProfile = app.getCurrentProfile()
+      expect(spaceProfile.name).toContain('Space')
+
+      app.switchProfile(groundProfileId)
+      const groundProfile = app.getCurrentProfile()
+      expect(groundProfile.name).toContain('Ground')
+
       // Delete unused profile (if delete functionality exists)
       if (app.deleteProfile) {
-        const testProfileId = app.createProfile('Test Profile to Delete');
-        app.deleteProfile(testProfileId);
-        const allData = stoStorage.getAllData();
-        const deletedProfile = allData.profiles[testProfileId];
-        expect(deletedProfile).toBeUndefined();
+        const testProfileId = app.createProfile('Test Profile to Delete')
+        app.deleteProfile(testProfileId)
+        const allData = stoStorage.getAllData()
+        const deletedProfile = allData.profiles[testProfileId]
+        expect(deletedProfile).toBeUndefined()
       }
-      
+
       // Verify all operations work correctly
-      const allData = stoStorage.getAllData();
-      expect(Object.keys(allData.profiles).length).toBeGreaterThanOrEqual(2);
+      const allData = stoStorage.getAllData()
+      expect(Object.keys(allData.profiles).length).toBeGreaterThanOrEqual(2)
     })
 
     it('should handle profile switching with modifications', async () => {
       // Create profile and add keybinds
-      const profile1Id = app.createProfile('Profile 1');
-      app.switchProfile(profile1Id);
-      app.selectKey('F1');
-      app.addCommand('F1', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
-      
-      const profile2Id = app.createProfile('Profile 2');
-      
+      const profile1Id = app.createProfile('Profile 1')
+      app.switchProfile(profile1Id)
+      app.selectKey('F1')
+      app.addCommand('F1', {
+        command: 'GenSendMessage HUD_Root FireAll',
+        type: 'space',
+      })
+
+      const profile2Id = app.createProfile('Profile 2')
+
       // Make modifications without explicit saving (auto-save should handle this)
-      app.selectKey('F2');
-      app.addCommand('F2', { command: 'target_enemy_near', type: 'targeting' });
-      
+      app.selectKey('F2')
+      app.addCommand('F2', { command: 'target_enemy_near', type: 'targeting' })
+
       // Attempt to switch profiles
-      app.switchProfile(profile2Id);
-      
+      app.switchProfile(profile2Id)
+
       // Switch back and verify data integrity
-      app.switchProfile(profile1Id);
-      const profile = app.getCurrentProfile();
-      
+      app.switchProfile(profile1Id)
+      const profile = app.getCurrentProfile()
+
       // Verify the keybinds are still there (auto-saved)
-      const hasF1 = !!(profile.keys && profile.keys.F1) || 
-                   !!(profile.builds?.space?.keys && profile.builds.space.keys.F1);
-      const hasF2 = !!(profile.keys && profile.keys.F2) || 
-                   !!(profile.builds?.space?.keys && profile.builds.space.keys.F2);
-      
-      expect(hasF1 || hasF2).toBe(true); // At least one should be saved
+      const hasF1 =
+        !!(profile.keys && profile.keys.F1) ||
+        !!(profile.builds?.space?.keys && profile.builds.space.keys.F1)
+      const hasF2 =
+        !!(profile.keys && profile.keys.F2) ||
+        !!(profile.builds?.space?.keys && profile.builds.space.keys.F2)
+
+      expect(hasF1 || hasF2).toBe(true) // At least one should be saved
     })
   })
 
   describe('keybind creation workflows', () => {
     it('should create complex keybind with multiple commands', async () => {
       // Create a profile for testing
-      const profileId = app.createProfile('Complex Keybind Test');
-      app.switchProfile(profileId);
-      
+      const profileId = app.createProfile('Complex Keybind Test')
+      app.switchProfile(profileId)
+
       // Select key (Space bar)
-      app.selectKey('Space');
-      
+      app.selectKey('Space')
+
       // Add multiple commands in sequence
-      app.addCommand('Space', { command: 'target_enemy_near', type: 'targeting' });
-      app.addCommand('Space', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
-      app.addCommand('Space', { command: '+STOTrayExecByTray 0 0', type: 'space' });
-      app.addCommand('Space', { command: 'distribute_shields', type: 'defensive' });
-      
+      app.addCommand('Space', {
+        command: 'target_enemy_near',
+        type: 'targeting',
+      })
+      app.addCommand('Space', {
+        command: 'GenSendMessage HUD_Root FireAll',
+        type: 'space',
+      })
+      app.addCommand('Space', {
+        command: '+STOTrayExecByTray 0 0',
+        type: 'space',
+      })
+      app.addCommand('Space', {
+        command: 'distribute_shields',
+        type: 'defensive',
+      })
+
       // Verify the commands were added
-      const profile = app.getCurrentProfile();
-      const spaceKey = profile.keys?.Space || profile.builds?.space?.keys?.Space;
-      
+      const profile = app.getCurrentProfile()
+      const spaceKey = profile.keys?.Space || profile.builds?.space?.keys?.Space
+
       if (Array.isArray(spaceKey)) {
-        expect(spaceKey.length).toBeGreaterThanOrEqual(1);
+        expect(spaceKey.length).toBeGreaterThanOrEqual(1)
       } else if (spaceKey) {
         // Single command or command string
-        expect(spaceKey).toBeDefined();
+        expect(spaceKey).toBeDefined()
       }
-      
+
       // Test command reordering (if available)
       if (app.reorderCommands) {
-        app.reorderCommands('Space', [1, 0, 2, 3]); // Swap first two commands
+        app.reorderCommands('Space', [1, 0, 2, 3]) // Swap first two commands
       }
-      
+
       // Verify command preview updates (if available)
       if (app.getCommandPreview) {
-        const preview = app.getCommandPreview('Space');
-        expect(preview).toBeDefined();
+        const preview = app.getCommandPreview('Space')
+        expect(preview).toBeDefined()
       }
-      
-      expect(true).toBe(true); // Test passes if no errors
+
+      expect(true).toBe(true) // Test passes if no errors
     })
 
     it('should create keybind using command library', async () => {
       // Create a profile for testing
-      const profileId = app.createProfile('Library Test');
-      app.switchProfile(profileId);
-      
+      const profileId = app.createProfile('Library Test')
+      app.switchProfile(profileId)
+
       // Select key to bind
-      app.selectKey('F1');
-      
+      app.selectKey('F1')
+
       // Open command library (if available)
       if (app.openCommandLibrary) {
-        app.openCommandLibrary();
+        app.openCommandLibrary()
       }
-      
+
       // Browse different categories (if available)
       if (app.browseCommandCategory) {
-        app.browseCommandCategory('targeting');
-        app.browseCommandCategory('space');
-        app.browseCommandCategory('defensive');
+        app.browseCommandCategory('targeting')
+        app.browseCommandCategory('space')
+        app.browseCommandCategory('defensive')
       }
-      
+
       // Search for specific commands (if available)
       if (app.searchCommands) {
-        const searchResults = app.searchCommands('fire');
-        expect(Array.isArray(searchResults)).toBe(true);
+        const searchResults = app.searchCommands('fire')
+        expect(Array.isArray(searchResults)).toBe(true)
       }
-      
+
       // Add commands from library
-      app.addCommand('F1', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
-      
+      app.addCommand('F1', {
+        command: 'GenSendMessage HUD_Root FireAll',
+        type: 'space',
+      })
+
       // Verify parameters are set correctly
-      const profile = app.getCurrentProfile();
-      const f1Key = profile.keys?.F1 || profile.builds?.space?.keys?.F1;
-      expect(f1Key).toBeDefined();
+      const profile = app.getCurrentProfile()
+      const f1Key = profile.keys?.F1 || profile.builds?.space?.keys?.F1
+      expect(f1Key).toBeDefined()
     })
 
     it('should create and use aliases in keybinds', async () => {
       // Create a profile for testing
-      const profileId = app.createProfile('Alias Test');
-      app.switchProfile(profileId);
-      
+      const profileId = app.createProfile('Alias Test')
+      app.switchProfile(profileId)
+
       // Create alias for complex command sequence (if available)
       if (app.createAlias || app.addAlias) {
-        const aliasCommand = app.createAlias || app.addAlias;
-        aliasCommand('fire_sequence', 'target_enemy_near$$GenSendMessage HUD_Root FireAll$$distribute_shields');
-        
+        const aliasCommand = app.createAlias || app.addAlias
+        aliasCommand(
+          'fire_sequence',
+          'target_enemy_near$$GenSendMessage HUD_Root FireAll$$distribute_shields'
+        )
+
         // Use alias in multiple keybinds
-        app.selectKey('F1');
-        app.addCommand('F1', { command: 'fire_sequence', type: 'alias' });
-        app.selectKey('F2');
-        app.addCommand('F2', { command: 'fire_sequence', type: 'alias' });
-        
+        app.selectKey('F1')
+        app.addCommand('F1', { command: 'fire_sequence', type: 'alias' })
+        app.selectKey('F2')
+        app.addCommand('F2', { command: 'fire_sequence', type: 'alias' })
+
         // Modify alias definition (if available)
         if (app.modifyAlias) {
-          app.modifyAlias('fire_sequence', 'target_enemy_near$$GenSendMessage HUD_Root FireAll');
+          app.modifyAlias(
+            'fire_sequence',
+            'target_enemy_near$$GenSendMessage HUD_Root FireAll'
+          )
         }
-        
+
         // Verify alias appears in profile
-        const profile = app.getCurrentProfile();
+        const profile = app.getCurrentProfile()
         if (profile.aliases) {
-          expect(profile.aliases.fire_sequence).toBeDefined();
+          expect(profile.aliases.fire_sequence).toBeDefined()
         }
       }
-      
-      expect(true).toBe(true); // Test passes if no errors
+
+      expect(true).toBe(true) // Test passes if no errors
     })
   })
 
   describe('space and ground environment setup', () => {
     it('should set up complete space combat configuration', async () => {
       // Create space combat profile
-      const profileId = app.createProfile('Space Combat Setup');
-      app.switchProfile(profileId);
-      
+      const profileId = app.createProfile('Space Combat Setup')
+      app.switchProfile(profileId)
+
       // Ensure space environment is selected
-      app.switchMode('space');
-      
+      app.switchMode('space')
+
       // Bind essential space keys - F1-F4 for tray abilities
-      app.selectKey('F1');
-      app.addCommand('F1', { command: '+STOTrayExecByTray 0 0', type: 'space' });
-      app.selectKey('F2');
-      app.addCommand('F2', { command: '+STOTrayExecByTray 0 1', type: 'space' });
-      app.selectKey('F3');
-      app.addCommand('F3', { command: '+STOTrayExecByTray 0 2', type: 'space' });
-      app.selectKey('F4');
-      app.addCommand('F4', { command: '+STOTrayExecByTray 0 3', type: 'space' });
-      
+      app.selectKey('F1')
+      app.addCommand('F1', { command: '+STOTrayExecByTray 0 0', type: 'space' })
+      app.selectKey('F2')
+      app.addCommand('F2', { command: '+STOTrayExecByTray 0 1', type: 'space' })
+      app.selectKey('F3')
+      app.addCommand('F3', { command: '+STOTrayExecByTray 0 2', type: 'space' })
+      app.selectKey('F4')
+      app.addCommand('F4', { command: '+STOTrayExecByTray 0 3', type: 'space' })
+
       // Space for weapons
-      app.selectKey('Space');
-      app.addCommand('Space', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
-      
+      app.selectKey('Space')
+      app.addCommand('Space', {
+        command: 'GenSendMessage HUD_Root FireAll',
+        type: 'space',
+      })
+
       // Tab for targeting
-      app.selectKey('Tab');
-      app.addCommand('Tab', { command: 'target_enemy_near', type: 'targeting' });
-      
+      app.selectKey('Tab')
+      app.addCommand('Tab', { command: 'target_enemy_near', type: 'targeting' })
+
       // WASD for movement
-      app.selectKey('W');
-      app.addCommand('W', { command: '+forward', type: 'movement' });
-      app.selectKey('A');
-      app.addCommand('A', { command: '+left', type: 'movement' });
-      app.selectKey('S');
-      app.addCommand('S', { command: '+backward', type: 'movement' });
-      app.selectKey('D');
-      app.addCommand('D', { command: '+right', type: 'movement' });
-      
+      app.selectKey('W')
+      app.addCommand('W', { command: '+forward', type: 'movement' })
+      app.selectKey('A')
+      app.addCommand('A', { command: '+left', type: 'movement' })
+      app.selectKey('S')
+      app.addCommand('S', { command: '+backward', type: 'movement' })
+      app.selectKey('D')
+      app.addCommand('D', { command: '+right', type: 'movement' })
+
       // Add advanced bindings - Shield management
-      app.selectKey('R');
-      app.addCommand('R', { command: 'distribute_shields', type: 'defensive' });
-      
+      app.selectKey('R')
+      app.addCommand('R', { command: 'distribute_shields', type: 'defensive' })
+
       // Power routing (if available)
-      app.selectKey('1');
-      app.addCommand('1', { command: 'PowerLevel_Weapons 100', type: 'power' });
-      app.selectKey('2');
-      app.addCommand('2', { command: 'PowerLevel_Shields 100', type: 'power' });
-      
+      app.selectKey('1')
+      app.addCommand('1', { command: 'PowerLevel_Weapons 100', type: 'power' })
+      app.selectKey('2')
+      app.addCommand('2', { command: 'PowerLevel_Shields 100', type: 'power' })
+
       // Verify profile has the expected keybinds
-      const profile = app.getCurrentProfile();
-      const hasSpaceKeybinds = (profile.keys && Object.keys(profile.keys).length > 0) ||
-                              (profile.builds?.space?.keys && Object.keys(profile.builds.space.keys).length > 0);
-      
-      expect(hasSpaceKeybinds).toBe(true);
-      
+      const profile = app.getCurrentProfile()
+      const hasSpaceKeybinds =
+        (profile.keys && Object.keys(profile.keys).length > 0) ||
+        (profile.builds?.space?.keys &&
+          Object.keys(profile.builds.space.keys).length > 0)
+
+      expect(hasSpaceKeybinds).toBe(true)
+
       // Test export and verify STO compatibility (if export available)
       if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
-        let exportedContent = '';
-        const originalDownload = stoExport.downloadFile;
-        stoExport.downloadFile = (content) => { exportedContent = content; };
-        
-        stoExport.exportSTOKeybindFile(profile);
-        expect(exportedContent.length).toBeGreaterThan(0);
-        
-        stoExport.downloadFile = originalDownload;
+        let exportedContent = ''
+        const originalDownload = stoExport.downloadFile
+        stoExport.downloadFile = (content) => {
+          exportedContent = content
+        }
+
+        stoExport.exportSTOKeybindFile(profile)
+        expect(exportedContent.length).toBeGreaterThan(0)
+
+        stoExport.downloadFile = originalDownload
       }
     })
 
     it('should set up ground combat configuration', async () => {
       // Create ground combat profile
-      const profileId = app.createProfile('Ground Combat Setup');
-      app.switchProfile(profileId);
-      
+      const profileId = app.createProfile('Ground Combat Setup')
+      app.switchProfile(profileId)
+
       // Click ground environment button
-      app.switchMode('ground');
-      
+      app.switchMode('ground')
+
       // Bind ground-specific keys - Movement and jump
-      app.selectKey('W');
-      app.addCommand('W', { command: '+forward', type: 'movement' });
-      app.selectKey('A');
-      app.addCommand('A', { command: '+left', type: 'movement' });
-      app.selectKey('S');
-      app.addCommand('S', { command: '+backward', type: 'movement' });
-      app.selectKey('D');
-      app.addCommand('D', { command: '+right', type: 'movement' });
-      app.selectKey('Space');
-      app.addCommand('Space', { command: '+jump', type: 'movement' });
-      
+      app.selectKey('W')
+      app.addCommand('W', { command: '+forward', type: 'movement' })
+      app.selectKey('A')
+      app.addCommand('A', { command: '+left', type: 'movement' })
+      app.selectKey('S')
+      app.addCommand('S', { command: '+backward', type: 'movement' })
+      app.selectKey('D')
+      app.addCommand('D', { command: '+right', type: 'movement' })
+      app.selectKey('Space')
+      app.addCommand('Space', { command: '+jump', type: 'movement' })
+
       // Weapon firing
-      app.selectKey('Button1');
-      app.addCommand('Button1', { command: '+attack', type: 'ground' });
-      
+      app.selectKey('Button1')
+      app.addCommand('Button1', { command: '+attack', type: 'ground' })
+
       // Kit abilities
-      app.selectKey('F1');
-      app.addCommand('F1', { command: '+STOTrayExecByTray 0 0', type: 'ground' });
-      app.selectKey('F2');
-      app.addCommand('F2', { command: '+STOTrayExecByTray 0 1', type: 'ground' });
-      
+      app.selectKey('F1')
+      app.addCommand('F1', {
+        command: '+STOTrayExecByTray 0 0',
+        type: 'ground',
+      })
+      app.selectKey('F2')
+      app.addCommand('F2', {
+        command: '+STOTrayExecByTray 0 1',
+        type: 'ground',
+      })
+
       // Communication
-      app.selectKey('T');
-      app.addCommand('T', { command: 'startchat', type: 'communication' });
-      
+      app.selectKey('T')
+      app.addCommand('T', { command: 'startchat', type: 'communication' })
+
       // Verify ground keybinds were set
-      const profile = app.getCurrentProfile();
-      const hasGroundKeybinds = (profile.keys && Object.keys(profile.keys).length > 0) ||
-                               (profile.builds?.ground?.keys && Object.keys(profile.builds.ground.keys).length > 0);
-      
-      expect(hasGroundKeybinds).toBe(true);
-      
+      const profile = app.getCurrentProfile()
+      const hasGroundKeybinds =
+        (profile.keys && Object.keys(profile.keys).length > 0) ||
+        (profile.builds?.ground?.keys &&
+          Object.keys(profile.builds.ground.keys).length > 0)
+
+      expect(hasGroundKeybinds).toBe(true)
+
       // Export ground-specific file (if available)
       if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
-        let exportedContent = '';
-        const originalDownload = stoExport.downloadFile;
-        stoExport.downloadFile = (content) => { exportedContent = content; };
-        
-        stoExport.exportSTOKeybindFile(profile);
-        expect(exportedContent.length).toBeGreaterThan(0);
-        
-        stoExport.downloadFile = originalDownload;
+        let exportedContent = ''
+        const originalDownload = stoExport.downloadFile
+        stoExport.downloadFile = (content) => {
+          exportedContent = content
+        }
+
+        stoExport.exportSTOKeybindFile(profile)
+        expect(exportedContent.length).toBeGreaterThan(0)
+
+        stoExport.downloadFile = originalDownload
       }
     })
 
     it('should switch between space and ground seamlessly', async () => {
       // Create profile for environment switching test
-      const profileId = app.createProfile('Environment Switch Test');
-      app.switchProfile(profileId);
-      
+      const profileId = app.createProfile('Environment Switch Test')
+      app.switchProfile(profileId)
+
       // Set up keybinds in space environment
-      app.switchMode('space');
-      app.selectKey('F1');
-      app.addCommand('F1', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
-      app.selectKey('Space');
-      app.addCommand('Space', { command: '+STOTrayExecByTray 0 0', type: 'space' });
-      
+      app.switchMode('space')
+      app.selectKey('F1')
+      app.addCommand('F1', {
+        command: 'GenSendMessage HUD_Root FireAll',
+        type: 'space',
+      })
+      app.selectKey('Space')
+      app.addCommand('Space', {
+        command: '+STOTrayExecByTray 0 0',
+        type: 'space',
+      })
+
       // Click ground environment button
-      app.switchMode('ground');
-      
+      app.switchMode('ground')
+
       // Set up different keybinds on same keys
-      app.selectKey('F1');
-      app.addCommand('F1', { command: '+STOTrayExecByTray 0 0', type: 'ground' });
-      app.selectKey('Space');
-      app.addCommand('Space', { command: '+jump', type: 'movement' });
-      
+      app.selectKey('F1')
+      app.addCommand('F1', {
+        command: '+STOTrayExecByTray 0 0',
+        type: 'ground',
+      })
+      app.selectKey('Space')
+      app.addCommand('Space', { command: '+jump', type: 'movement' })
+
       // Switch back and forth using mode buttons
-      app.switchMode('space');
-      expect(app.currentEnvironment).toBe('space');
-      
-      app.switchMode('ground');
-      expect(app.currentEnvironment).toBe('ground');
-      
+      app.switchMode('space')
+      expect(app.currentEnvironment).toBe('space')
+
+      app.switchMode('ground')
+      expect(app.currentEnvironment).toBe('ground')
+
       // Verify each environment maintains its configuration
-      const profile = app.getCurrentProfile();
-      
+      const profile = app.getCurrentProfile()
+
       // Check if builds structure exists for separate environments
       if (profile.builds) {
-        expect(profile.builds.space || profile.builds.ground).toBeDefined();
+        expect(profile.builds.space || profile.builds.ground).toBeDefined()
       }
-      
+
       // Export both configurations (if available)
       if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
-        app.switchMode('space');
-        let spaceContent = '';
-        const originalDownload = stoExport.downloadFile;
-        stoExport.downloadFile = (content) => { spaceContent = content; };
-        stoExport.exportSTOKeybindFile(profile);
-        
-        app.switchMode('ground');
-        let groundContent = '';
-        stoExport.downloadFile = (content) => { groundContent = content; };
-        stoExport.exportSTOKeybindFile(profile);
-        
-        expect(spaceContent.length).toBeGreaterThan(0);
-        expect(groundContent.length).toBeGreaterThan(0);
-        
-        stoExport.downloadFile = originalDownload;
+        app.switchMode('space')
+        let spaceContent = ''
+        const originalDownload = stoExport.downloadFile
+        stoExport.downloadFile = (content) => {
+          spaceContent = content
+        }
+        stoExport.exportSTOKeybindFile(profile)
+
+        app.switchMode('ground')
+        let groundContent = ''
+        stoExport.downloadFile = (content) => {
+          groundContent = content
+        }
+        stoExport.exportSTOKeybindFile(profile)
+
+        expect(spaceContent.length).toBeGreaterThan(0)
+        expect(groundContent.length).toBeGreaterThan(0)
+
+        stoExport.downloadFile = originalDownload
       }
     })
   })
@@ -493,211 +571,243 @@ describe('Complete User Workflows', () => {
   describe('import and export workflows', () => {
     it('should import existing STO keybind file', async () => {
       // Create profile for import test
-      const profileId = app.createProfile('Import Test');
-      app.switchProfile(profileId);
-      
+      const profileId = app.createProfile('Import Test')
+      app.switchProfile(profileId)
+
       // Create sample STO keybind file content
       const sampleKeybindContent = `; Sample STO Keybind File
 alias fire_all "GenSendMessage HUD_Root FireAll"
 bind F1 "fire_all"
 bind Space "+STOTrayExecByTray 0 0$$+STOTrayExecByTray 1 0"
 bind W "+forward"
-bind Tab "target_enemy_near"`;
-      
+bind Tab "target_enemy_near"`
+
       // Import file using keybind import functionality
       if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
-        const importResult = stoKeybinds.importKeybindFile(sampleKeybindContent);
-        
+        const importResult = stoKeybinds.importKeybindFile(sampleKeybindContent)
+
         // Verify import was successful
-        expect(importResult).toBeDefined();
-        
+        expect(importResult).toBeDefined()
+
         // Verify all keybinds imported correctly
-        const profile = app.getCurrentProfile();
-        const hasImportedKeys = (profile.keys && Object.keys(profile.keys).length > 0) ||
-                               (profile.builds?.space?.keys && Object.keys(profile.builds.space.keys).length > 0);
-        
+        const profile = app.getCurrentProfile()
+        const hasImportedKeys =
+          (profile.keys && Object.keys(profile.keys).length > 0) ||
+          (profile.builds?.space?.keys &&
+            Object.keys(profile.builds.space.keys).length > 0)
+
         if (hasImportedKeys) {
-          expect(hasImportedKeys).toBe(true);
+          expect(hasImportedKeys).toBe(true)
         } else {
           // At least verify the import function was called
-          expect(importResult).toBeDefined();
+          expect(importResult).toBeDefined()
         }
-        
+
         // Check for aliases if supported
         if (profile.aliases) {
-          expect(Object.keys(profile.aliases).length).toBeGreaterThanOrEqual(0);
+          expect(Object.keys(profile.aliases).length).toBeGreaterThanOrEqual(0)
         }
       }
-      
-      expect(true).toBe(true); // Test passes if no errors
+
+      expect(true).toBe(true) // Test passes if no errors
     })
 
     it('should export and re-import complete project', async () => {
       // Create multiple profiles with data
-      const profile1Id = app.createProfile('Profile 1');
-      app.switchProfile(profile1Id);
-      app.selectKey('F1');
-      app.addCommand('F1', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
-      
-      const profile2Id = app.createProfile('Profile 2');
-      app.switchProfile(profile2Id);
-      app.selectKey('F2');
-      app.addCommand('F2', { command: 'target_enemy_near', type: 'targeting' });
-      
+      const profile1Id = app.createProfile('Profile 1')
+      app.switchProfile(profile1Id)
+      app.selectKey('F1')
+      app.addCommand('F1', {
+        command: 'GenSendMessage HUD_Root FireAll',
+        type: 'space',
+      })
+
+      const profile2Id = app.createProfile('Profile 2')
+      app.switchProfile(profile2Id)
+      app.selectKey('F2')
+      app.addCommand('F2', { command: 'target_enemy_near', type: 'targeting' })
+
       // Export complete project (if available)
       if (stoStorage && typeof stoStorage.exportData === 'function') {
-        const exportedData = stoStorage.exportData();
-        expect(exportedData).toBeDefined();
-        expect(exportedData.length).toBeGreaterThan(0);
-        
+        const exportedData = stoStorage.exportData()
+        expect(exportedData).toBeDefined()
+        expect(exportedData.length).toBeGreaterThan(0)
+
         // Clear all application data
-        localStorage.clear();
+        localStorage.clear()
         if (app.resetApplication) {
-          app.resetApplication();
+          app.resetApplication()
         }
-        
+
         // Import project file (if available)
         if (typeof stoStorage.importData === 'function') {
-          const importSuccess = stoStorage.importData(exportedData);
-          
+          const importSuccess = stoStorage.importData(exportedData)
+
           // Verify all profiles and settings restored
           if (importSuccess) {
-            const allData = stoStorage.getAllData();
-            expect(Object.keys(allData.profiles).length).toBeGreaterThanOrEqual(2);
+            const allData = stoStorage.getAllData()
+            expect(Object.keys(allData.profiles).length).toBeGreaterThanOrEqual(
+              2
+            )
           }
         }
       }
-      
-      expect(true).toBe(true); // Test passes if no errors
+
+      expect(true).toBe(true) // Test passes if no errors
     })
 
     it('should handle file format errors gracefully', async () => {
       // Create profile for error testing
-      const profileId = app.createProfile('Error Test');
-      app.switchProfile(profileId);
-      
+      const profileId = app.createProfile('Error Test')
+      app.switchProfile(profileId)
+
       // Attempt to import invalid file
       if (stoKeybinds && typeof stoKeybinds.importKeybindFile === 'function') {
-        const invalidContent = 'This is not a valid keybind file';
-        
+        const invalidContent = 'This is not a valid keybind file'
+
         // Should not throw an error, but handle gracefully
         expect(() => {
-          stoKeybinds.importKeybindFile(invalidContent);
-        }).not.toThrow();
-        
+          stoKeybinds.importKeybindFile(invalidContent)
+        }).not.toThrow()
+
         // Attempt to import corrupted JSON (if JSON import available)
-        const corruptedJson = '{"invalid": json syntax}';
+        const corruptedJson = '{"invalid": json syntax}'
         if (stoStorage && typeof stoStorage.importData === 'function') {
           expect(() => {
-            stoStorage.importData(corruptedJson);
-          }).not.toThrow();
+            stoStorage.importData(corruptedJson)
+          }).not.toThrow()
         }
       }
-      
+
       // Verify app remains functional after errors
-      expect(app.getCurrentProfile()).toBeDefined();
-      const allData = stoStorage.getAllData();
-      expect(Object.keys(allData.profiles).length).toBeGreaterThanOrEqual(1);
+      expect(app.getCurrentProfile()).toBeDefined()
+      const allData = stoStorage.getAllData()
+      expect(Object.keys(allData.profiles).length).toBeGreaterThanOrEqual(1)
     })
   })
 
   describe('advanced editing workflows', () => {
     it('should use drag and drop for command reordering', async () => {
       // Create keybind with multiple commands
-      const profileId = app.createProfile('Drag Drop Test');
-      app.switchProfile(profileId);
-      
-      app.selectKey('Space');
-      app.addCommand('Space', { command: 'target_enemy_near', type: 'targeting' });
-      app.addCommand('Space', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
-      app.addCommand('Space', { command: 'distribute_shields', type: 'defensive' });
-      
+      const profileId = app.createProfile('Drag Drop Test')
+      app.switchProfile(profileId)
+
+      app.selectKey('Space')
+      app.addCommand('Space', {
+        command: 'target_enemy_near',
+        type: 'targeting',
+      })
+      app.addCommand('Space', {
+        command: 'GenSendMessage HUD_Root FireAll',
+        type: 'space',
+      })
+      app.addCommand('Space', {
+        command: 'distribute_shields',
+        type: 'defensive',
+      })
+
       // Test drag and drop functionality (if available)
       if (app.reorderCommands) {
         // Reorder commands: move first command to last position
-        app.reorderCommands('Space', [1, 2, 0]);
-        
+        app.reorderCommands('Space', [1, 2, 0])
+
         // Verify new order is saved
-        const profile = app.getCurrentProfile();
-        const spaceKey = profile.keys?.Space || profile.builds?.space?.keys?.Space;
-        expect(spaceKey).toBeDefined();
+        const profile = app.getCurrentProfile()
+        const spaceKey =
+          profile.keys?.Space || profile.builds?.space?.keys?.Space
+        expect(spaceKey).toBeDefined()
       }
-      
+
       // Test keyboard accessibility alternative (if available)
       if (app.moveCommandUp || app.moveCommandDown) {
-        app.moveCommandUp('Space', 1);
-        app.moveCommandDown('Space', 0);
+        app.moveCommandUp('Space', 1)
+        app.moveCommandDown('Space', 0)
       }
-      
-      expect(true).toBe(true); // Test passes if no errors
+
+      expect(true).toBe(true) // Test passes if no errors
     })
 
     it('should copy commands between keys', async () => {
       // Create complex keybind on one key
-      const profileId = app.createProfile('Copy Test');
-      app.switchProfile(profileId);
-      
-      app.selectKey('F1');
-      app.addCommand('F1', { command: 'target_enemy_near', type: 'targeting' });
-      app.addCommand('F1', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
-      
+      const profileId = app.createProfile('Copy Test')
+      app.switchProfile(profileId)
+
+      app.selectKey('F1')
+      app.addCommand('F1', { command: 'target_enemy_near', type: 'targeting' })
+      app.addCommand('F1', {
+        command: 'GenSendMessage HUD_Root FireAll',
+        type: 'space',
+      })
+
       // Copy commands to another key (if available)
       if (app.copyCommands) {
-        app.copyCommands('F1', 'F2');
-        
+        app.copyCommands('F1', 'F2')
+
         // Verify copied commands exist
-        const profile = app.getCurrentProfile();
-        const f2Key = profile.keys?.F2 || profile.builds?.space?.keys?.F2;
-        expect(f2Key).toBeDefined();
-        
+        const profile = app.getCurrentProfile()
+        const f2Key = profile.keys?.F2 || profile.builds?.space?.keys?.F2
+        expect(f2Key).toBeDefined()
+
         // Modify copied commands
-        app.selectKey('F2');
-        app.addCommand('F2', { command: 'distribute_shields', type: 'defensive' });
-        
+        app.selectKey('F2')
+        app.addCommand('F2', {
+          command: 'distribute_shields',
+          type: 'defensive',
+        })
+
         // Verify original is unchanged
-        const f1Key = profile.keys?.F1 || profile.builds?.space?.keys?.F1;
-        expect(f1Key).toBeDefined();
+        const f1Key = profile.keys?.F1 || profile.builds?.space?.keys?.F1
+        expect(f1Key).toBeDefined()
       } else {
         // Manual copy by adding same commands
-        app.selectKey('F2');
-        app.addCommand('F2', { command: 'target_enemy_near', type: 'targeting' });
-        app.addCommand('F2', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
+        app.selectKey('F2')
+        app.addCommand('F2', {
+          command: 'target_enemy_near',
+          type: 'targeting',
+        })
+        app.addCommand('F2', {
+          command: 'GenSendMessage HUD_Root FireAll',
+          type: 'space',
+        })
       }
-      
-      expect(true).toBe(true); // Test passes if no errors
+
+      expect(true).toBe(true) // Test passes if no errors
     })
 
     it('should validate commands with real-time feedback', async () => {
       // Create profile for validation testing
-      const profileId = app.createProfile('Validation Test');
-      app.switchProfile(profileId);
-      
+      const profileId = app.createProfile('Validation Test')
+      app.switchProfile(profileId)
+
       // Enter valid command
-      app.selectKey('F1');
-      app.addCommand('F1', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
-      
+      app.selectKey('F1')
+      app.addCommand('F1', {
+        command: 'GenSendMessage HUD_Root FireAll',
+        type: 'space',
+      })
+
       // Verify command was accepted
-      const profile = app.getCurrentProfile();
-      const f1Key = profile.keys?.F1 || profile.builds?.space?.keys?.F1;
-      expect(f1Key).toBeDefined();
-      
+      const profile = app.getCurrentProfile()
+      const f1Key = profile.keys?.F1 || profile.builds?.space?.keys?.F1
+      expect(f1Key).toBeDefined()
+
       // Test validation (if available)
       if (app.validateCommand) {
         // Enter valid command
-        const validResult = app.validateCommand('target_enemy_near');
-        expect(validResult.valid).toBe(true);
-        
+        const validResult = app.validateCommand('target_enemy_near')
+        expect(validResult.valid).toBe(true)
+
         // Enter invalid command syntax
-        const invalidResult = app.validateCommand('invalid_command_xyz');
-        expect(invalidResult.valid).toBe(false);
-        
+        const invalidResult = app.validateCommand('invalid_command_xyz')
+        expect(invalidResult.valid).toBe(false)
+
         // Check for suggestions (if available)
         if (invalidResult.suggestions) {
-          expect(Array.isArray(invalidResult.suggestions)).toBe(true);
+          expect(Array.isArray(invalidResult.suggestions)).toBe(true)
         }
       }
-      
-      expect(true).toBe(true); // Test passes if no errors
+
+      expect(true).toBe(true) // Test passes if no errors
     })
   })
 
@@ -705,278 +815,326 @@ bind Tab "target_enemy_near"`;
     it('should work on different screen sizes', async () => {
       // STUB: Test responsive design
       // This would test mobile/tablet/desktop viewports, but app is not mobile responsive yet
-      expect(true).toBe(true);
+      expect(true).toBe(true)
     })
 
     it('should be keyboard accessible', async () => {
       // STUB: Test keyboard navigation
       // This would test keyboard shortcuts and navigation, but we don't have keyboard shortcuts yet
-      expect(true).toBe(true);
+      expect(true).toBe(true)
     })
 
     it('should support high contrast and accessibility', async () => {
       // STUB: Test accessibility features
       // This would test high contrast mode and screen reader support, but we don't have this yet
-      expect(true).toBe(true);
+      expect(true).toBe(true)
     })
   })
 
   describe('performance and large datasets', () => {
     it('should handle large profiles efficiently', async () => {
       // Create profile with many keybinds
-      const profileId = app.createProfile('Large Profile Test');
-      app.switchProfile(profileId);
-      
+      const profileId = app.createProfile('Large Profile Test')
+      app.switchProfile(profileId)
+
       // Add multiple keybinds to simulate large dataset
-      const keys = ['F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12',
-                   '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
-                   'Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P'];
-      
-      const startTime = performance.now();
-      
+      const keys = [
+        'F1',
+        'F2',
+        'F3',
+        'F4',
+        'F5',
+        'F6',
+        'F7',
+        'F8',
+        'F9',
+        'F10',
+        'F11',
+        'F12',
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+        '6',
+        '7',
+        '8',
+        '9',
+        '0',
+        'Q',
+        'W',
+        'E',
+        'R',
+        'T',
+        'Y',
+        'U',
+        'I',
+        'O',
+        'P',
+      ]
+
+      const startTime = performance.now()
+
       for (let i = 0; i < keys.length; i++) {
-        const key = keys[i];
-        app.selectKey(key);
-        app.addCommand(key, { 
-          command: `GenSendMessage HUD_Root FireAll_${i}`, 
-          type: 'space' 
-        });
+        const key = keys[i]
+        app.selectKey(key)
+        app.addCommand(key, {
+          command: `GenSendMessage HUD_Root FireAll_${i}`,
+          type: 'space',
+        })
       }
-      
-      const endTime = performance.now();
-      const duration = endTime - startTime;
-      
+
+      const endTime = performance.now()
+      const duration = endTime - startTime
+
       // Verify UI remains responsive (operations should complete quickly)
-      expect(duration).toBeLessThan(5000); // Should complete within 5 seconds
-      
+      expect(duration).toBeLessThan(5000) // Should complete within 5 seconds
+
       // Verify profile has the expected number of keybinds
-      const profile = app.getCurrentProfile();
-      const keyCount = (profile.keys && Object.keys(profile.keys).length) ||
-                      (profile.builds?.space?.keys && Object.keys(profile.builds.space.keys).length) ||
-                      0;
-      
-      expect(keyCount).toBeGreaterThan(10); // Should have added multiple keys
-      
+      const profile = app.getCurrentProfile()
+      const keyCount =
+        (profile.keys && Object.keys(profile.keys).length) ||
+        (profile.builds?.space?.keys &&
+          Object.keys(profile.builds.space.keys).length) ||
+        0
+
+      expect(keyCount).toBeGreaterThan(10) // Should have added multiple keys
+
       // Test export performance (if available)
       if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
-        const exportStartTime = performance.now();
-        let exportedContent = '';
-        const originalDownload = stoExport.downloadFile;
-        stoExport.downloadFile = (content) => { exportedContent = content; };
-        
-        stoExport.exportSTOKeybindFile(profile);
-        
-        const exportEndTime = performance.now();
-        const exportDuration = exportEndTime - exportStartTime;
-        
-        expect(exportDuration).toBeLessThan(2000); // Export should be fast
-        expect(exportedContent.length).toBeGreaterThan(0);
-        
-        stoExport.downloadFile = originalDownload;
+        const exportStartTime = performance.now()
+        let exportedContent = ''
+        const originalDownload = stoExport.downloadFile
+        stoExport.downloadFile = (content) => {
+          exportedContent = content
+        }
+
+        stoExport.exportSTOKeybindFile(profile)
+
+        const exportEndTime = performance.now()
+        const exportDuration = exportEndTime - exportStartTime
+
+        expect(exportDuration).toBeLessThan(2000) // Export should be fast
+        expect(exportedContent.length).toBeGreaterThan(0)
+
+        stoExport.downloadFile = originalDownload
       }
     })
 
     it('should handle multiple profiles without slowdown', async () => {
-      const profileIds = [];
-      const startTime = performance.now();
-      
+      const profileIds = []
+      const startTime = performance.now()
+
       // Create multiple profiles
       for (let i = 0; i < 10; i++) {
-        const profileId = app.createProfile(`Test Profile ${i}`);
-        profileIds.push(profileId);
-        
+        const profileId = app.createProfile(`Test Profile ${i}`)
+        profileIds.push(profileId)
+
         // Add some keybinds to each
-        app.switchProfile(profileId);
-        app.selectKey('F1');
-        app.addCommand('F1', { command: `test_command_${i}`, type: 'space' });
+        app.switchProfile(profileId)
+        app.selectKey('F1')
+        app.addCommand('F1', { command: `test_command_${i}`, type: 'space' })
       }
-      
-      const createTime = performance.now();
-      
+
+      const createTime = performance.now()
+
       // Test profile switching speed
       for (let i = 0; i < profileIds.length; i++) {
-        app.switchProfile(profileIds[i]);
-        const profile = app.getCurrentProfile();
-        expect(profile).toBeDefined();
+        app.switchProfile(profileIds[i])
+        const profile = app.getCurrentProfile()
+        expect(profile).toBeDefined()
       }
-      
-      const switchTime = performance.now();
-      
+
+      const switchTime = performance.now()
+
       // Verify operations complete in reasonable time
-      const totalDuration = switchTime - startTime;
-      expect(totalDuration).toBeLessThan(3000); // Should complete within 3 seconds
-      
+      const totalDuration = switchTime - startTime
+      expect(totalDuration).toBeLessThan(3000) // Should complete within 3 seconds
+
       // Verify all profiles exist
-      const allData = stoStorage.getAllData();
-      expect(Object.keys(allData.profiles).length).toBeGreaterThanOrEqual(10);
+      const allData = stoStorage.getAllData()
+      expect(Object.keys(allData.profiles).length).toBeGreaterThanOrEqual(10)
     })
   })
 
   describe('real-world gaming scenarios', () => {
     it('should set up keybinds for PvP combat', async () => {
       // Create PvP profile
-      const profileId = app.createProfile('PvP Combat');
-      app.switchProfile(profileId);
-      app.switchMode('space');
-      
+      const profileId = app.createProfile('PvP Combat')
+      app.switchProfile(profileId)
+      app.switchMode('space')
+
       // Bind high-priority abilities to easy keys
-      app.selectKey('Space');
-      app.addCommand('Space', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
-      
-      app.selectKey('F1');
-      app.addCommand('F1', { command: '+STOTrayExecByTray 0 0', type: 'space' }); // Emergency heal
-      
-      app.selectKey('F2');
-      app.addCommand('F2', { command: '+STOTrayExecByTray 0 1', type: 'space' }); // Tactical ability
-      
+      app.selectKey('Space')
+      app.addCommand('Space', {
+        command: 'GenSendMessage HUD_Root FireAll',
+        type: 'space',
+      })
+
+      app.selectKey('F1')
+      app.addCommand('F1', { command: '+STOTrayExecByTray 0 0', type: 'space' }) // Emergency heal
+
+      app.selectKey('F2')
+      app.addCommand('F2', { command: '+STOTrayExecByTray 0 1', type: 'space' }) // Tactical ability
+
       // Set up target cycling
-      app.selectKey('Tab');
-      app.addCommand('Tab', { command: 'target_enemy_near', type: 'targeting' });
-      
-      app.selectKey('G');
-      app.addCommand('G', { command: 'target_enemy_next', type: 'targeting' });
-      
+      app.selectKey('Tab')
+      app.addCommand('Tab', { command: 'target_enemy_near', type: 'targeting' })
+
+      app.selectKey('G')
+      app.addCommand('G', { command: 'target_enemy_next', type: 'targeting' })
+
       // Configure shield and power management
-      app.selectKey('R');
-      app.addCommand('R', { command: 'distribute_shields', type: 'defensive' });
-      
-      app.selectKey('1');
-      app.addCommand('1', { command: 'PowerLevel_Weapons 100', type: 'power' });
-      
-      app.selectKey('2');
-      app.addCommand('2', { command: 'PowerLevel_Shields 100', type: 'power' });
-      
+      app.selectKey('R')
+      app.addCommand('R', { command: 'distribute_shields', type: 'defensive' })
+
+      app.selectKey('1')
+      app.addCommand('1', { command: 'PowerLevel_Weapons 100', type: 'power' })
+
+      app.selectKey('2')
+      app.addCommand('2', { command: 'PowerLevel_Shields 100', type: 'power' })
+
       // Verify PvP setup
-      const profile = app.getCurrentProfile();
-      expect(profile.name).toContain('PvP');
-      
+      const profile = app.getCurrentProfile()
+      expect(profile.name).toContain('PvP')
+
       // Export for in-game use (if available)
       if (stoExport && typeof stoExport.exportSTOKeybindFile === 'function') {
-        let exportedContent = '';
-        const originalDownload = stoExport.downloadFile;
-        stoExport.downloadFile = (content) => { exportedContent = content; };
-        
-        stoExport.exportSTOKeybindFile(profile);
-        expect(exportedContent.length).toBeGreaterThan(0);
-        
-        stoExport.downloadFile = originalDownload;
+        let exportedContent = ''
+        const originalDownload = stoExport.downloadFile
+        stoExport.downloadFile = (content) => {
+          exportedContent = content
+        }
+
+        stoExport.exportSTOKeybindFile(profile)
+        expect(exportedContent.length).toBeGreaterThan(0)
+
+        stoExport.downloadFile = originalDownload
       }
     })
 
     it('should set up keybinds for PvE missions', async () => {
       // Create PvE profile
-      const profileId = app.createProfile('PvE Missions');
-      app.switchProfile(profileId);
-      app.switchMode('space');
-      
+      const profileId = app.createProfile('PvE Missions')
+      app.switchProfile(profileId)
+      app.switchMode('space')
+
       // Bind AoE abilities
-      app.selectKey('F3');
-      app.addCommand('F3', { command: '+STOTrayExecByTray 0 2', type: 'space' }); // AoE ability
-      
-      app.selectKey('F4');
-      app.addCommand('F4', { command: '+STOTrayExecByTray 0 3', type: 'space' }); // Scatter volley
-      
+      app.selectKey('F3')
+      app.addCommand('F3', { command: '+STOTrayExecByTray 0 2', type: 'space' }) // AoE ability
+
+      app.selectKey('F4')
+      app.addCommand('F4', { command: '+STOTrayExecByTray 0 3', type: 'space' }) // Scatter volley
+
       // Set up automatic firing
-      app.selectKey('Space');
-      app.addCommand('Space', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
-      
+      app.selectKey('Space')
+      app.addCommand('Space', {
+        command: 'GenSendMessage HUD_Root FireAll',
+        type: 'space',
+      })
+
       // Configure team support abilities
-      app.selectKey('F5');
-      app.addCommand('F5', { command: '+STOTrayExecByTray 1 0', type: 'space' }); // Team heal
-      
-      app.selectKey('F6');
-      app.addCommand('F6', { command: '+STOTrayExecByTray 1 1', type: 'space' }); // Team buff
-      
+      app.selectKey('F5')
+      app.addCommand('F5', { command: '+STOTrayExecByTray 1 0', type: 'space' }) // Team heal
+
+      app.selectKey('F6')
+      app.addCommand('F6', { command: '+STOTrayExecByTray 1 1', type: 'space' }) // Team buff
+
       // Basic movement and targeting
-      app.selectKey('W');
-      app.addCommand('W', { command: '+forward', type: 'movement' });
-      
-      app.selectKey('Tab');
-      app.addCommand('Tab', { command: 'target_enemy_near', type: 'targeting' });
-      
+      app.selectKey('W')
+      app.addCommand('W', { command: '+forward', type: 'movement' })
+
+      app.selectKey('Tab')
+      app.addCommand('Tab', { command: 'target_enemy_near', type: 'targeting' })
+
       // Verify PvE setup
-      const profile = app.getCurrentProfile();
-      expect(profile.name).toContain('PvE');
-      
-      const hasKeybinds = (profile.keys && Object.keys(profile.keys).length > 0) ||
-                         (profile.builds?.space?.keys && Object.keys(profile.builds.space.keys).length > 0);
-      expect(hasKeybinds).toBe(true);
+      const profile = app.getCurrentProfile()
+      expect(profile.name).toContain('PvE')
+
+      const hasKeybinds =
+        (profile.keys && Object.keys(profile.keys).length > 0) ||
+        (profile.builds?.space?.keys &&
+          Object.keys(profile.builds.space.keys).length > 0)
+      expect(hasKeybinds).toBe(true)
     })
 
     it('should create alt-friendly keybind sets', async () => {
       // STUB: Test multi-character setup
-      // This would test ship-type specific profiles, but the concept of "alt-friendly" 
+      // This would test ship-type specific profiles, but the concept of "alt-friendly"
       // keybind sets isn't clearly defined in the current app structure
-      expect(true).toBe(true);
+      expect(true).toBe(true)
     })
   })
 
   describe('error recovery and edge cases', () => {
     it('should recover from browser crashes', async () => {
       // Make changes to profile
-      const profileId = app.createProfile('Crash Recovery Test');
-      app.switchProfile(profileId);
-      app.selectKey('F1');
-      app.addCommand('F1', { command: 'GenSendMessage HUD_Root FireAll', type: 'space' });
-      
+      const profileId = app.createProfile('Crash Recovery Test')
+      app.switchProfile(profileId)
+      app.selectKey('F1')
+      app.addCommand('F1', {
+        command: 'GenSendMessage HUD_Root FireAll',
+        type: 'space',
+      })
+
       // Simulate data persistence (auto-save should handle this)
-      const profile = app.getCurrentProfile();
-      expect(profile).toBeDefined();
-      
+      const profile = app.getCurrentProfile()
+      expect(profile).toBeDefined()
+
       // Verify data would be preserved (localStorage should contain the data)
-      const storedData = localStorage.getItem('sto-keybind-manager');
+      const storedData = localStorage.getItem('sto-keybind-manager')
       if (storedData) {
-        expect(storedData.length).toBeGreaterThan(0);
+        expect(storedData.length).toBeGreaterThan(0)
       }
-      
+
       // Verify app recovers gracefully (app is functional)
-      const allData = stoStorage.getAllData();
-      expect(Object.keys(allData.profiles).length).toBeGreaterThanOrEqual(1);
+      const allData = stoStorage.getAllData()
+      expect(Object.keys(allData.profiles).length).toBeGreaterThanOrEqual(1)
     })
 
     it('should handle corrupted localStorage', async () => {
       // Manually corrupt localStorage data
-      localStorage.setItem('sto-keybind-manager', '{"corrupted": json}');
-      
+      localStorage.setItem('sto-keybind-manager', '{"corrupted": json}')
+
       // App should handle this gracefully and not crash
       expect(() => {
         if (stoStorage && typeof stoStorage.loadData === 'function') {
-          stoStorage.loadData();
+          stoStorage.loadData()
         }
-      }).not.toThrow();
-      
+      }).not.toThrow()
+
       // Verify graceful fallback to defaults
-      const allData = stoStorage.getAllData();
-      expect(Object.keys(allData.profiles).length).toBeGreaterThanOrEqual(0);
-      
+      const allData = stoStorage.getAllData()
+      expect(Object.keys(allData.profiles).length).toBeGreaterThanOrEqual(0)
+
       // App should remain functional
-      const testProfileId = app.createProfile('Recovery Test');
-      expect(testProfileId).toBeDefined();
+      const testProfileId = app.createProfile('Recovery Test')
+      expect(testProfileId).toBeDefined()
     })
 
     it('should handle localStorage quota exceeded', async () => {
       // Create a large profile to test storage limits
-      const profileId = app.createProfile('Storage Limit Test');
-      app.switchProfile(profileId);
-      
+      const profileId = app.createProfile('Storage Limit Test')
+      app.switchProfile(profileId)
+
       // Add many keybinds to approach storage limits
       try {
         for (let i = 0; i < 100; i++) {
-          app.selectKey(`TestKey${i}`);
-          app.addCommand(`TestKey${i}`, { 
-            command: `very_long_command_name_to_use_storage_${i}_${'x'.repeat(100)}`, 
-            type: 'test' 
-          });
+          app.selectKey(`TestKey${i}`)
+          app.addCommand(`TestKey${i}`, {
+            command: `very_long_command_name_to_use_storage_${i}_${'x'.repeat(100)}`,
+            type: 'test',
+          })
         }
       } catch (error) {
         // Should handle storage errors gracefully
-        expect(error).toBeInstanceOf(Error);
+        expect(error).toBeInstanceOf(Error)
       }
-      
+
       // Verify app remains functional even if storage is full
-      expect(app.getCurrentProfile()).toBeDefined();
-      const allData = stoStorage.getAllData();
-      expect(Object.keys(allData.profiles).length).toBeGreaterThanOrEqual(1);
+      expect(app.getCurrentProfile()).toBeDefined()
+      const allData = stoStorage.getAllData()
+      expect(Object.keys(allData.profiles).length).toBeGreaterThanOrEqual(1)
     })
   })
-}) 
+})

--- a/tests/browser/vertigo-operations.test.js
+++ b/tests/browser/vertigo-operations.test.js
@@ -1,561 +1,600 @@
 // Browser test for real-world Vertigo functionality
 // This test runs in a browser context and uses the actual implementation
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 
 describe('Vertigo Operations Browser Test', () => {
-    let app;
+  let app
 
+  beforeEach(async () => {
+    // Clear localStorage to start fresh
+    testUtils.clearAppData()
+
+    // Wait for the real app to be ready (loaded via browser test configuration)
+    await testUtils.waitForAppReady()
+
+    // Get the real app instance (exposed globally by app.js)
+    app = window.app
+
+    // Ensure we have a clean profile for testing
+    if (app && typeof app.createProfile === 'function') {
+      // Create a test profile if it doesn't exist
+      const currentProfile = app.getCurrentProfile()
+      if (!currentProfile) {
+        app.createProfile('Test Profile', 'Test profile for vertigo operations')
+      }
+    }
+
+    // Ensure vertigo manager is ready
+    if (window.vertigoManager) {
+      window.vertigoManager.clearAllEffects()
+    }
+  })
+
+  afterEach(() => {
+    // Clean up any open modals
+    const vertigoModal = document.getElementById('vertigoModal')
+    if (vertigoModal && vertigoModal.style.display !== 'none') {
+      vertigoModal.style.display = 'none'
+    }
+
+    // Clear effects after tests (except for state persistence tests which handle their own cleanup)
+    if (window.vertigoManager) {
+      window.vertigoManager.clearAllEffects()
+    }
+  })
+
+  describe('Core Vertigo Manager Functionality', () => {
+    it('should have VERTIGO_EFFECTS data loaded', () => {
+      expect(window.VERTIGO_EFFECTS).toBeDefined()
+      expect(window.VERTIGO_EFFECTS.space).toBeInstanceOf(Array)
+      expect(window.VERTIGO_EFFECTS.ground).toBeInstanceOf(Array)
+      expect(window.VERTIGO_EFFECTS.space.length).toBeGreaterThan(0)
+      expect(window.VERTIGO_EFFECTS.ground.length).toBeGreaterThan(0)
+    })
+
+    it('should have vertigoManager instance available', () => {
+      expect(window.vertigoManager).toBeDefined()
+      expect(typeof window.vertigoManager.generateAlias).toBe('function')
+      expect(typeof window.vertigoManager.toggleEffect).toBe('function')
+      expect(typeof window.vertigoManager.selectAllEffects).toBe('function')
+      expect(typeof window.vertigoManager.clearAllEffects).toBe('function')
+    })
+
+    it('should generate properly formatted STO commands', () => {
+      const manager = window.vertigoManager
+      manager.clearAllEffects()
+      manager.selectedEffects.space.add('Fx_Test_Effect_1')
+      manager.selectedEffects.space.add('Fx_Test_Effect_2')
+      manager.showPlayerSay = false
+
+      const spaceAlias = manager.generateAlias('space')
+      expect(spaceAlias).toMatch(/ &>$/)
+      expect(spaceAlias).toBe(
+        'alias dynFxSetFXExlusionList_Space <& dynFxSetFXExlusionList Fx_Test_Effect_1,Fx_Test_Effect_2 &>'
+      )
+    })
+  })
+
+  describe('App Integration', () => {
+    it('should have app instance available', () => {
+      expect(window.app).toBeDefined()
+      expect(app).toBeDefined()
+    })
+
+    it('should have vertigo modal methods on app', () => {
+      expect(typeof app.showVertigoModal).toBe('function')
+      expect(typeof app.populateVertigoModal).toBe('function')
+      expect(typeof app.setupVertigoEventListeners).toBe('function')
+      expect(typeof app.generateVertigoAliases).toBe('function')
+    })
+
+    it('should have vertigo button in DOM', () => {
+      const vertigoBtn = document.getElementById('vertigoBtn')
+      expect(vertigoBtn).toBeDefined()
+    })
+  })
+
+  describe('Modal Operations', () => {
+    it('should show vertigo modal when showVertigoModal is called', async () => {
+      const modal = document.getElementById('vertigoModal')
+      expect(modal).toBeDefined()
+
+      // Modal should be hidden initially
+      expect(modal.style.display).toBe('none')
+
+      // Show modal
+      app.showVertigoModal()
+
+      // Wait for modal to be visible
+      await testUtils.waitForModalElement('#vertigoModal')
+    })
+
+    it('should populate effect lists when modal is opened', async () => {
+      // Open modal and populate it
+      app.showVertigoModal()
+      await testUtils.waitForModalElement('#vertigoModal')
+
+      const spaceList = document.getElementById('spaceEffectsList')
+      const groundList = document.getElementById('groundEffectsList')
+
+      expect(spaceList).toBeDefined()
+      expect(groundList).toBeDefined()
+
+      // Check if effects are populated
+      expect(spaceList.children.length).toBeGreaterThan(0)
+      expect(groundList.children.length).toBeGreaterThan(0)
+    })
+
+    it('should create proper effect item HTML structure', () => {
+      const testEffect = { label: 'Test Effect', effect: 'Fx_Test_Effect' }
+      const effectItem = app.createEffectItem('space', testEffect)
+
+      expect(effectItem).toBeDefined()
+      expect(effectItem.className).toBe('effect-item')
+
+      const checkbox = effectItem.querySelector('input[type="checkbox"]')
+      const label = effectItem.querySelector('.effect-label')
+
+      expect(checkbox).toBeDefined()
+      expect(label).toBeDefined()
+      expect(label.textContent).toBe('Test Effect')
+      expect(checkbox.dataset.environment).toBe('space')
+      expect(checkbox.dataset.effect).toBe('Fx_Test_Effect')
+    })
+  })
+
+  describe('Effect Selection Operations', () => {
+    beforeEach(() => {
+      app.populateVertigoModal()
+    })
+
+    it('should handle individual effect selection', () => {
+      const manager = window.vertigoManager
+      manager.clearAllEffects()
+
+      const firstEffect = window.VERTIGO_EFFECTS.space[0]
+      manager.toggleEffect('space', firstEffect.effect)
+
+      expect(manager.isEffectSelected('space', firstEffect.effect)).toBe(true)
+      expect(manager.getEffectCount('space')).toBe(1)
+
+      // Toggle again to deselect
+      manager.toggleEffect('space', firstEffect.effect)
+      expect(manager.isEffectSelected('space', firstEffect.effect)).toBe(false)
+      expect(manager.getEffectCount('space')).toBe(0)
+    })
+
+    it('should handle select all functionality', () => {
+      const manager = window.vertigoManager
+      manager.clearAllEffects()
+
+      manager.selectAllEffects('space')
+      expect(manager.getEffectCount('space')).toBe(
+        window.VERTIGO_EFFECTS.space.length
+      )
+
+      manager.selectAllEffects('ground')
+      expect(manager.getEffectCount('ground')).toBe(
+        window.VERTIGO_EFFECTS.ground.length
+      )
+    })
+
+    it('should handle clear all functionality', () => {
+      const manager = window.vertigoManager
+
+      // Select some effects first
+      manager.selectAllEffects('space')
+      manager.selectAllEffects('ground')
+
+      expect(manager.getEffectCount('space')).toBeGreaterThan(0)
+      expect(manager.getEffectCount('ground')).toBeGreaterThan(0)
+
+      // Clear all
+      manager.clearAllEffects()
+      expect(manager.getEffectCount('space')).toBe(0)
+      expect(manager.getEffectCount('ground')).toBe(0)
+    })
+  })
+
+  describe('UI Updates and Event Handling', () => {
     beforeEach(async () => {
-        // Clear localStorage to start fresh
-        testUtils.clearAppData();
-        
-        // Wait for the real app to be ready (loaded via browser test configuration)
-        await testUtils.waitForAppReady();
-        
-        // Get the real app instance (exposed globally by app.js)
-        app = window.app;
-        
-        // Ensure we have a clean profile for testing
-        if (app && typeof app.createProfile === 'function') {
-            // Create a test profile if it doesn't exist
-            const currentProfile = app.getCurrentProfile();
-            if (!currentProfile) {
-                app.createProfile('Test Profile', 'Test profile for vertigo operations');
-            }
-        }
-        
-        // Ensure vertigo manager is ready
-        if (window.vertigoManager) {
-            window.vertigoManager.clearAllEffects();
-        }
-    });
+      app.showVertigoModal()
+      await testUtils.waitForModalElement('#vertigoModal')
+      app.setupVertigoEventListeners()
+    })
 
+    it('should update effect counts in UI', () => {
+      const manager = window.vertigoManager
+      manager.clearAllEffects()
+
+      // Add some effects
+      manager.selectedEffects.space.add('Fx_Test_1')
+      manager.selectedEffects.space.add('Fx_Test_2')
+      manager.selectedEffects.ground.add('Fx_Ground_Test')
+
+      app.updateVertigoEffectCounts()
+
+      const spaceCount = document.getElementById('spaceEffectCount')
+      const groundCount = document.getElementById('groundEffectCount')
+
+      expect(spaceCount.textContent).toBe('2 selected')
+      expect(groundCount.textContent).toBe('1 selected')
+    })
+
+    it('should update preview when effects change', () => {
+      const manager = window.vertigoManager
+      manager.clearAllEffects()
+      manager.showPlayerSay = false
+
+      // Add test effect
+      manager.selectedEffects.space.add('Fx_Test_Effect')
+
+      app.updateVertigoPreview()
+
+      const spacePreview = document.getElementById('spaceAliasCommand')
+      const groundPreview = document.getElementById('groundAliasCommand')
+
+      expect(spacePreview.textContent).toContain(
+        'dynFxSetFXExlusionList Fx_Test_Effect'
+      )
+      expect(groundPreview.textContent).toBe('No ground effects selected')
+    })
+
+    it('should handle PlayerSay checkbox toggle', async () => {
+      const playerSayCheckbox = document.getElementById('vertigoShowPlayerSay')
+      const manager = window.vertigoManager
+
+      expect(playerSayCheckbox).toBeDefined()
+
+      // Set initial state
+      manager.showPlayerSay = false
+      playerSayCheckbox.checked = false
+
+      // Simulate checkbox change
+      playerSayCheckbox.checked = true
+      playerSayCheckbox.dispatchEvent(new Event('change', { bubbles: true }))
+
+      // Give event time to process
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      // Check if manager state updated
+      expect(manager.showPlayerSay).toBe(true)
+    })
+
+    it('should handle Select All button clicks', async () => {
+      const spaceSelectAllBtn = document.getElementById('spaceSelectAll')
+      const groundSelectAllBtn = document.getElementById('groundSelectAll')
+
+      expect(spaceSelectAllBtn).toBeDefined()
+      expect(groundSelectAllBtn).toBeDefined()
+
+      const manager = window.vertigoManager
+      manager.clearAllEffects()
+
+      // Simulate button clicks
+      await testUtils.clickElement('#spaceSelectAll')
+      await testUtils.clickElement('#groundSelectAll')
+
+      // Check if effects were selected
+      expect(manager.getEffectCount('space')).toBe(
+        window.VERTIGO_EFFECTS.space.length
+      )
+      expect(manager.getEffectCount('ground')).toBe(
+        window.VERTIGO_EFFECTS.ground.length
+      )
+    })
+
+    it('should handle Clear All button clicks', async () => {
+      const spaceClearAllBtn = document.getElementById('spaceClearAll')
+      const groundClearAllBtn = document.getElementById('groundClearAll')
+
+      expect(spaceClearAllBtn).toBeDefined()
+      expect(groundClearAllBtn).toBeDefined()
+
+      const manager = window.vertigoManager
+
+      // Select some effects first
+      manager.selectAllEffects('space')
+      manager.selectAllEffects('ground')
+
+      // Simulate button clicks
+      await testUtils.clickElement('#spaceClearAll')
+      await testUtils.clickElement('#groundClearAll')
+
+      // Check if effects were cleared
+      expect(manager.getEffectCount('space')).toBe(0)
+      expect(manager.getEffectCount('ground')).toBe(0)
+    })
+  })
+
+  describe('Alias Generation and Profile Integration', () => {
+    it('should generate aliases and add to profile', () => {
+      const manager = window.vertigoManager
+      manager.clearAllEffects()
+      manager.selectedEffects.space.add('Fx_Test_Space')
+      manager.selectedEffects.ground.add('Fx_Test_Ground')
+      manager.showPlayerSay = true
+
+      // Get current profile from storage (root profile)
+      const rootProfile = stoStorage.getProfile(app.currentProfile)
+      expect(rootProfile).toBeDefined()
+
+      const initialAliasCount = rootProfile.aliases
+        ? Object.keys(rootProfile.aliases).length
+        : 0
+
+      // Generate aliases
+      app.generateVertigoAliases()
+
+      // Get updated profile from storage after alias generation
+      const updatedProfile = stoStorage.getProfile(app.currentProfile)
+      expect(updatedProfile.aliases).toBeDefined()
+      const finalAliasCount = Object.keys(updatedProfile.aliases).length
+      expect(finalAliasCount).toBeGreaterThan(initialAliasCount)
+
+      // Check specific aliases
+      const spaceAlias = updatedProfile.aliases['dynFxSetFXExlusionList_Space']
+      const groundAlias =
+        updatedProfile.aliases['dynFxSetFXExlusionList_Ground']
+
+      expect(spaceAlias).toBeDefined()
+      expect(groundAlias).toBeDefined()
+      expect(spaceAlias.commands).toContain(
+        'dynFxSetFXExlusionList Fx_Test_Space'
+      )
+      expect(groundAlias.commands).toContain(
+        'dynFxSetFXExlusionList Fx_Test_Ground'
+      )
+    })
+
+    it('should not generate aliases when no effects selected', () => {
+      const manager = window.vertigoManager
+      manager.clearAllEffects()
+
+      const rootProfile = stoStorage.getProfile(app.currentProfile)
+      expect(rootProfile).toBeDefined()
+
+      const initialAliasCount = rootProfile.aliases
+        ? Object.keys(rootProfile.aliases).length
+        : 0
+
+      // Try to generate aliases with no effects
+      app.generateVertigoAliases()
+
+      // Should not add any aliases
+      const updatedProfile = stoStorage.getProfile(app.currentProfile)
+      const finalAliasCount = updatedProfile.aliases
+        ? Object.keys(updatedProfile.aliases).length
+        : 0
+      expect(finalAliasCount).toBe(initialAliasCount)
+    })
+  })
+
+  // Separate describe block for state persistence tests with their own cleanup
+  describe('State Persistence', () => {
+    // Don't clear effects after each test in this group - let tests manage their own state
     afterEach(() => {
-        // Clean up any open modals
-        const vertigoModal = document.getElementById('vertigoModal');
-        if (vertigoModal && vertigoModal.style.display !== 'none') {
-            vertigoModal.style.display = 'none';
-        }
-        
-        // Clear effects after tests (except for state persistence tests which handle their own cleanup)
-        if (window.vertigoManager) {
-            window.vertigoManager.clearAllEffects();
-        }
-    });
+      // Only close modals, don't clear effects
+      const vertigoModal = document.getElementById('vertigoModal')
+      if (vertigoModal && vertigoModal.style.display !== 'none') {
+        vertigoModal.style.display = 'none'
+      }
+    })
 
-    describe('Core Vertigo Manager Functionality', () => {
-        it('should have VERTIGO_EFFECTS data loaded', () => {
-            expect(window.VERTIGO_EFFECTS).toBeDefined();
-            expect(window.VERTIGO_EFFECTS.space).toBeInstanceOf(Array);
-            expect(window.VERTIGO_EFFECTS.ground).toBeInstanceOf(Array);
-            expect(window.VERTIGO_EFFECTS.space.length).toBeGreaterThan(0);
-            expect(window.VERTIGO_EFFECTS.ground.length).toBeGreaterThan(0);
-        });
+    it('should save and load vertigo settings to/from profile', () => {
+      const manager = window.vertigoManager
+      const profile = app.getCurrentProfile()
+      expect(profile).toBeDefined()
 
-        it('should have vertigoManager instance available', () => {
-            expect(window.vertigoManager).toBeDefined();
-            expect(typeof window.vertigoManager.generateAlias).toBe('function');
-            expect(typeof window.vertigoManager.toggleEffect).toBe('function');
-            expect(typeof window.vertigoManager.selectAllEffects).toBe('function');
-            expect(typeof window.vertigoManager.clearAllEffects).toBe('function');
-        });
+      // Set up test state
+      manager.clearAllEffects()
+      manager.selectedEffects.space.add('Fx_Test_1')
+      manager.selectedEffects.space.add('Fx_Test_2')
+      manager.selectedEffects.ground.add('Fx_Ground_Test')
+      manager.showPlayerSay = true
 
-        it('should generate properly formatted STO commands', () => {
-            const manager = window.vertigoManager;
-            manager.clearAllEffects();
-            manager.selectedEffects.space.add('Fx_Test_Effect_1');
-            manager.selectedEffects.space.add('Fx_Test_Effect_2');
-            manager.showPlayerSay = false;
-            
-            const spaceAlias = manager.generateAlias('space');
-            expect(spaceAlias).toMatch(/ &>$/);
-            expect(spaceAlias).toBe('alias dynFxSetFXExlusionList_Space <& dynFxSetFXExlusionList Fx_Test_Effect_1,Fx_Test_Effect_2 &>');
-        });
-    });
+      // Save state
+      manager.saveState(profile)
 
-    describe('App Integration', () => {
-        it('should have app instance available', () => {
-            expect(window.app).toBeDefined();
-            expect(app).toBeDefined();
-        });
+      expect(profile.vertigoSettings).toBeDefined()
+      expect(profile.vertigoSettings.selectedEffects.space).toEqual([
+        'Fx_Test_1',
+        'Fx_Test_2',
+      ])
+      expect(profile.vertigoSettings.selectedEffects.ground).toEqual([
+        'Fx_Ground_Test',
+      ])
+      expect(profile.vertigoSettings.showPlayerSay).toBe(true)
 
-        it('should have vertigo modal methods on app', () => {
-            expect(typeof app.showVertigoModal).toBe('function');
-            expect(typeof app.populateVertigoModal).toBe('function');
-            expect(typeof app.setupVertigoEventListeners).toBe('function');
-            expect(typeof app.generateVertigoAliases).toBe('function');
-        });
+      // Clear manager state
+      manager.clearAllEffects()
+      manager.showPlayerSay = false
 
-        it('should have vertigo button in DOM', () => {
-            const vertigoBtn = document.getElementById('vertigoBtn');
-            expect(vertigoBtn).toBeDefined();
-        });
-    });
+      // Load state back
+      manager.loadState(profile)
 
-    describe('Modal Operations', () => {
-        it('should show vertigo modal when showVertigoModal is called', async () => {
-            const modal = document.getElementById('vertigoModal');
-            expect(modal).toBeDefined();
-            
-            // Modal should be hidden initially
-            expect(modal.style.display).toBe('none');
-            
-            // Show modal
-            app.showVertigoModal();
-            
-            // Wait for modal to be visible
-            await testUtils.waitForModalElement('#vertigoModal');
-        });
+      expect(manager.getEffectCount('space')).toBe(2)
+      expect(manager.getEffectCount('ground')).toBe(1)
+      expect(manager.showPlayerSay).toBe(true)
+      expect(manager.isEffectSelected('space', 'Fx_Test_1')).toBe(true)
+      expect(manager.isEffectSelected('space', 'Fx_Test_2')).toBe(true)
+      expect(manager.isEffectSelected('ground', 'Fx_Ground_Test')).toBe(true)
 
-        it('should populate effect lists when modal is opened', async () => {
-            // Open modal and populate it
-            app.showVertigoModal();
-            await testUtils.waitForModalElement('#vertigoModal');
-            
-            const spaceList = document.getElementById('spaceEffectsList');
-            const groundList = document.getElementById('groundEffectsList');
-            
-            expect(spaceList).toBeDefined();
-            expect(groundList).toBeDefined();
-            
-            // Check if effects are populated
-            expect(spaceList.children.length).toBeGreaterThan(0);
-            expect(groundList.children.length).toBeGreaterThan(0);
-        });
+      // Clean up for this test
+      manager.clearAllEffects()
+    })
 
-        it('should create proper effect item HTML structure', () => {
-            const testEffect = { label: 'Test Effect', effect: 'Fx_Test_Effect' };
-            const effectItem = app.createEffectItem('space', testEffect);
-            
-            expect(effectItem).toBeDefined();
-            expect(effectItem.className).toBe('effect-item');
-            
-            const checkbox = effectItem.querySelector('input[type="checkbox"]');
-            const label = effectItem.querySelector('.effect-label');
-            
-            expect(checkbox).toBeDefined();
-            expect(label).toBeDefined();
-            expect(label.textContent).toBe('Test Effect');
-            expect(checkbox.dataset.environment).toBe('space');
-            expect(checkbox.dataset.effect).toBe('Fx_Test_Effect');
-        });
-    });
+    it('should preserve selections after generating aliases (save transaction)', async () => {
+      const manager = window.vertigoManager
+      const profile = app.getCurrentProfile()
+      expect(profile).toBeDefined()
 
-    describe('Effect Selection Operations', () => {
-        beforeEach(() => {
-            app.populateVertigoModal();
-        });
+      // Start with clean state
+      manager.clearAllEffects()
 
-        it('should handle individual effect selection', () => {
-            const manager = window.vertigoManager;
-            manager.clearAllEffects();
-            
-            const firstEffect = window.VERTIGO_EFFECTS.space[0];
-            manager.toggleEffect('space', firstEffect.effect);
-            
-            expect(manager.isEffectSelected('space', firstEffect.effect)).toBe(true);
-            expect(manager.getEffectCount('space')).toBe(1);
-            
-            // Toggle again to deselect
-            manager.toggleEffect('space', firstEffect.effect);
-            expect(manager.isEffectSelected('space', firstEffect.effect)).toBe(false);
-            expect(manager.getEffectCount('space')).toBe(0);
-        });
+      // Open modal and set up selections
+      app.showVertigoModal()
+      await testUtils.waitForModalElement('#vertigoModal')
 
-        it('should handle select all functionality', () => {
-            const manager = window.vertigoManager;
-            manager.clearAllEffects();
-            
-            manager.selectAllEffects('space');
-            expect(manager.getEffectCount('space')).toBe(window.VERTIGO_EFFECTS.space.length);
-            
-            manager.selectAllEffects('ground');
-            expect(manager.getEffectCount('ground')).toBe(window.VERTIGO_EFFECTS.ground.length);
-        });
+      // Select some effects
+      const firstSpaceEffect = window.VERTIGO_EFFECTS.space[0]
+      const firstGroundEffect = window.VERTIGO_EFFECTS.ground[0]
 
-        it('should handle clear all functionality', () => {
-            const manager = window.vertigoManager;
-            
-            // Select some effects first
-            manager.selectAllEffects('space');
-            manager.selectAllEffects('ground');
-            
-            expect(manager.getEffectCount('space')).toBeGreaterThan(0);
-            expect(manager.getEffectCount('ground')).toBeGreaterThan(0);
-            
-            // Clear all
-            manager.clearAllEffects();
-            expect(manager.getEffectCount('space')).toBe(0);
-            expect(manager.getEffectCount('ground')).toBe(0);
-        });
-    });
+      manager.toggleEffect('space', firstSpaceEffect.effect)
+      manager.toggleEffect('ground', firstGroundEffect.effect)
 
-    describe('UI Updates and Event Handling', () => {
-        beforeEach(async () => {
-            app.showVertigoModal();
-            await testUtils.waitForModalElement('#vertigoModal');
-            app.setupVertigoEventListeners();
-        });
+      // Verify selections are made
+      expect(manager.isEffectSelected('space', firstSpaceEffect.effect)).toBe(
+        true
+      )
+      expect(manager.isEffectSelected('ground', firstGroundEffect.effect)).toBe(
+        true
+      )
 
-        it('should update effect counts in UI', () => {
-            const manager = window.vertigoManager;
-            manager.clearAllEffects();
-            
-            // Add some effects
-            manager.selectedEffects.space.add('Fx_Test_1');
-            manager.selectedEffects.space.add('Fx_Test_2');
-            manager.selectedEffects.ground.add('Fx_Ground_Test');
-            
-            app.updateVertigoEffectCounts();
-            
-            const spaceCount = document.getElementById('spaceEffectCount');
-            const groundCount = document.getElementById('groundEffectCount');
-            
-            expect(spaceCount.textContent).toBe('2 selected');
-            expect(groundCount.textContent).toBe('1 selected');
-        });
+      // Generate aliases (save transaction)
+      app.generateVertigoAliases()
 
-        it('should update preview when effects change', () => {
-            const manager = window.vertigoManager;
-            manager.clearAllEffects();
-            manager.showPlayerSay = false;
-            
-            // Add test effect
-            manager.selectedEffects.space.add('Fx_Test_Effect');
-            
-            app.updateVertigoPreview();
-            
-            const spacePreview = document.getElementById('spaceAliasCommand');
-            const groundPreview = document.getElementById('groundAliasCommand');
-            
-            expect(spacePreview.textContent).toContain('dynFxSetFXExlusionList Fx_Test_Effect');
-            expect(groundPreview.textContent).toBe('No ground effects selected');
-        });
+      // Modal should be closed after generating aliases
+      const modal = document.getElementById('vertigoModal')
+      expect(modal.style.display).toBe('none')
 
-        it('should handle PlayerSay checkbox toggle', async () => {
-            const playerSayCheckbox = document.getElementById('vertigoShowPlayerSay');
-            const manager = window.vertigoManager;
-            
-            expect(playerSayCheckbox).toBeDefined();
-            
-            // Set initial state
-            manager.showPlayerSay = false;
-            playerSayCheckbox.checked = false;
-            
-            // Simulate checkbox change
-            playerSayCheckbox.checked = true;
-            playerSayCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
-            
-            // Give event time to process
-            await new Promise(resolve => setTimeout(resolve, 10));
-            
-            // Check if manager state updated
-            expect(manager.showPlayerSay).toBe(true);
-        });
+      // Reopen modal
+      app.showVertigoModal()
+      await testUtils.waitForModalElement('#vertigoModal')
 
-        it('should handle Select All button clicks', async () => {
-            const spaceSelectAllBtn = document.getElementById('spaceSelectAll');
-            const groundSelectAllBtn = document.getElementById('groundSelectAll');
-            
-            expect(spaceSelectAllBtn).toBeDefined();
-            expect(groundSelectAllBtn).toBeDefined();
-            
-            const manager = window.vertigoManager;
-            manager.clearAllEffects();
-            
-            // Simulate button clicks
-            await testUtils.clickElement('#spaceSelectAll');
-            await testUtils.clickElement('#groundSelectAll');
-            
-            // Check if effects were selected
-            expect(manager.getEffectCount('space')).toBe(window.VERTIGO_EFFECTS.space.length);
-            expect(manager.getEffectCount('ground')).toBe(window.VERTIGO_EFFECTS.ground.length);
-        });
+      // Verify selections are restored after reopening (they were saved)
+      expect(manager.isEffectSelected('space', firstSpaceEffect.effect)).toBe(
+        true
+      )
+      expect(manager.isEffectSelected('ground', firstGroundEffect.effect)).toBe(
+        true
+      )
 
-        it('should handle Clear All button clicks', async () => {
-            const spaceClearAllBtn = document.getElementById('spaceClearAll');
-            const groundClearAllBtn = document.getElementById('groundClearAll');
-            
-            expect(spaceClearAllBtn).toBeDefined();
-            expect(groundClearAllBtn).toBeDefined();
-            
-            const manager = window.vertigoManager;
-            
-            // Select some effects first
-            manager.selectAllEffects('space');
-            manager.selectAllEffects('ground');
-            
-            // Simulate button clicks
-            await testUtils.clickElement('#spaceClearAll');
-            await testUtils.clickElement('#groundClearAll');
-            
-            // Check if effects were cleared
-            expect(manager.getEffectCount('space')).toBe(0);
-            expect(manager.getEffectCount('ground')).toBe(0);
-        });
-    });
+      // Clean up for this test
+      manager.clearAllEffects()
+    })
 
-    describe('Alias Generation and Profile Integration', () => {
-        it('should generate aliases and add to profile', () => {
-            const manager = window.vertigoManager;
-            manager.clearAllEffects();
-            manager.selectedEffects.space.add('Fx_Test_Space');
-            manager.selectedEffects.ground.add('Fx_Test_Ground');
-            manager.showPlayerSay = true;
-            
-            // Get current profile from storage (root profile)
-            const rootProfile = stoStorage.getProfile(app.currentProfile);
-            expect(rootProfile).toBeDefined();
-            
-            const initialAliasCount = rootProfile.aliases ? Object.keys(rootProfile.aliases).length : 0;
-            
-            // Generate aliases
-            app.generateVertigoAliases();
-            
-            // Get updated profile from storage after alias generation
-            const updatedProfile = stoStorage.getProfile(app.currentProfile);
-            expect(updatedProfile.aliases).toBeDefined();
-            const finalAliasCount = Object.keys(updatedProfile.aliases).length;
-            expect(finalAliasCount).toBeGreaterThan(initialAliasCount);
-            
-            // Check specific aliases
-            const spaceAlias = updatedProfile.aliases['dynFxSetFXExlusionList_Space'];
-            const groundAlias = updatedProfile.aliases['dynFxSetFXExlusionList_Ground'];
-            
-            expect(spaceAlias).toBeDefined();
-            expect(groundAlias).toBeDefined();
-            expect(spaceAlias.commands).toContain('dynFxSetFXExlusionList Fx_Test_Space');
-            expect(groundAlias.commands).toContain('dynFxSetFXExlusionList Fx_Test_Ground');
-        });
+    it('should rollback changes on cancel (cancel transaction)', async () => {
+      const manager = window.vertigoManager
+      const profile = app.getCurrentProfile()
+      expect(profile).toBeDefined()
 
-        it('should not generate aliases when no effects selected', () => {
-            const manager = window.vertigoManager;
-            manager.clearAllEffects();
-            
-            const rootProfile = stoStorage.getProfile(app.currentProfile);
-            expect(rootProfile).toBeDefined();
-            
-            const initialAliasCount = rootProfile.aliases ? Object.keys(rootProfile.aliases).length : 0;
-            
-            // Try to generate aliases with no effects
-            app.generateVertigoAliases();
-            
-            // Should not add any aliases
-            const updatedProfile = stoStorage.getProfile(app.currentProfile);
-            const finalAliasCount = updatedProfile.aliases ? Object.keys(updatedProfile.aliases).length : 0;
-            expect(finalAliasCount).toBe(initialAliasCount);
-        });
-    });
+      // Get root profile for saving state
+      const rootProfile = stoStorage.getProfile(app.currentProfile)
 
-    // Separate describe block for state persistence tests with their own cleanup
-    describe('State Persistence', () => {
-        // Don't clear effects after each test in this group - let tests manage their own state
-        afterEach(() => {
-            // Only close modals, don't clear effects
-            const vertigoModal = document.getElementById('vertigoModal');
-            if (vertigoModal && vertigoModal.style.display !== 'none') {
-                vertigoModal.style.display = 'none';
-            }
-        });
+      // Start with one effect selected and save it
+      manager.clearAllEffects()
+      const initialEffect = window.VERTIGO_EFFECTS.space[0]
+      manager.toggleEffect('space', initialEffect.effect)
+      manager.saveState(rootProfile)
+      stoStorage.saveProfile(app.currentProfile, rootProfile)
 
-        it('should save and load vertigo settings to/from profile', () => {
-            const manager = window.vertigoManager;
-            const profile = app.getCurrentProfile();
-            expect(profile).toBeDefined();
-            
-            // Set up test state
-            manager.clearAllEffects();
-            manager.selectedEffects.space.add('Fx_Test_1');
-            manager.selectedEffects.space.add('Fx_Test_2');
-            manager.selectedEffects.ground.add('Fx_Ground_Test');
-            manager.showPlayerSay = true;
-            
-            // Save state
-            manager.saveState(profile);
-            
-            expect(profile.vertigoSettings).toBeDefined();
-            expect(profile.vertigoSettings.selectedEffects.space).toEqual(['Fx_Test_1', 'Fx_Test_2']);
-            expect(profile.vertigoSettings.selectedEffects.ground).toEqual(['Fx_Ground_Test']);
-            expect(profile.vertigoSettings.showPlayerSay).toBe(true);
-            
-            // Clear manager state
-            manager.clearAllEffects();
-            manager.showPlayerSay = false;
-            
-            // Load state back
-            manager.loadState(profile);
-            
-            expect(manager.getEffectCount('space')).toBe(2);
-            expect(manager.getEffectCount('ground')).toBe(1);
-            expect(manager.showPlayerSay).toBe(true);
-            expect(manager.isEffectSelected('space', 'Fx_Test_1')).toBe(true);
-            expect(manager.isEffectSelected('space', 'Fx_Test_2')).toBe(true);
-            expect(manager.isEffectSelected('ground', 'Fx_Ground_Test')).toBe(true);
-            
-            // Clean up for this test
-            manager.clearAllEffects();
-        });
+      // Open modal (should load the saved state)
+      app.showVertigoModal()
+      await testUtils.waitForModalElement('#vertigoModal')
 
-        it('should preserve selections after generating aliases (save transaction)', async () => {
-            const manager = window.vertigoManager;
-            const profile = app.getCurrentProfile();
-            expect(profile).toBeDefined();
-            
-            // Start with clean state
-            manager.clearAllEffects();
-            
-            // Open modal and set up selections
-            app.showVertigoModal();
-            await testUtils.waitForModalElement('#vertigoModal');
-            
-            // Select some effects
-            const firstSpaceEffect = window.VERTIGO_EFFECTS.space[0];
-            const firstGroundEffect = window.VERTIGO_EFFECTS.ground[0];
-            
-            manager.toggleEffect('space', firstSpaceEffect.effect);
-            manager.toggleEffect('ground', firstGroundEffect.effect);
-            
-            // Verify selections are made
-            expect(manager.isEffectSelected('space', firstSpaceEffect.effect)).toBe(true);
-            expect(manager.isEffectSelected('ground', firstGroundEffect.effect)).toBe(true);
-            
-            // Generate aliases (save transaction)
-            app.generateVertigoAliases();
-            
-            // Modal should be closed after generating aliases
-            const modal = document.getElementById('vertigoModal');
-            expect(modal.style.display).toBe('none');
-            
-            // Reopen modal
-            app.showVertigoModal();
-            await testUtils.waitForModalElement('#vertigoModal');
-            
-            // Verify selections are restored after reopening (they were saved)
-            expect(manager.isEffectSelected('space', firstSpaceEffect.effect)).toBe(true);
-            expect(manager.isEffectSelected('ground', firstGroundEffect.effect)).toBe(true);
-            
-            // Clean up for this test
-            manager.clearAllEffects();
-        });
+      // Verify initial effect is loaded
+      expect(manager.isEffectSelected('space', initialEffect.effect)).toBe(true)
 
-        it('should rollback changes on cancel (cancel transaction)', async () => {
-            const manager = window.vertigoManager;
-            const profile = app.getCurrentProfile();
-            expect(profile).toBeDefined();
-            
-            // Get root profile for saving state
-            const rootProfile = stoStorage.getProfile(app.currentProfile);
-            
-            // Start with one effect selected and save it
-            manager.clearAllEffects();
-            const initialEffect = window.VERTIGO_EFFECTS.space[0];
-            manager.toggleEffect('space', initialEffect.effect);
-            manager.saveState(rootProfile);
-            stoStorage.saveProfile(app.currentProfile, rootProfile);
-            
-            // Open modal (should load the saved state)
-            app.showVertigoModal();
-            await testUtils.waitForModalElement('#vertigoModal');
-            
-            // Verify initial effect is loaded
-            expect(manager.isEffectSelected('space', initialEffect.effect)).toBe(true);
-            
-            // Make changes: deselect initial effect and select a different one
-            const newEffect = window.VERTIGO_EFFECTS.space[1];
-            manager.toggleEffect('space', initialEffect.effect); // deselect
-            manager.toggleEffect('space', newEffect.effect); // select new
-            
-            // Verify temporary changes
-            expect(manager.isEffectSelected('space', initialEffect.effect)).toBe(false);
-            expect(manager.isEffectSelected('space', newEffect.effect)).toBe(true);
-            
-            // Cancel modal (should rollback changes)
-            const cancelBtn = document.querySelector('#vertigoModal .btn-secondary[data-modal="vertigoModal"]');
-            cancelBtn.click();
-            
-            // Wait for modal to close
-            await new Promise(resolve => setTimeout(resolve, 100));
-            
-            // Reopen modal
-            app.showVertigoModal();
-            await testUtils.waitForModalElement('#vertigoModal');
-            
-            // Verify rollback: initial effect should be restored, new effect should not be there
-            expect(manager.isEffectSelected('space', initialEffect.effect)).toBe(true);
-            expect(manager.isEffectSelected('space', newEffect.effect)).toBe(false);
-            
-            // Clean up for this test
-            manager.clearAllEffects();
-        });
-    });
+      // Make changes: deselect initial effect and select a different one
+      const newEffect = window.VERTIGO_EFFECTS.space[1]
+      manager.toggleEffect('space', initialEffect.effect) // deselect
+      manager.toggleEffect('space', newEffect.effect) // select new
 
-    describe('Error Handling and Edge Cases', () => {
-        it('should handle missing DOM elements gracefully', () => {
-            // Remove some DOM elements
-            const spaceList = document.getElementById('spaceEffectsList');
-            if (spaceList) spaceList.remove();
-            
-            // Should not throw errors
-            expect(() => {
-                app.populateVertigoModal();
-            }).not.toThrow();
-        });
+      // Verify temporary changes
+      expect(manager.isEffectSelected('space', initialEffect.effect)).toBe(
+        false
+      )
+      expect(manager.isEffectSelected('space', newEffect.effect)).toBe(true)
 
-        it('should handle invalid effect names', () => {
-            const manager = window.vertigoManager;
-            
-            expect(() => {
-                manager.toggleEffect('space', null);
-            }).toThrow(InvalidEffectError);
-            
-            expect(() => {
-                manager.toggleEffect('space', undefined);
-            }).toThrow(InvalidEffectError);
-            
-            expect(() => {
-                manager.toggleEffect('space', '');
-            }).toThrow(InvalidEffectError);
-        });
+      // Cancel modal (should rollback changes)
+      const cancelBtn = document.querySelector(
+        '#vertigoModal .btn-secondary[data-modal="vertigoModal"]'
+      )
+      cancelBtn.click()
 
-        it('should handle invalid environment names', () => {
-            const manager = window.vertigoManager;
-            
-            expect(() => {
-                manager.generateAlias('invalid');
-            }).toThrow(InvalidEnvironmentError);
-            
-            expect(() => {
-                manager.toggleEffect('invalid', 'effect');
-            }).toThrow(InvalidEnvironmentError);
-            
-            expect(() => {
-                manager.selectAllEffects('invalid');
-            }).toThrow(InvalidEnvironmentError);
-        });
+      // Wait for modal to close
+      await new Promise((resolve) => setTimeout(resolve, 100))
 
-        it('should show error messages when app methods catch exceptions', async () => {
-            // Mock stoUI.showToast to capture error messages
-            const originalShowToast = stoUI.showToast;
-            const toastCalls = [];
-            stoUI.showToast = (message, type) => {
-                toastCalls.push({ message, type });
-            };
+      // Reopen modal
+      app.showVertigoModal()
+      await testUtils.waitForModalElement('#vertigoModal')
 
-            try {
-                // Test that app error handling works
-                app.updateVertigoPreview();
-                
-                // Test generateVertigoAliases error handling
-                app.generateVertigoAliases();
-                
-                // The methods should handle errors gracefully without throwing
-                expect(toastCalls.length).toBeGreaterThanOrEqual(0);
-                
-            } finally {
-                // Restore original showToast method
-                stoUI.showToast = originalShowToast;
-            }
-        });
-    });
-}); 
+      // Verify rollback: initial effect should be restored, new effect should not be there
+      expect(manager.isEffectSelected('space', initialEffect.effect)).toBe(true)
+      expect(manager.isEffectSelected('space', newEffect.effect)).toBe(false)
+
+      // Clean up for this test
+      manager.clearAllEffects()
+    })
+  })
+
+  describe('Error Handling and Edge Cases', () => {
+    it('should handle missing DOM elements gracefully', () => {
+      // Remove some DOM elements
+      const spaceList = document.getElementById('spaceEffectsList')
+      if (spaceList) spaceList.remove()
+
+      // Should not throw errors
+      expect(() => {
+        app.populateVertigoModal()
+      }).not.toThrow()
+    })
+
+    it('should handle invalid effect names', () => {
+      const manager = window.vertigoManager
+
+      expect(() => {
+        manager.toggleEffect('space', null)
+      }).toThrow(InvalidEffectError)
+
+      expect(() => {
+        manager.toggleEffect('space', undefined)
+      }).toThrow(InvalidEffectError)
+
+      expect(() => {
+        manager.toggleEffect('space', '')
+      }).toThrow(InvalidEffectError)
+    })
+
+    it('should handle invalid environment names', () => {
+      const manager = window.vertigoManager
+
+      expect(() => {
+        manager.generateAlias('invalid')
+      }).toThrow(InvalidEnvironmentError)
+
+      expect(() => {
+        manager.toggleEffect('invalid', 'effect')
+      }).toThrow(InvalidEnvironmentError)
+
+      expect(() => {
+        manager.selectAllEffects('invalid')
+      }).toThrow(InvalidEnvironmentError)
+    })
+
+    it('should show error messages when app methods catch exceptions', async () => {
+      // Mock stoUI.showToast to capture error messages
+      const originalShowToast = stoUI.showToast
+      const toastCalls = []
+      stoUI.showToast = (message, type) => {
+        toastCalls.push({ message, type })
+      }
+
+      try {
+        // Test that app error handling works
+        app.updateVertigoPreview()
+
+        // Test generateVertigoAliases error handling
+        app.generateVertigoAliases()
+
+        // The methods should handle errors gracefully without throwing
+        expect(toastCalls.length).toBeGreaterThanOrEqual(0)
+      } finally {
+        // Restore original showToast method
+        stoUI.showToast = originalShowToast
+      }
+    })
+  })
+})

--- a/tests/fixtures/sample-profiles.js
+++ b/tests/fixtures/sample-profiles.js
@@ -8,34 +8,30 @@ export const basicProfile = {
       builds: {
         space: {
           keys: {
-            'F1': {
-              commands: [
-                { id: 1, command: 'FireAll', delay: 0 }
-              ]
+            F1: {
+              commands: [{ id: 1, command: 'FireAll', delay: 0 }],
             },
-            'F2': {
-              commands: [
-                { id: 2, command: 'FirePhasers', delay: 0 }
-              ]
-            }
+            F2: {
+              commands: [{ id: 2, command: 'FirePhasers', delay: 0 }],
+            },
           },
-          aliases: {}
+          aliases: {},
         },
         ground: {
           keys: {},
-          aliases: {}
-        }
+          aliases: {},
+        },
       },
       currentEnvironment: 'space',
       created: '2024-01-01T00:00:00.000Z',
-      lastModified: '2024-01-01T00:00:00.000Z'
-    }
+      lastModified: '2024-01-01T00:00:00.000Z',
+    },
   },
   currentProfile: 'test-profile-1',
   settings: {
     theme: 'dark',
-    autoSave: true
-  }
+    autoSave: true,
+  },
 }
 
 export const complexProfile = {
@@ -46,44 +42,41 @@ export const complexProfile = {
       builds: {
         space: {
           keys: {
-            'Space': {
+            Space: {
               commands: [
                 { id: 1, command: 'FireAll', delay: 0 },
                 { id: 2, command: '+TrayExecByTray 0 0', delay: 500 },
-                { id: 3, command: 'FireTorps', delay: 1000 }
-              ]
+                { id: 3, command: 'FireTorps', delay: 1000 },
+              ],
             },
-            'Tab': {
-              commands: [
-                { id: 4, command: 'Target_Enemy_Near', delay: 0 }
-              ]
-            }
+            Tab: {
+              commands: [{ id: 4, command: 'Target_Enemy_Near', delay: 0 }],
+            },
           },
           aliases: {
-            'FireSequence': '+TrayExecByTray 0 0$$+TrayExecByTray 0 1$$+TrayExecByTray 0 2'
-          }
+            FireSequence:
+              '+TrayExecByTray 0 0$$+TrayExecByTray 0 1$$+TrayExecByTray 0 2',
+          },
         },
         ground: {
           keys: {
-            'Space': {
-              commands: [
-                { id: 5, command: 'Jump', delay: 0 }
-              ]
-            }
+            Space: {
+              commands: [{ id: 5, command: 'Jump', delay: 0 }],
+            },
           },
-          aliases: {}
-        }
+          aliases: {},
+        },
       },
       currentEnvironment: 'space',
       created: '2024-01-01T00:00:00.000Z',
-      lastModified: '2024-01-01T00:00:00.000Z'
-    }
+      lastModified: '2024-01-01T00:00:00.000Z',
+    },
   },
   currentProfile: 'complex-profile',
   settings: {
     theme: 'light',
-    autoSave: false
-  }
+    autoSave: false,
+  },
 }
 
 export const emptyProfile = {
@@ -94,23 +87,23 @@ export const emptyProfile = {
       builds: {
         space: {
           keys: {},
-          aliases: {}
+          aliases: {},
         },
         ground: {
           keys: {},
-          aliases: {}
-        }
+          aliases: {},
+        },
       },
       currentEnvironment: 'space',
       created: '2024-01-01T00:00:00.000Z',
-      lastModified: '2024-01-01T00:00:00.000Z'
-    }
+      lastModified: '2024-01-01T00:00:00.000Z',
+    },
   },
   currentProfile: 'empty-profile',
   settings: {
     theme: 'dark',
-    autoSave: true
-  }
+    autoSave: true,
+  },
 }
 
 export const multiProfile = {
@@ -120,39 +113,41 @@ export const multiProfile = {
       description: 'First test profile',
       builds: {
         space: {
-          keys: { 'F1': { commands: [{ id: 1, command: 'FireAll', delay: 0 }] } },
-          aliases: {}
+          keys: { F1: { commands: [{ id: 1, command: 'FireAll', delay: 0 }] } },
+          aliases: {},
         },
         ground: {
           keys: {},
-          aliases: {}
-        }
+          aliases: {},
+        },
       },
       currentEnvironment: 'space',
       created: '2024-01-01T00:00:00.000Z',
-      lastModified: '2024-01-01T00:00:00.000Z'
+      lastModified: '2024-01-01T00:00:00.000Z',
     },
     'profile-2': {
       name: 'Profile Two',
       description: 'Second test profile',
       builds: {
         space: {
-          keys: { 'F2': { commands: [{ id: 2, command: 'FirePhasers', delay: 0 }] } },
-          aliases: {}
+          keys: {
+            F2: { commands: [{ id: 2, command: 'FirePhasers', delay: 0 }] },
+          },
+          aliases: {},
         },
         ground: {
           keys: {},
-          aliases: {}
-        }
+          aliases: {},
+        },
       },
       currentEnvironment: 'space',
       created: '2024-01-02T00:00:00.000Z',
-      lastModified: '2024-01-02T00:00:00.000Z'
-    }
+      lastModified: '2024-01-02T00:00:00.000Z',
+    },
   },
   currentProfile: 'profile-1',
   settings: {
     theme: 'dark',
-    autoSave: true
-  }
-} 
+    autoSave: true,
+  },
+}

--- a/tests/integration/alias-commands.test.js
+++ b/tests/integration/alias-commands.test.js
@@ -1,102 +1,106 @@
 // Integration tests for alias command functionality
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 describe('Alias Command Integration', () => {
-    let mockApp, mockProfile, mockCommands, mockUI;
+  let mockApp, mockProfile, mockCommands, mockUI
 
-    beforeEach(() => {
-        // Mock profile with aliases
-        mockProfile = {
-            name: 'Test Profile',
-            aliases: {
-                'TestAlias1': {
-                    name: 'TestAlias1',
-                    description: 'Test alias for targeting',
-                    commands: 'target_nearest_enemy $$ FireAll'
-                },
-                'TestAlias2': {
-                    name: 'TestAlias2',
-                    description: 'Test alias for healing',
-                    commands: 'target_self $$ +power_exec Science_Team'
-                },
-                'dynFxSetFXExlusionList_Space': {
-                    name: 'dynFxSetFXExlusionList_Space',
-                    description: 'Vertigo - Disable Space Visual Effects',
-                    commands: 'dynFxSetFXExlusionList Fx_Explosion_Large,Fx_Weapon_Beam $$ PlayerSay Vertigo VFX Loaded'
-                }
+  beforeEach(() => {
+    // Mock profile with aliases
+    mockProfile = {
+      name: 'Test Profile',
+      aliases: {
+        TestAlias1: {
+          name: 'TestAlias1',
+          description: 'Test alias for targeting',
+          commands: 'target_nearest_enemy $$ FireAll',
+        },
+        TestAlias2: {
+          name: 'TestAlias2',
+          description: 'Test alias for healing',
+          commands: 'target_self $$ +power_exec Science_Team',
+        },
+        dynFxSetFXExlusionList_Space: {
+          name: 'dynFxSetFXExlusionList_Space',
+          description: 'Vertigo - Disable Space Visual Effects',
+          commands:
+            'dynFxSetFXExlusionList Fx_Explosion_Large,Fx_Weapon_Beam $$ PlayerSay Vertigo VFX Loaded',
+        },
+      },
+    }
+
+    mockApp = {
+      getCurrentProfile: vi.fn(() => mockProfile),
+    }
+
+    mockUI = {
+      showModal: vi.fn(),
+      hideModal: vi.fn(),
+      showToast: vi.fn(),
+    }
+
+    mockCommands = {
+      commandBuilders: new Map(),
+      setupCommandBuilders() {
+        this.commandBuilders.set('alias', {
+          build: (commandId, params = {}) => {
+            const aliasName = params.alias_name || ''
+
+            if (!aliasName.trim()) {
+              return null
             }
-        };
 
-        mockApp = {
-            getCurrentProfile: vi.fn(() => mockProfile)
-        };
+            return {
+              command: aliasName,
+              type: 'alias',
+              icon: '📝',
+              text: `Alias: ${aliasName}`,
+              description: 'Execute custom alias',
+              parameters: { alias_name: aliasName },
+            }
+          },
+          getUI: () => this.createAliasUI(),
+        })
+      },
+      createAliasUI() {
+        const profile = mockApp.getCurrentProfile()
+        const aliases = profile?.aliases || {}
+        const aliasEntries = Object.entries(aliases)
 
-        mockUI = {
-            showModal: vi.fn(),
-            hideModal: vi.fn(),
-            showToast: vi.fn()
-        };
-
-        mockCommands = {
-            commandBuilders: new Map(),
-            setupCommandBuilders() {
-                this.commandBuilders.set('alias', {
-                    build: (commandId, params = {}) => {
-                        const aliasName = params.alias_name || '';
-                        
-                        if (!aliasName.trim()) {
-                            return null;
-                        }
-                        
-                        return {
-                            command: aliasName,
-                            type: 'alias',
-                            icon: '📝',
-                            text: `Alias: ${aliasName}`,
-                            description: 'Execute custom alias',
-                            parameters: { alias_name: aliasName }
-                        };
-                    },
-                    getUI: () => this.createAliasUI()
-                });
-            },
-            createAliasUI() {
-                const profile = mockApp.getCurrentProfile();
-                const aliases = profile?.aliases || {};
-                const aliasEntries = Object.entries(aliases);
-                
-                if (aliasEntries.length === 0) {
-                    return `
+        if (aliasEntries.length === 0) {
+          return `
                         <div class="alias-builder">
                             <div class="empty-state">
                                 <h4>No Aliases Available</h4>
                                 <p>Create aliases in the Alias Manager first.</p>
                             </div>
                         </div>
-                    `;
-                }
-                
-                return `
+                    `
+        }
+
+        return `
                     <div class="alias-builder">
                         <div class="form-group">
                             <label for="aliasSelect">Available Aliases:</label>
                             <select id="aliasSelect">
                                 <option value="">Select an alias...</option>
-                                ${aliasEntries.map(([name, alias]) => 
-                                    `<option value="${name}">${name}${alias.description ? ' - ' + alias.description : ''}</option>`
-                                ).join('')}
+                                ${aliasEntries
+                                  .map(
+                                    ([name, alias]) =>
+                                      `<option value="${name}">${name}${alias.description ? ' - ' + alias.description : ''}</option>`
+                                  )
+                                  .join('')}
                             </select>
                         </div>
                     </div>
-                `;
-            }
-        };
+                `
+      },
+    }
 
-        global.app = mockApp;
-        global.stoUI = mockUI;
-        
-        // Setup DOM
-        document.body.innerHTML = `
+    global.app = mockApp
+    global.stoUI = mockUI
+
+    // Setup DOM
+    document.body.innerHTML = `
             <div id="addCommandModal">
                 <select id="commandType">
                     <option value="alias">Alias</option>
@@ -104,132 +108,145 @@ describe('Alias Command Integration', () => {
                 <div id="commandBuilder"></div>
                 <div id="modalCommandPreview">Select a command type to see preview</div>
             </div>
-        `;
-    });
+        `
+  })
 
-    afterEach(() => {
-        document.body.innerHTML = '';
-        delete global.app;
-        delete global.stoUI;
-    });
+  afterEach(() => {
+    document.body.innerHTML = ''
+    delete global.app
+    delete global.stoUI
+  })
 
-    describe('Alias Command Builder', () => {
-        beforeEach(() => {
-            mockCommands.setupCommandBuilders();
-        });
+  describe('Alias Command Builder', () => {
+    beforeEach(() => {
+      mockCommands.setupCommandBuilders()
+    })
 
-        it('should build alias command correctly', () => {
-            const builder = mockCommands.commandBuilders.get('alias');
-            const result = builder.build('alias', { alias_name: 'TestAlias1' });
-            
-            expect(result).toEqual({
-                command: 'TestAlias1',
-                type: 'alias',
-                icon: '📝',
-                text: 'Alias: TestAlias1',
-                description: 'Execute custom alias',
-                parameters: { alias_name: 'TestAlias1' }
-            });
-        });
+    it('should build alias command correctly', () => {
+      const builder = mockCommands.commandBuilders.get('alias')
+      const result = builder.build('alias', { alias_name: 'TestAlias1' })
 
-        it('should return null for empty alias name', () => {
-            const builder = mockCommands.commandBuilders.get('alias');
-            const result = builder.build('alias', { alias_name: '' });
-            
-            expect(result).toBeNull();
-        });
+      expect(result).toEqual({
+        command: 'TestAlias1',
+        type: 'alias',
+        icon: '📝',
+        text: 'Alias: TestAlias1',
+        description: 'Execute custom alias',
+        parameters: { alias_name: 'TestAlias1' },
+      })
+    })
 
-        it('should generate UI with available aliases', () => {
-            const ui = mockCommands.createAliasUI();
-            
-            expect(ui).toContain('TestAlias1');
-            expect(ui).toContain('TestAlias2');
-            expect(ui).toContain('dynFxSetFXExlusionList_Space');
-            expect(ui).toContain('Test alias for targeting');
-            expect(ui).toContain('Test alias for healing');
-            expect(ui).toContain('Vertigo - Disable Space Visual Effects');
-        });
+    it('should return null for empty alias name', () => {
+      const builder = mockCommands.commandBuilders.get('alias')
+      const result = builder.build('alias', { alias_name: '' })
 
-        it('should show empty state when no aliases available', () => {
-            mockProfile.aliases = {};
-            
-            const ui = mockCommands.createAliasUI();
-            
-            expect(ui).toContain('No Aliases Available');
-            expect(ui).toContain('Create aliases in the Alias Manager first');
-        });
-    });
+      expect(result).toBeNull()
+    })
 
-    describe('Command Modal Integration', () => {
-        it('should have alias option in command type selector', () => {
-            const commandType = document.getElementById('commandType');
-            const aliasOption = commandType.querySelector('option[value="alias"]');
-            
-            expect(aliasOption).toBeTruthy();
-            expect(aliasOption.textContent).toBe('Alias');
-        });
+    it('should generate UI with available aliases', () => {
+      const ui = mockCommands.createAliasUI()
 
-        it('should populate command builder when alias type selected', () => {
-            mockCommands.setupCommandBuilders();
-            const commandBuilder = document.getElementById('commandBuilder');
-            const ui = mockCommands.createAliasUI();
-            
-            commandBuilder.innerHTML = ui;
-            
-            const aliasSelect = commandBuilder.querySelector('#aliasSelect');
-            expect(aliasSelect).toBeTruthy();
-            
-            const options = aliasSelect.querySelectorAll('option');
-            expect(options.length).toBe(4); // 3 aliases + empty option
-        });
-    });
+      expect(ui).toContain('TestAlias1')
+      expect(ui).toContain('TestAlias2')
+      expect(ui).toContain('dynFxSetFXExlusionList_Space')
+      expect(ui).toContain('Test alias for targeting')
+      expect(ui).toContain('Test alias for healing')
+      expect(ui).toContain('Vertigo - Disable Space Visual Effects')
+    })
 
-    describe('Vertigo Alias Integration', () => {
-        it('should properly handle Vertigo-generated aliases', () => {
-            const vertigoAlias = mockProfile.aliases['dynFxSetFXExlusionList_Space'];
-            
-            expect(vertigoAlias).toBeDefined();
-            expect(vertigoAlias.name).toBe('dynFxSetFXExlusionList_Space');
-            expect(vertigoAlias.commands).toContain('dynFxSetFXExlusionList');
-            expect(vertigoAlias.commands).toContain('PlayerSay Vertigo VFX Loaded');
-        });
+    it('should show empty state when no aliases available', () => {
+      mockProfile.aliases = {}
 
-        it('should build Vertigo alias command correctly', () => {
-            mockCommands.setupCommandBuilders();
-            const builder = mockCommands.commandBuilders.get('alias');
-            const result = builder.build('alias', { alias_name: 'dynFxSetFXExlusionList_Space' });
-            
-            expect(result.command).toBe('dynFxSetFXExlusionList_Space');
-            expect(result.type).toBe('alias');
-            expect(result.text).toBe('Alias: dynFxSetFXExlusionList_Space');
-        });
-    });
+      const ui = mockCommands.createAliasUI()
 
-    describe('Alias Command Validation', () => {
-        it('should validate alias names correctly', () => {
-            const validAliasNames = ['TestAlias', 'My_Alias_123', 'dynFxSetFXExlusionList_Space'];
-            const invalidAliasNames = ['', '   ', 'Alias With Spaces', 'Alias-With-Dashes'];
-            
-            validAliasNames.forEach(name => {
-                expect(name.trim().length).toBeGreaterThan(0);
-                expect(/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)).toBe(true);
-            });
-            
-            invalidAliasNames.forEach(name => {
-                expect(name.trim().length === 0 || !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)).toBe(true);
-            });
-        });
+      expect(ui).toContain('No Aliases Available')
+      expect(ui).toContain('Create aliases in the Alias Manager first')
+    })
+  })
 
-        it('should handle non-existent alias names gracefully', () => {
-            mockCommands.setupCommandBuilders();
-            const builder = mockCommands.commandBuilders.get('alias');
-            
-            // Should still build the command even if alias doesn't exist in profile
-            // (validation happens elsewhere)
-            const result = builder.build('alias', { alias_name: 'NonExistentAlias' });
-            
-            expect(result).not.toBeNull();
-            expect(result.command).toBe('NonExistentAlias');
-        });
-    });
-}); 
+  describe('Command Modal Integration', () => {
+    it('should have alias option in command type selector', () => {
+      const commandType = document.getElementById('commandType')
+      const aliasOption = commandType.querySelector('option[value="alias"]')
+
+      expect(aliasOption).toBeTruthy()
+      expect(aliasOption.textContent).toBe('Alias')
+    })
+
+    it('should populate command builder when alias type selected', () => {
+      mockCommands.setupCommandBuilders()
+      const commandBuilder = document.getElementById('commandBuilder')
+      const ui = mockCommands.createAliasUI()
+
+      commandBuilder.innerHTML = ui
+
+      const aliasSelect = commandBuilder.querySelector('#aliasSelect')
+      expect(aliasSelect).toBeTruthy()
+
+      const options = aliasSelect.querySelectorAll('option')
+      expect(options.length).toBe(4) // 3 aliases + empty option
+    })
+  })
+
+  describe('Vertigo Alias Integration', () => {
+    it('should properly handle Vertigo-generated aliases', () => {
+      const vertigoAlias = mockProfile.aliases['dynFxSetFXExlusionList_Space']
+
+      expect(vertigoAlias).toBeDefined()
+      expect(vertigoAlias.name).toBe('dynFxSetFXExlusionList_Space')
+      expect(vertigoAlias.commands).toContain('dynFxSetFXExlusionList')
+      expect(vertigoAlias.commands).toContain('PlayerSay Vertigo VFX Loaded')
+    })
+
+    it('should build Vertigo alias command correctly', () => {
+      mockCommands.setupCommandBuilders()
+      const builder = mockCommands.commandBuilders.get('alias')
+      const result = builder.build('alias', {
+        alias_name: 'dynFxSetFXExlusionList_Space',
+      })
+
+      expect(result.command).toBe('dynFxSetFXExlusionList_Space')
+      expect(result.type).toBe('alias')
+      expect(result.text).toBe('Alias: dynFxSetFXExlusionList_Space')
+    })
+  })
+
+  describe('Alias Command Validation', () => {
+    it('should validate alias names correctly', () => {
+      const validAliasNames = [
+        'TestAlias',
+        'My_Alias_123',
+        'dynFxSetFXExlusionList_Space',
+      ]
+      const invalidAliasNames = [
+        '',
+        '   ',
+        'Alias With Spaces',
+        'Alias-With-Dashes',
+      ]
+
+      validAliasNames.forEach((name) => {
+        expect(name.trim().length).toBeGreaterThan(0)
+        expect(/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)).toBe(true)
+      })
+
+      invalidAliasNames.forEach((name) => {
+        expect(
+          name.trim().length === 0 || !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)
+        ).toBe(true)
+      })
+    })
+
+    it('should handle non-existent alias names gracefully', () => {
+      mockCommands.setupCommandBuilders()
+      const builder = mockCommands.commandBuilders.get('alias')
+
+      // Should still build the command even if alias doesn't exist in profile
+      // (validation happens elsewhere)
+      const result = builder.build('alias', { alias_name: 'NonExistentAlias' })
+
+      expect(result).not.toBeNull()
+      expect(result.command).toBe('NonExistentAlias')
+    })
+  })
+})

--- a/tests/integration/app-workflow.test.js
+++ b/tests/integration/app-workflow.test.js
@@ -18,15 +18,15 @@ describe('App Workflow Integration', () => {
     const htmlPath = path.join(process.cwd(), 'src', 'index.html')
     const htmlContent = fs.readFileSync(htmlPath, 'utf-8')
     document.documentElement.innerHTML = htmlContent
-    
+
     // Clear localStorage
     localStorage.clear()
-    
+
     // Mock UI methods that show actual modals
     const originalAlert = window.alert
     const originalConfirm = window.confirm
     const originalPrompt = window.prompt
-    
+
     window.alert = vi.fn()
     window.confirm = vi.fn(() => true)
     window.prompt = vi.fn((message, defaultValue) => {
@@ -34,12 +34,12 @@ describe('App Workflow Integration', () => {
       if (message.includes('alias name')) return 'TestAlias'
       return defaultValue || 'test'
     })
-    
+
     // Store originals for cleanup
     window._originalAlert = originalAlert
     window._originalConfirm = originalConfirm
     window._originalPrompt = originalPrompt
-    
+
     await import('../../src/js/data.js')
     stoStorage = new STOStorage()
     stoProfiles = new STOProfileManager()
@@ -57,7 +57,7 @@ describe('App Workflow Integration', () => {
     if (window._originalAlert) window.alert = window._originalAlert
     if (window._originalConfirm) window.confirm = window._originalConfirm
     if (window._originalPrompt) window.prompt = window._originalPrompt
-    
+
     // Clean up
     document.documentElement.innerHTML = ''
     localStorage.clear()
@@ -67,19 +67,24 @@ describe('App Workflow Integration', () => {
     it('should create new profile and switch to it', async () => {
       const initialData = stoStorage.getAllData()
       const initialProfileCount = Object.keys(initialData.profiles).length
-      
+
       // Create new profile
-      const profileId = app.createProfile('Integration Test Profile', 'Test Description')
-      
+      const profileId = app.createProfile(
+        'Integration Test Profile',
+        'Test Description'
+      )
+
       const updatedData = stoStorage.getAllData()
       const profiles = Object.values(updatedData.profiles)
       expect(profiles).toHaveLength(initialProfileCount + 1)
-      expect(profiles.some(p => p.name === 'Integration Test Profile')).toBe(true)
-      
+      expect(profiles.some((p) => p.name === 'Integration Test Profile')).toBe(
+        true
+      )
+
       // Verify profile is current
       const currentProfile = app.getCurrentProfile()
       expect(currentProfile.name).toBe('Integration Test Profile')
-      
+
       // Verify profile selector updates
       const profileSelect = document.getElementById('profileSelect')
       expect(profileSelect.value).toBe(profileId)
@@ -89,33 +94,37 @@ describe('App Workflow Integration', () => {
       // Create initial profile with data
       const sourceId = app.createProfile('Source Profile', 'Source Description')
       app.switchProfile(sourceId)
-      
+
       // Add some keybinds to source profile
       const profile = app.getCurrentProfile()
-      profile.builds.space.keys['F1'] = [{ command: 'say "test command"', type: 'chat' }]
-      profile.builds.ground.keys['F2'] = [{ command: 'say "ground command"', type: 'chat' }]
+      profile.builds.space.keys['F1'] = [
+        { command: 'say "test command"', type: 'chat' },
+      ]
+      profile.builds.ground.keys['F2'] = [
+        { command: 'say "ground command"', type: 'chat' },
+      ]
       app.saveCurrentProfile()
-      
+
       // Clone the profile using the app
       const clonedId = app.cloneProfile(sourceId, 'Cloned Profile')
-      
+
       // Verify cloned profile exists and has data
       app.switchProfile(clonedId)
       const clonedProfile = app.getCurrentProfile()
       expect(clonedProfile).toBeDefined()
       expect(clonedProfile.name).toBe('Cloned Profile')
-      
+
       // Check if keys were cloned (they may be empty initially)
       expect(clonedProfile.builds).toBeDefined()
       expect(clonedProfile.builds.space).toBeDefined()
       expect(clonedProfile.builds.ground).toBeDefined()
-      
+
       // Verify modifications to clone don't affect original
       app.switchProfile(clonedId)
       app.selectKey('F1')
       app.deleteKey('F1')
       app.addCommand('F1', { command: 'say "modified"', type: 'chat' })
-      
+
       app.switchProfile(sourceId)
       const originalProfile = app.getCurrentProfile()
       // Original profile should still exist (clone test passed basic structure checks)
@@ -128,18 +137,18 @@ describe('App Workflow Integration', () => {
       const profile1Id = app.createProfile('Profile 1')
       const profile2Id = app.createProfile('Profile 2')
       const profile3Id = app.createProfile('Profile 3')
-      
+
       const initialData = stoStorage.getAllData()
       const initialCount = Object.keys(initialData.profiles).length
-      
+
       // Delete one profile
       app.deleteProfile(profile2Id)
-      
+
       const updatedData = stoStorage.getAllData()
       const remainingProfiles = Object.values(updatedData.profiles)
       expect(remainingProfiles).toHaveLength(initialCount - 1)
-      expect(remainingProfiles.some(p => p.id === profile2Id)).toBe(false)
-      
+      expect(remainingProfiles.some((p) => p.id === profile2Id)).toBe(false)
+
       // Verify UI switches to remaining profile (should have a current profile)
       const currentProfile = app.getCurrentProfile()
       expect(currentProfile).toBeDefined()
@@ -151,19 +160,21 @@ describe('App Workflow Integration', () => {
       const profileAId = app.createProfile('Profile A')
       const profileBId = app.createProfile('Profile B')
       app.switchProfile(profileAId)
-      
+
       // Make changes to current profile
       const profile = app.getCurrentProfile()
-      profile.builds.space.keys['F1'] = [{ command: 'say "unsaved change"', type: 'chat' }]
-      
+      profile.builds.space.keys['F1'] = [
+        { command: 'say "unsaved change"', type: 'chat' },
+      ]
+
       // Mark as modified
       app.setModified(true)
-      
+
       // Attempt to switch profiles - should trigger confirmation
       window.confirm = vi.fn(() => false) // User cancels
-      
+
       app.switchProfile(profileBId)
-      
+
       // Profile switch should have happened since no unsaved changes detection
       const currentProfile = app.getCurrentProfile()
       expect(currentProfile).toBeDefined()
@@ -176,25 +187,27 @@ describe('App Workflow Integration', () => {
     it('should add key binding and update storage', async () => {
       const profileId = app.createProfile('Keybind Test Profile')
       app.switchProfile(profileId)
-      
+
       // Select a key and add commands
       app.selectKey('F1')
-      
+
       const commands = [
         { command: 'say "Hello World"', type: 'chat' },
-        { command: 'emote dance', type: 'emote' }
+        { command: 'emote dance', type: 'emote' },
       ]
       app.addCommand('F1', commands[0])
       app.addCommand('F1', commands[1])
-      
+
       // Verify commands are stored in profile
       const profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F1']).toHaveLength(2)
-      expect(profile.builds.space.keys['F1'][0].command).toBe('say "Hello World"')
+      expect(profile.builds.space.keys['F1'][0].command).toBe(
+        'say "Hello World"'
+      )
       expect(profile.builds.space.keys['F1'][1].command).toBe('emote dance')
-      
+
       // The profile already has the key binding verified above
-      
+
       // Verify command preview updates
       const commandPreview = document.getElementById('commandPreview')
       expect(commandPreview.textContent).toContain('F1')
@@ -203,21 +216,25 @@ describe('App Workflow Integration', () => {
     it('should edit existing keybind commands', async () => {
       const profileId = app.createProfile('Edit Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create initial keybind
       app.selectKey('F2')
       app.addCommand('F2', { command: 'say "initial"', type: 'chat' })
-      
+
       // Edit the keybind by adding another command
       app.selectKey('F2')
       app.addCommand('F2', { command: 'emote wave', type: 'emote' })
-      
+
       // Verify changes are saved
       const updatedProfile = app.getCurrentProfile()
       expect(updatedProfile.builds.space.keys['F2']).toHaveLength(2)
-      expect(updatedProfile.builds.space.keys['F2'][0].command).toBe('say "initial"')
-      expect(updatedProfile.builds.space.keys['F2'][1].command).toBe('emote wave')
-      
+      expect(updatedProfile.builds.space.keys['F2'][0].command).toBe(
+        'say "initial"'
+      )
+      expect(updatedProfile.builds.space.keys['F2'][1].command).toBe(
+        'emote wave'
+      )
+
       // Verify UI reflects changes in the profile data (DOM may not be updated)
       // The profile data is the source of truth for integration tests
       expect(updatedProfile.builds.space.keys['F2'][0].type).toBe('chat')
@@ -227,22 +244,22 @@ describe('App Workflow Integration', () => {
     it('should delete keybind and update UI', async () => {
       const profileId = app.createProfile('Delete Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create keybind
       app.selectKey('F3')
       app.addCommand('F3', { command: 'say "to be deleted"', type: 'chat' })
-      
+
       // Verify keybind exists
       const profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F3']).toBeDefined()
-      
+
       // Delete the keybind
       app.deleteKey('F3')
-      
+
       // Verify keybind removed from storage
       const updatedProfile = app.getCurrentProfile()
       expect(updatedProfile.builds.space.keys['F3']).toBeUndefined()
-      
+
       // Verify key shows as unbound in UI
       const keyElement = document.querySelector('[data-key="F3"]')
       expect(keyElement?.classList.contains('bound')).toBe(false)
@@ -251,26 +268,28 @@ describe('App Workflow Integration', () => {
     it('should handle command chain reordering', async () => {
       const profileId = app.createProfile('Reorder Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create keybind with multiple commands
       app.selectKey('F4')
       app.addCommand('F4', { command: 'say "first"', type: 'chat' })
       app.addCommand('F4', { command: 'say "second"', type: 'chat' })
       app.addCommand('F4', { command: 'say "third"', type: 'chat' })
-      
+
       // Simulate reordering (move first command to last)
       app.moveCommand('F4', 0, 2)
-      
+
       // Verify new order is saved
       const profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F4'][0].command).toBe('say "second"')
       expect(profile.builds.space.keys['F4'][1].command).toBe('say "third"')
       expect(profile.builds.space.keys['F4'][2].command).toBe('say "first"')
-      
+
       // Verify command preview updates
       const commandPreview = document.getElementById('commandPreview')
       const previewText = commandPreview.textContent
-      expect(previewText.indexOf('second')).toBeLessThan(previewText.indexOf('first'))
+      expect(previewText.indexOf('second')).toBeLessThan(
+        previewText.indexOf('first')
+      )
     })
   })
 
@@ -278,26 +297,31 @@ describe('App Workflow Integration', () => {
     it('should add command from library to selected key', async () => {
       const profileId = app.createProfile('Library Test Profile')
       app.switchProfile(profileId)
-      
+
       // Select a key
       app.selectKey('F5')
-      
+
       // Find a command from the library
-      const spaceCommands = Object.values(window.COMMANDS).filter(cmd => 
-        !cmd.environment || cmd.environment === 'space'
+      const spaceCommands = Object.values(window.COMMANDS).filter(
+        (cmd) => !cmd.environment || cmd.environment === 'space'
       )
       expect(spaceCommands.length).toBeGreaterThan(0)
-      
+
       const testCommand = spaceCommands[0]
-      
+
       // Add command from library
-      app.addCommand('F5', { command: testCommand.command, type: testCommand.category })
-      
+      app.addCommand('F5', {
+        command: testCommand.command,
+        type: testCommand.category,
+      })
+
       // Verify command added to key
       const profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F5']).toHaveLength(1)
-      expect(profile.builds.space.keys['F5'][0].command).toBe(testCommand.command)
-      
+      expect(profile.builds.space.keys['F5'][0].command).toBe(
+        testCommand.command
+      )
+
       // Verify command preview updates
       const commandPreview = document.getElementById('commandPreview')
       expect(commandPreview.textContent).toContain(testCommand.command)
@@ -306,25 +330,30 @@ describe('App Workflow Integration', () => {
     it('should filter command library by search', async () => {
       const searchTerm = 'fire'
       const commandSearch = document.getElementById('commandSearch')
-      
+
       // Enter search term
       commandSearch.value = searchTerm
       commandSearch.dispatchEvent(new Event('input'))
-      
+
       // Get filtered commands
       const allCommands = Object.values(window.COMMANDS)
-      const filteredCommands = allCommands.filter(cmd =>
-        cmd.command.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        cmd.description.toLowerCase().includes(searchTerm.toLowerCase())
+      const filteredCommands = allCommands.filter(
+        (cmd) =>
+          cmd.command.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          cmd.description.toLowerCase().includes(searchTerm.toLowerCase())
       )
-      
+
       expect(filteredCommands.length).toBeGreaterThan(0)
       expect(filteredCommands.length).toBeLessThan(allCommands.length)
-      
+
       // Verify filtered results contain search term
-      filteredCommands.forEach(cmd => {
-        const matchesCommand = cmd.command.toLowerCase().includes(searchTerm.toLowerCase())
-        const matchesDescription = cmd.description.toLowerCase().includes(searchTerm.toLowerCase())
+      filteredCommands.forEach((cmd) => {
+        const matchesCommand = cmd.command
+          .toLowerCase()
+          .includes(searchTerm.toLowerCase())
+        const matchesDescription = cmd.description
+          .toLowerCase()
+          .includes(searchTerm.toLowerCase())
         expect(matchesCommand || matchesDescription).toBe(true)
       })
     })
@@ -332,23 +361,28 @@ describe('App Workflow Integration', () => {
     it('should build parameterized commands from library', async () => {
       const profileId = app.createProfile('Parameter Test Profile')
       app.switchProfile(profileId)
-      
+
       // Find a parameterized command
-      const paramCommands = Object.values(window.COMMANDS).filter(cmd => 
-        cmd.customizable && cmd.parameters
+      const paramCommands = Object.values(window.COMMANDS).filter(
+        (cmd) => cmd.customizable && cmd.parameters
       )
       expect(paramCommands.length).toBeGreaterThan(0)
-      
+
       const testCommand = paramCommands[0]
-      
+
       // Build command with parameters
       const paramValues = {}
-      Object.keys(testCommand.parameters).forEach(paramName => {
+      Object.keys(testCommand.parameters).forEach((paramName) => {
         paramValues[paramName] = 'test_value'
       })
-      
-      const builtCommand = app.buildParameterizedCommand(testCommand.category, testCommand.key, testCommand, paramValues)
-      
+
+      const builtCommand = app.buildParameterizedCommand(
+        testCommand.category,
+        testCommand.key,
+        testCommand,
+        paramValues
+      )
+
       // Verify command has correct parameter values
       expect(builtCommand).toBeTruthy()
       expect(typeof builtCommand).toBe('object')
@@ -361,92 +395,97 @@ describe('App Workflow Integration', () => {
     it('should switch between space and ground environments', async () => {
       const profileId = app.createProfile('Environment Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create keybinds in space environment
       expect(app.currentEnvironment).toBe('space')
       app.selectKey('F6')
       app.addCommand('F6', { command: 'say "space command"', type: 'chat' })
-      
+
       // Switch to ground environment
       app.switchMode('ground')
       expect(app.currentEnvironment).toBe('ground')
-      
+
       // Verify different keybind set loaded (F6 should be empty)
       const profile = app.getCurrentProfile()
       expect(profile.builds.ground.keys['F6']).toBeUndefined()
-      
+
       // Create ground-specific keybinds
       app.selectKey('F6')
       app.addCommand('F6', { command: 'say "ground command"', type: 'chat' })
-      
+
       // Switch back to space environment
       app.switchMode('space')
       expect(app.currentEnvironment).toBe('space')
-      
+
       // Verify space keybinds are restored
       const updatedProfile = app.getCurrentProfile()
-      expect(updatedProfile.builds.space.keys['F6'][0].command).toBe('say "space command"')
+      expect(updatedProfile.builds.space.keys['F6'][0].command).toBe(
+        'say "space command"'
+      )
     })
 
     it('should maintain separate builds for each environment', async () => {
       const profileId = app.createProfile('Build Isolation Test')
       app.switchProfile(profileId)
-      
+
       // Add commands in space environment
       app.switchMode('space')
       app.selectKey('F7')
       app.addCommand('F7', { command: 'say "space F7"', type: 'chat' })
-      
+
       // Switch to ground environment
       app.switchMode('ground')
       app.selectKey('F7')
       app.addCommand('F7', { command: 'say "ground F7"', type: 'chat' })
-      
+
       // Verify commands don't interfere
       const profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F7'][0].command).toBe('say "space F7"')
-      expect(profile.builds.ground.keys['F7'][0].command).toBe('say "ground F7"')
-      
+      expect(profile.builds.ground.keys['F7'][0].command).toBe(
+        'say "ground F7"'
+      )
+
       // Verify each environment maintains its own state
       app.switchMode('space')
       app.selectKey('F7')
       const spacePreview = document.getElementById('commandPreview').textContent
       expect(spacePreview).toContain('space F7')
-      
+
       app.switchMode('ground')
       app.selectKey('F7')
-      const groundPreview = document.getElementById('commandPreview').textContent
+      const groundPreview =
+        document.getElementById('commandPreview').textContent
       expect(groundPreview).toContain('ground F7')
     })
 
     it('should filter commands by environment in library', async () => {
       // Switch to space environment
       app.switchMode('space')
-      
-      const spaceCommands = Object.values(window.COMMANDS).filter(cmd =>
-        !cmd.environment || cmd.environment === 'space'
+
+      const spaceCommands = Object.values(window.COMMANDS).filter(
+        (cmd) => !cmd.environment || cmd.environment === 'space'
       )
-      const groundOnlyCommands = Object.values(window.COMMANDS).filter(cmd =>
-        cmd.environment === 'ground'
+      const groundOnlyCommands = Object.values(window.COMMANDS).filter(
+        (cmd) => cmd.environment === 'ground'
       )
-      
+
       expect(spaceCommands.length).toBeGreaterThan(0)
-      
+
       // Switch to ground environment
       app.switchMode('ground')
-      
-      const availableCommands = Object.values(window.COMMANDS).filter(cmd =>
-        !cmd.environment || cmd.environment === 'ground'
+
+      const availableCommands = Object.values(window.COMMANDS).filter(
+        (cmd) => !cmd.environment || cmd.environment === 'ground'
       )
-      
+
       // Verify ground commands available
       expect(availableCommands.length).toBeGreaterThan(0)
-      
+
       // Verify space-only commands are filtered out when appropriate
-      const spaceOnlyCommands = Object.values(window.COMMANDS).filter(cmd =>
-        cmd.environment === 'space'
+      const spaceOnlyCommands = Object.values(window.COMMANDS).filter(
+        (cmd) => cmd.environment === 'space'
       )
-      
+
       // This test verifies the filtering logic exists
       expect(spaceOnlyCommands.length).toBeGreaterThan(0)
     })
@@ -454,18 +493,18 @@ describe('App Workflow Integration', () => {
     it('should update profile currentEnvironment when switching', async () => {
       const profileId = app.createProfile('Environment Tracking Test')
       app.switchProfile(profileId)
-      
+
       // Switch environments
       app.switchMode('ground')
-      
+
       // Verify profile.currentEnvironment is updated
       const profile = app.getCurrentProfile()
       expect(profile.currentEnvironment).toBe('ground')
-      
+
       app.switchMode('space')
       const updatedProfile = app.getCurrentProfile()
       expect(updatedProfile.currentEnvironment).toBe('space')
-      
+
       // Verify environment persists on profile reload
       app.saveCurrentProfile()
       app.switchProfile(profileId)
@@ -478,16 +517,18 @@ describe('App Workflow Integration', () => {
     it('should auto-save changes to localStorage', async () => {
       const profileId = app.createProfile('Auto-save Test Profile')
       app.switchProfile(profileId)
-      
+
       // Make changes to profile
       app.selectKey('F8')
       app.addCommand('F8', { command: 'say "auto-saved"', type: 'chat' })
-      
+
       // Verify changes are stored in profile
       const profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F8']).toBeDefined()
-      expect(profile.builds.space.keys['F8'][0].command).toBe('say "auto-saved"')
-      
+      expect(profile.builds.space.keys['F8'][0].command).toBe(
+        'say "auto-saved"'
+      )
+
       // Verify we have a valid profile (the test profile creation worked)
       expect(profile).toBeDefined()
       expect(profile.name).toBeDefined()
@@ -496,39 +537,44 @@ describe('App Workflow Integration', () => {
     it('should handle localStorage failures gracefully', async () => {
       const profileId = app.createProfile('Error Handling Test')
       app.switchProfile(profileId)
-      
+
       // Make changes to profile (this should work even if localStorage fails)
       app.selectKey('F9')
       app.addCommand('F9', { command: 'say "error test"', type: 'chat' })
-      
+
       // Verify app continues to function normally
       const profile = app.getCurrentProfile()
       expect(profile).toBeDefined()
       expect(profile.builds.space.keys['F9']).toBeDefined()
-      expect(profile.builds.space.keys['F9'][0].command).toBe('say "error test"')
+      expect(profile.builds.space.keys['F9'][0].command).toBe(
+        'say "error test"'
+      )
     })
 
     it('should migrate old data format on load', async () => {
       // Set up old format data in localStorage
       const oldFormatData = {
         profiles: {
-          'old_profile': {
+          old_profile: {
             id: 'old_profile',
             name: 'Old Profile',
             keys: {
-              'F10': [{ command: 'say "old format"', type: 'chat' }]
-            }
-          }
+              F10: [{ command: 'say "old format"', type: 'chat' }],
+            },
+          },
         },
-        currentProfile: 'old_profile'
+        currentProfile: 'old_profile',
       }
-      
+
       localStorage.setItem('stoKeybindManager', JSON.stringify(oldFormatData))
-      
+
       // Create a new profile to test the migration concept
-      const newProfileId = app.createProfile('Migration Test', 'Testing migration')
+      const newProfileId = app.createProfile(
+        'Migration Test',
+        'Testing migration'
+      )
       app.switchProfile(newProfileId)
-      
+
       // Verify new profile has correct structure
       const profile = app.getCurrentProfile()
       expect(profile.builds).toBeDefined()
@@ -541,18 +587,20 @@ describe('App Workflow Integration', () => {
     it('should backup data before major operations', async () => {
       const profileId = app.createProfile('Backup Test Profile')
       app.switchProfile(profileId)
-      
+
       // Add some data
       app.selectKey('F11')
       app.addCommand('F11', { command: 'say "backup me"', type: 'chat' })
       app.saveCurrentProfile()
-      
+
       // Verify profile data is accessible and contains our changes
       const profile = app.getCurrentProfile()
       expect(profile).toBeDefined()
       expect(profile.builds.space.keys['F11']).toBeDefined()
-      expect(profile.builds.space.keys['F11'][0].command).toBe('say "backup me"')
-      
+      expect(profile.builds.space.keys['F11'][0].command).toBe(
+        'say "backup me"'
+      )
+
       // Verify profile can be accessed from storage
       const data = stoStorage.getAllData()
       expect(data.profiles[profileId]).toBeDefined()
@@ -563,22 +611,24 @@ describe('App Workflow Integration', () => {
     it('should export profile as STO keybind file', async () => {
       const profileId = app.createProfile('Export Test Profile')
       app.switchProfile(profileId)
-      
+
       // Create profile with keybinds and aliases
       app.selectKey('F1')
       app.addCommand('F1', { command: 'say "export test"', type: 'chat' })
       app.selectKey('F2')
       app.addCommand('F2', { command: 'emote dance', type: 'emote' })
       app.addCommand('F2', { command: 'say "multi-command"', type: 'chat' })
-      
+
       // Add an alias
       const profile = app.getCurrentProfile()
-      profile.aliases['TestExportAlias'] = [{ command: 'say "alias command"', type: 'chat' }]
+      profile.aliases['TestExportAlias'] = [
+        { command: 'say "alias command"', type: 'chat' },
+      ]
       app.saveCurrentProfile()
-      
+
       // Export profile
       app.exportKeybinds()
-      
+
       // Since export triggers download, we can verify the profile has exportable data
       expect(profile.builds.space.keys['F1']).toBeDefined()
       expect(profile.builds.space.keys['F2']).toHaveLength(2)
@@ -588,16 +638,16 @@ describe('App Workflow Integration', () => {
     it('should handle validation and error scenarios', async () => {
       const profileId = app.createProfile('Validation Test Profile')
       app.switchProfile(profileId)
-      
+
       // Test invalid key name
       expect(() => {
         app.selectKey('Invalid Key Name!')
       }).not.toThrow() // App should handle gracefully
-      
+
       // Test adding commands to selected key
       app.selectKey('F1')
       app.addCommand('F1', { command: 'say "valid command"', type: 'chat' })
-      
+
       // Verify command was added
       const profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F1']).toHaveLength(1)
@@ -608,28 +658,28 @@ describe('App Workflow Integration', () => {
     it('should synchronize key selection with command editor', async () => {
       const profileId = app.createProfile('UI Sync Test')
       app.switchProfile(profileId)
-      
+
       // Add commands to a key
       app.selectKey('F1')
       app.addCommand('F1', { command: 'say "sync test"', type: 'chat' })
       app.addCommand('F1', { command: 'emote wave', type: 'emote' })
-      
+
       // Select key from grid
       app.selectKey('F1')
-      
+
       // Verify command editor shows key's commands
       const commandList = document.getElementById('commandList')
       expect(commandList).toBeDefined()
-      
+
       // Check that commands are present in the profile
       const profile = app.getCurrentProfile()
       expect(profile.builds.space.keys['F1']).toHaveLength(2)
       expect(profile.builds.space.keys['F1'][0].command).toBe('say "sync test"')
       expect(profile.builds.space.keys['F1'][1].command).toBe('emote wave')
-      
+
       // Verify key grid reflects changes in profile data
       expect(profile.builds.space.keys['F1']).toBeDefined()
-      
+
       // Verify command count updates
       const commandCount = document.getElementById('commandCount')
       expect(commandCount.textContent).toContain('2 command')
@@ -638,22 +688,24 @@ describe('App Workflow Integration', () => {
     it('should update profile selector when profiles change', async () => {
       const profileSelect = document.getElementById('profileSelect')
       const initialOptions = profileSelect.options.length
-      
+
       // Create new profile
       const profileId = app.createProfile('UI Profile Test')
-      
+
       // Verify profile appears in selector
       app.renderProfiles() // Trigger UI update
-      const options = Array.from(profileSelect.options).map(opt => opt.value)
+      const options = Array.from(profileSelect.options).map((opt) => opt.value)
       expect(options).toContain(profileId)
       expect(profileSelect.options.length).toBe(initialOptions + 1)
-      
+
       // Delete profile
       app.deleteProfile(profileId)
-      
+
       // Verify profile removed from selector
       app.renderProfiles() // Trigger UI update
-      const updatedOptions = Array.from(profileSelect.options).map(opt => opt.value)
+      const updatedOptions = Array.from(profileSelect.options).map(
+        (opt) => opt.value
+      )
       expect(updatedOptions).not.toContain(profileId)
       expect(profileSelect.options.length).toBe(initialOptions)
     })
@@ -661,26 +713,26 @@ describe('App Workflow Integration', () => {
     it('should maintain modified state indicator', async () => {
       const profileId = app.createProfile('Modified State Test')
       app.switchProfile(profileId)
-      
+
       const modifiedIndicator = document.getElementById('modifiedIndicator')
-      
+
       // Initially not modified
       expect(modifiedIndicator.style.display).toBe('none')
-      
+
       // Make changes to profile
       app.selectKey('F1')
       app.addCommand('F1', { command: 'say "modified"', type: 'chat' })
       app.setModified(true)
-      
+
       // Verify modified indicator shows
       expect(modifiedIndicator.style.display).not.toBe('none')
-      
+
       // Save changes
       app.saveCurrentProfile()
       app.setModified(false)
-      
+
       // Verify modified indicator clears
       expect(modifiedIndicator.style.display).toBe('none')
     })
   })
-}) 
+})

--- a/tests/integration/export-mirroring.test.js
+++ b/tests/integration/export-mirroring.test.js
@@ -13,51 +13,53 @@ describe('Export Mirroring Integration', () => {
     resetStore()
     // Clear localStorage
     localStorage.clear()
-    
+
     // Mock UI methods that show actual modals/alerts
     const originalAlert = window.alert
     const originalConfirm = window.confirm
     const originalPrompt = window.prompt
-    
+
     window.alert = vi.fn()
     window.confirm = vi.fn(() => true)
     window.prompt = vi.fn((message, defaultValue) => {
       if (message.includes('profile name')) return 'Export Test Profile'
       return defaultValue || 'test'
     })
-    
+
     // Store originals for cleanup
     window._originalAlert = originalAlert
     window._originalConfirm = originalConfirm
     window._originalPrompt = originalPrompt
-    
+
     // Mock file download functionality
     global.URL = {
       createObjectURL: vi.fn().mockReturnValue('blob:test-url'),
-      revokeObjectURL: vi.fn()
+      revokeObjectURL: vi.fn(),
     }
     global.Blob = vi.fn()
     const mockAnchor = {
       click: vi.fn(),
       href: '',
-      download: ''
+      download: '',
     }
     vi.spyOn(document, 'createElement').mockImplementation((tagName) => {
       if (tagName === 'a') return mockAnchor
-      return document.createElement.wrappedMethod ? document.createElement.wrappedMethod(tagName) : {}
+      return document.createElement.wrappedMethod
+        ? document.createElement.wrappedMethod(tagName)
+        : {}
     })
-    
+
     stoStorage = new STOStorage()
     stoKeybinds = new STOKeybindFileManager()
     stoExport = new STOExportManager()
     stoUI = { showToast: vi.fn() }
     Object.assign(global, { stoStorage, stoKeybinds, stoExport, stoUI })
-    
+
     // Create minimal app-like object for testing
     app = {
       currentProfile: 'test-profile',
       currentEnvironment: 'space',
-      
+
       createProfile(name) {
         const profileId = `profile_${Date.now()}`
         const profile = {
@@ -65,13 +67,13 @@ describe('Export Mirroring Integration', () => {
           name: name,
           builds: {
             space: { keys: {} },
-            ground: { keys: {} }
+            ground: { keys: {} },
           },
           aliases: {},
           keybindMetadata: {},
           created: new Date().toISOString(),
           lastModified: new Date().toISOString(),
-          currentEnvironment: 'space'
+          currentEnvironment: 'space',
         }
         stoStorage.saveProfile(profileId, profile)
         this.currentProfile = profileId
@@ -89,20 +91,20 @@ describe('Export Mirroring Integration', () => {
         }
         store.currentEnvironment = this.currentEnvironment
       },
-      
+
       getCurrentProfile() {
         const profile = stoStorage.getProfile(this.currentProfile)
         if (!profile) return null
-        
+
         // Return a profile-like object with current build data
         return {
           ...profile,
           keys: profile.builds[this.currentEnvironment].keys,
           aliases: profile.aliases || {},
-          mode: this.currentEnvironment === 'space' ? 'Space' : 'Ground'
+          mode: this.currentEnvironment === 'space' ? 'Space' : 'Ground',
         }
       },
-      
+
       saveCurrentProfile() {
         // For testing, just save the profile as-is
         const profile = stoStorage.getProfile(this.currentProfile)
@@ -111,19 +113,22 @@ describe('Export Mirroring Integration', () => {
           stoStorage.saveProfile(this.currentProfile, profile)
         }
       },
-      
+
       exportKeybinds() {
         const profile = this.getCurrentProfile()
         if (!profile) return
-        
+
         // Check if stabilization is enabled
-        const stabilizeCheckbox = document.getElementById('stabilizeExecutionOrder')
-        const stabilizeExecutionOrder = stabilizeCheckbox && stabilizeCheckbox.checked
-        
+        const stabilizeCheckbox = document.getElementById(
+          'stabilizeExecutionOrder'
+        )
+        const stabilizeExecutionOrder =
+          stabilizeCheckbox && stabilizeCheckbox.checked
+
         // Use the export manager with stabilization options
         const options = { stabilizeExecutionOrder }
         const content = stoExport.generateSTOKeybindFile(profile, options)
-        
+
         // Download the file
         const blob = new Blob([content], { type: 'text/plain' })
         const url = URL.createObjectURL(blob)
@@ -136,17 +141,17 @@ describe('Export Mirroring Integration', () => {
         a.click()
         URL.revokeObjectURL(url)
       },
-      
+
       setModified(modified) {
         // Mock method for import functionality
         this.modified = modified
       },
-      
+
       renderKeyGrid() {
         // Mock method for import functionality
-      }
+      },
     }
-    
+
     // Set initial store state and global app reference
     store.currentProfile = app.currentProfile
     store.currentEnvironment = app.currentEnvironment
@@ -158,12 +163,12 @@ describe('Export Mirroring Integration', () => {
     if (window._originalAlert) window.alert = window._originalAlert
     if (window._originalConfirm) window.confirm = window._originalConfirm
     if (window._originalPrompt) window.prompt = window._originalPrompt
-    
+
     // Clean up mocks
     delete global.URL
     delete global.Blob
     vi.restoreAllMocks()
-    
+
     // Clean up storage
     localStorage.clear()
     resetStore()
@@ -176,46 +181,46 @@ describe('Export Mirroring Integration', () => {
       // Create a test profile with mirrored commands
       testProfileId = app.createProfile('Mirroring Export Test')
       app.switchProfile(testProfileId)
-      
+
       // Get the actual profile from storage to modify it
       const actualProfile = stoStorage.getProfile(testProfileId)
-      
+
       // Add mirrored tray sequence
       actualProfile.builds.space.keys['F1'] = [
         { command: '+TrayExecByTray 9 0', type: 'tray' },
         { command: '+TrayExecByTray 9 1', type: 'tray' },
-        { command: '+TrayExecByTray 9 2', type: 'tray' }
+        { command: '+TrayExecByTray 9 2', type: 'tray' },
       ]
-      
+
       // Add single command (should not be mirrored)
       actualProfile.builds.space.keys['F2'] = [
-        { command: 'FirePhasers', type: 'ability' }
+        { command: 'FirePhasers', type: 'ability' },
       ]
-      
+
       // Add mixed command sequence
       actualProfile.builds.space.keys['F3'] = [
         { command: 'FirePhasers', type: 'ability' },
         { command: 'target_nearest_enemy', type: 'targeting' },
-        { command: '+power_exec Distribute_Shields', type: 'power' }
+        { command: '+power_exec Distribute_Shields', type: 'power' },
       ]
-      
+
       // Add complex tray sequence (like the documentation example)
       actualProfile.builds.space.keys['numpad0'] = []
       for (let i = 0; i <= 4; i++) {
         actualProfile.builds.space.keys['numpad0'].push({
           command: `+TrayExecByTray 9 ${i}`,
-          type: 'tray'
+          type: 'tray',
         })
       }
-      
+
       // Set up keybind metadata for stabilization
       actualProfile.keybindMetadata = {
-        'F1': { stabilizeExecutionOrder: true },
-        'F3': { stabilizeExecutionOrder: true },
-        'numpad0': { stabilizeExecutionOrder: true }
+        F1: { stabilizeExecutionOrder: true },
+        F3: { stabilizeExecutionOrder: true },
+        numpad0: { stabilizeExecutionOrder: true },
         // F2 intentionally left without stabilization metadata
       }
-      
+
       // Save the modified profile back to storage
       stoStorage.saveProfile(testProfileId, actualProfile)
     })
@@ -223,23 +228,33 @@ describe('Export Mirroring Integration', () => {
     it('should export with global stabilization disabled but respect per-key metadata', () => {
       // Get the current profile
       const profile = app.getCurrentProfile()
-      
+
       // Generate export content without global stabilization
-      const exportContent = stoExport.generateSTOKeybindFile(profile, { stabilizeExecutionOrder: false })
-      
+      const exportContent = stoExport.generateSTOKeybindFile(profile, {
+        stabilizeExecutionOrder: false,
+      })
+
       // Verify export content
       expect(exportContent).toBeDefined()
       expect(typeof exportContent).toBe('string')
-      
+
       // Should not contain global stabilization header (since global option is false)
       expect(exportContent).not.toContain('EXECUTION ORDER STABILIZATION: ON')
-      expect(exportContent).not.toContain('Commands are mirrored to ensure consistent execution order')
-      
+      expect(exportContent).not.toContain(
+        'Commands are mirrored to ensure consistent execution order'
+      )
+
       // But keys with per-key metadata should still be mirrored
-      expect(exportContent).toContain('F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"')
-      expect(exportContent).toContain('F3 "FirePhasers $$ target_nearest_enemy $$ +power_exec Distribute_Shields $$ target_nearest_enemy $$ FirePhasers"')
-      expect(exportContent).toContain('numpad0 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 3 $$ +TrayExecByTray 9 4 $$ +TrayExecByTray 9 3 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"')
-      
+      expect(exportContent).toContain(
+        'F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"'
+      )
+      expect(exportContent).toContain(
+        'F3 "FirePhasers $$ target_nearest_enemy $$ +power_exec Distribute_Shields $$ target_nearest_enemy $$ FirePhasers"'
+      )
+      expect(exportContent).toContain(
+        'numpad0 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 3 $$ +TrayExecByTray 9 4 $$ +TrayExecByTray 9 3 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"'
+      )
+
       // Keys without per-key metadata should not be mirrored
       expect(exportContent).toContain('F2 "FirePhasers"')
       expect(exportContent).not.toContain('F2 "FirePhasers $$ FirePhasers"')
@@ -248,39 +263,49 @@ describe('Export Mirroring Integration', () => {
     it('should export with stabilization enabled when option is set', () => {
       // Get the current profile
       const profile = app.getCurrentProfile()
-      
+
       // Generate export content with stabilization
-      const exportContent = stoExport.generateSTOKeybindFile(profile, { stabilizeExecutionOrder: true })
-      
+      const exportContent = stoExport.generateSTOKeybindFile(profile, {
+        stabilizeExecutionOrder: true,
+      })
+
       // Verify export content
       expect(exportContent).toBeDefined()
       expect(typeof exportContent).toBe('string')
-      
+
       // Should contain stabilization header
       expect(exportContent).toContain('EXECUTION ORDER STABILIZATION: ON')
-      expect(exportContent).toContain('Commands are mirrored to ensure consistent execution order')
-      expect(exportContent).toContain('Phase 1: left-to-right, Phase 2: right-to-left')
-      
+      expect(exportContent).toContain(
+        'Commands are mirrored to ensure consistent execution order'
+      )
+      expect(exportContent).toContain(
+        'Phase 1: left-to-right, Phase 2: right-to-left'
+      )
+
       // Should contain mirrored multi-command sequences
-      expect(exportContent).toContain('F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"')
-      expect(exportContent).toContain('F3 "FirePhasers $$ target_nearest_enemy $$ +power_exec Distribute_Shields $$ target_nearest_enemy $$ FirePhasers"')
-      
+      expect(exportContent).toContain(
+        'F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"'
+      )
+      expect(exportContent).toContain(
+        'F3 "FirePhasers $$ target_nearest_enemy $$ +power_exec Distribute_Shields $$ target_nearest_enemy $$ FirePhasers"'
+      )
+
       // Single commands should not be mirrored
       expect(exportContent).toContain('F2 "FirePhasers"')
       expect(exportContent).not.toContain('F2 "FirePhasers $$ FirePhasers"')
-      
+
       // Complex sequence should be properly mirrored
-      expect(exportContent).toContain('numpad0 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 3 $$ +TrayExecByTray 9 4 $$ +TrayExecByTray 9 3 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"')
+      expect(exportContent).toContain(
+        'numpad0 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 3 $$ +TrayExecByTray 9 4 $$ +TrayExecByTray 9 3 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"'
+      )
     })
-
-
 
     it('should use app.exportKeybinds method with real file download', () => {
       // Mock the profile to have the test data
       const profile = app.getCurrentProfile()
       expect(profile).toBeDefined()
       expect(profile.builds.space.keys.F1).toBeDefined()
-      
+
       // Mock document.getElementById to return a checked checkbox
       const originalGetElementById = document.getElementById
       document.getElementById = vi.fn((id) => {
@@ -289,26 +314,28 @@ describe('Export Mirroring Integration', () => {
         }
         return originalGetElementById.call(document, id)
       })
-      
+
       // Call the real app export method
       app.exportKeybinds()
-      
+
       // Verify that Blob was created with content
       expect(global.Blob).toHaveBeenCalled()
       const blobCall = global.Blob.mock.calls[0]
       expect(blobCall).toBeDefined()
       expect(blobCall[0]).toBeDefined() // Content array
       expect(blobCall[1]).toEqual({ type: 'text/plain' }) // Options
-      
+
       // Verify the content contains mirrored sequences
       const exportedContent = blobCall[0][0]
       expect(exportedContent).toContain('EXECUTION ORDER STABILIZATION: ON')
-      expect(exportedContent).toContain('F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"')
-      
+      expect(exportedContent).toContain(
+        'F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"'
+      )
+
       // Verify file download was triggered
       expect(global.URL.createObjectURL).toHaveBeenCalled()
       expect(document.createElement).toHaveBeenCalledWith('a')
-      
+
       // Restore original function
       document.getElementById = originalGetElementById
     })
@@ -316,12 +343,14 @@ describe('Export Mirroring Integration', () => {
     it('should handle round-trip import/export of mirrored commands', () => {
       // Export with stabilization
       const profile = app.getCurrentProfile()
-      const exportContent = stoExport.generateSTOKeybindFile(profile, { stabilizeExecutionOrder: true })
-      
+      const exportContent = stoExport.generateSTOKeybindFile(profile, {
+        stabilizeExecutionOrder: true,
+      })
+
       // Create a new profile for import test
       const importProfileId = app.createProfile('Import Test Profile')
       app.switchProfile(importProfileId)
-      
+
       // Mock document.getElementById to return mock UI elements
       const originalGetElementById = document.getElementById
       document.getElementById = vi.fn((id) => {
@@ -333,32 +362,42 @@ describe('Export Mirroring Integration', () => {
         }
         return originalGetElementById.call(document, id)
       })
-      
+
       // Import the exported content
       const importResult = stoKeybinds.importKeybindFile(exportContent)
-      
+
       expect(importResult.success).toBe(true)
       expect(importResult.imported.keys).toBeGreaterThan(0)
-      
+
       // Verify that mirrored commands were detected and un-mirrored during import
       const importedProfile = app.getCurrentProfile()
-      
+
       // Restore original function
       document.getElementById = originalGetElementById
-      
+
       // F1 should have been detected as mirrored and stored as original commands
       expect(importedProfile.builds.space.keys.F1).toHaveLength(3)
-      expect(importedProfile.builds.space.keys.F1[0].command).toBe('+TrayExecByTray 9 0')
-      expect(importedProfile.builds.space.keys.F1[1].command).toBe('+TrayExecByTray 9 1')
-      expect(importedProfile.builds.space.keys.F1[2].command).toBe('+TrayExecByTray 9 2')
-      
+      expect(importedProfile.builds.space.keys.F1[0].command).toBe(
+        '+TrayExecByTray 9 0'
+      )
+      expect(importedProfile.builds.space.keys.F1[1].command).toBe(
+        '+TrayExecByTray 9 1'
+      )
+      expect(importedProfile.builds.space.keys.F1[2].command).toBe(
+        '+TrayExecByTray 9 2'
+      )
+
       // Stabilization metadata should be set
       const actualProfile = stoStorage.getProfile(importProfileId)
-      expect(actualProfile.keybindMetadata.space.F1.stabilizeExecutionOrder).toBe(true)
-      
+      expect(
+        actualProfile.keybindMetadata.space.F1.stabilizeExecutionOrder
+      ).toBe(true)
+
       // Single commands should remain unchanged
       expect(importedProfile.builds.space.keys.F2).toHaveLength(1)
-      expect(importedProfile.builds.space.keys.F2[0].command).toBe('FirePhasers')
+      expect(importedProfile.builds.space.keys.F2[0].command).toBe(
+        'FirePhasers'
+      )
     })
   })
-}) 
+})

--- a/tests/integration/vertigo-integration.test.js
+++ b/tests/integration/vertigo-integration.test.js
@@ -1,325 +1,370 @@
 // Integration tests for Vertigo VFX Manager functionality
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 describe('Vertigo VFX Manager Integration', () => {
-    let mockApp, mockProfile, mockUI, mockVertigoManager;
+  let mockApp, mockProfile, mockUI, mockVertigoManager
 
-    beforeEach(() => {
-        // Mock profile with test data
-        mockProfile = {
-            name: 'Test Profile',
-            aliases: {
-                'ExistingAlias': {
-                    name: 'ExistingAlias',
-                    description: 'Test existing alias',
-                    commands: 'target_nearest_enemy $$ FireAll'
-                }
-            },
-            keys: {},
-                builds: {
-      space: { keys: {} },
-      ground: { keys: {} }
+  beforeEach(() => {
+    // Mock profile with test data
+    mockProfile = {
+      name: 'Test Profile',
+      aliases: {
+        ExistingAlias: {
+          name: 'ExistingAlias',
+          description: 'Test existing alias',
+          commands: 'target_nearest_enemy $$ FireAll',
+        },
+      },
+      keys: {},
+      builds: {
+        space: { keys: {} },
+        ground: { keys: {} },
+      },
     }
-        };
 
-        // Mock app object
-        mockApp = {
-            getCurrentProfile: vi.fn(() => mockProfile),
-            saveProfile: vi.fn(),
-            setModified: vi.fn(),
-            showVertigoModal: vi.fn(),
-            generateVertigoAliases: vi.fn()
-        };
+    // Mock app object
+    mockApp = {
+      getCurrentProfile: vi.fn(() => mockProfile),
+      saveProfile: vi.fn(),
+      setModified: vi.fn(),
+      showVertigoModal: vi.fn(),
+      generateVertigoAliases: vi.fn(),
+    }
 
-        // Mock UI object
-        mockUI = {
-            showModal: vi.fn(),
-            hideModal: vi.fn(),
-            showToast: vi.fn()
-        };
+    // Mock UI object
+    mockUI = {
+      showModal: vi.fn(),
+      hideModal: vi.fn(),
+      showToast: vi.fn(),
+    }
 
-        // Mock Vertigo Manager
-        mockVertigoManager = {
-            selectedEffects: {
-                space: new Set(['Fx_Explosion_Large', 'Fx_Weapon_Beam']),
-                ground: new Set(['Fx_Ground_Impact'])
-            },
-            showPlayerSay: true,
-            
-            generateAlias(environment) {
-                const effects = Array.from(this.selectedEffects[environment]);
-                if (effects.length === 0) return '';
+    // Mock Vertigo Manager
+    mockVertigoManager = {
+      selectedEffects: {
+        space: new Set(['Fx_Explosion_Large', 'Fx_Weapon_Beam']),
+        ground: new Set(['Fx_Ground_Impact']),
+      },
+      showPlayerSay: true,
 
-                let aliasName = `dynFxSetFXExlusionList_${environment.charAt(0).toUpperCase() + environment.slice(1)}`;
-                let command = `alias ${aliasName} <& dynFxSetFXExlusionList ${effects.join(',')}`;
-                
-                if (this.showPlayerSay) {
-                    command += ' $$ PlayerSay Vertigo VFX Loaded';
-                }
-                
-                command += ' &>';
-                return command;
-            },
-            
-            clearAllEffects() {
-                this.selectedEffects.space.clear();
-                this.selectedEffects.ground.clear();
-            },
-            
-            selectAllEffects(environment) {
-                const testEffects = {
-                    space: ['Fx_Effect1', 'Fx_Effect2', 'Fx_Effect3'],
-                    ground: ['Fx_Ground1', 'Fx_Ground2']
-                };
-                testEffects[environment].forEach(effect => {
-                    this.selectedEffects[environment].add(effect);
-                });
-            }
-        };
+      generateAlias(environment) {
+        const effects = Array.from(this.selectedEffects[environment])
+        if (effects.length === 0) return ''
 
-        // Set up globals
-        global.app = mockApp;
-        global.stoUI = mockUI;
-        global.vertigoManager = mockVertigoManager;
-        
-        // Clear all mocks
-        vi.clearAllMocks();
-    });
+        let aliasName = `dynFxSetFXExlusionList_${environment.charAt(0).toUpperCase() + environment.slice(1)}`
+        let command = `alias ${aliasName} <& dynFxSetFXExlusionList ${effects.join(',')}`
 
-    afterEach(() => {
-        delete global.app;
-        delete global.stoUI;
-        delete global.vertigoManager;
-    });
+        if (this.showPlayerSay) {
+          command += ' $$ PlayerSay Vertigo VFX Loaded'
+        }
 
-    describe('Full Vertigo Workflow', () => {
-        it('should complete full workflow from effect selection to alias creation', () => {
-            // Step 1: Generate aliases with current selection
-            const spaceAlias = mockVertigoManager.generateAlias('space');
-            const groundAlias = mockVertigoManager.generateAlias('ground');
-            
-            // Verify aliases are generated correctly
-            expect(spaceAlias).toBe('alias dynFxSetFXExlusionList_Space <& dynFxSetFXExlusionList Fx_Explosion_Large,Fx_Weapon_Beam $$ PlayerSay Vertigo VFX Loaded &>');
-            expect(groundAlias).toBe('alias dynFxSetFXExlusionList_Ground <& dynFxSetFXExlusionList Fx_Ground_Impact $$ PlayerSay Vertigo VFX Loaded &>');
+        command += ' &>'
+        return command
+      },
 
-            // Step 2: Extract commands for profile storage
-            const spaceCommands = spaceAlias.replace('alias dynFxSetFXExlusionList_Space <& ', '').replace(' &>', '');
-            const groundCommands = groundAlias.replace('alias dynFxSetFXExlusionList_Ground <& ', '').replace(' &>', '');
+      clearAllEffects() {
+        this.selectedEffects.space.clear()
+        this.selectedEffects.ground.clear()
+      },
 
-            // Step 3: Add to profile
-            mockProfile.aliases['dynFxSetFXExlusionList_Space'] = {
-                name: 'dynFxSetFXExlusionList_Space',
-                description: 'Vertigo - Disable Space Visual Effects',
-                commands: spaceCommands
-            };
-            
-            mockProfile.aliases['dynFxSetFXExlusionList_Ground'] = {
-                name: 'dynFxSetFXExlusionList_Ground',
-                description: 'Vertigo - Disable Ground Visual Effects',
-                commands: groundCommands
-            };
+      selectAllEffects(environment) {
+        const testEffects = {
+          space: ['Fx_Effect1', 'Fx_Effect2', 'Fx_Effect3'],
+          ground: ['Fx_Ground1', 'Fx_Ground2'],
+        }
+        testEffects[environment].forEach((effect) => {
+          this.selectedEffects[environment].add(effect)
+        })
+      },
+    }
 
-            // Verify profile was updated correctly
-            expect(mockProfile.aliases['dynFxSetFXExlusionList_Space']).toEqual({
-                name: 'dynFxSetFXExlusionList_Space',
-                description: 'Vertigo - Disable Space Visual Effects',
-                commands: 'dynFxSetFXExlusionList Fx_Explosion_Large,Fx_Weapon_Beam $$ PlayerSay Vertigo VFX Loaded'
-            });
-            
-            expect(mockProfile.aliases['dynFxSetFXExlusionList_Ground']).toEqual({
-                name: 'dynFxSetFXExlusionList_Ground',
-                description: 'Vertigo - Disable Ground Visual Effects',
-                commands: 'dynFxSetFXExlusionList Fx_Ground_Impact $$ PlayerSay Vertigo VFX Loaded'
-            });
+    // Set up globals
+    global.app = mockApp
+    global.stoUI = mockUI
+    global.vertigoManager = mockVertigoManager
 
-            // Verify we now have 3 aliases total (including existing one)
-            expect(Object.keys(mockProfile.aliases)).toHaveLength(3);
-        });
+    // Clear all mocks
+    vi.clearAllMocks()
+  })
 
-        it('should handle PlayerSay toggle correctly', () => {
-            // Test with PlayerSay enabled
-            mockVertigoManager.showPlayerSay = true;
-            const aliasWithPlayerSay = mockVertigoManager.generateAlias('space');
-            expect(aliasWithPlayerSay).toContain('PlayerSay Vertigo VFX Loaded');
+  afterEach(() => {
+    delete global.app
+    delete global.stoUI
+    delete global.vertigoManager
+  })
 
-            // Test with PlayerSay disabled
-            mockVertigoManager.showPlayerSay = false;
-            const aliasWithoutPlayerSay = mockVertigoManager.generateAlias('space');
-            expect(aliasWithoutPlayerSay).not.toContain('PlayerSay Vertigo VFX Loaded');
-            expect(aliasWithoutPlayerSay).toBe('alias dynFxSetFXExlusionList_Space <& dynFxSetFXExlusionList Fx_Explosion_Large,Fx_Weapon_Beam &>');
-        });
+  describe('Full Vertigo Workflow', () => {
+    it('should complete full workflow from effect selection to alias creation', () => {
+      // Step 1: Generate aliases with current selection
+      const spaceAlias = mockVertigoManager.generateAlias('space')
+      const groundAlias = mockVertigoManager.generateAlias('ground')
 
-        it('should handle empty effect selections', () => {
-            // Clear all effects
-            mockVertigoManager.clearAllEffects();
-            
-            // Attempt to generate aliases
-            const spaceAlias = mockVertigoManager.generateAlias('space');
-            const groundAlias = mockVertigoManager.generateAlias('ground');
-            
-            // Should return empty strings
-            expect(spaceAlias).toBe('');
-            expect(groundAlias).toBe('');
-        });
+      // Verify aliases are generated correctly
+      expect(spaceAlias).toBe(
+        'alias dynFxSetFXExlusionList_Space <& dynFxSetFXExlusionList Fx_Explosion_Large,Fx_Weapon_Beam $$ PlayerSay Vertigo VFX Loaded &>'
+      )
+      expect(groundAlias).toBe(
+        'alias dynFxSetFXExlusionList_Ground <& dynFxSetFXExlusionList Fx_Ground_Impact $$ PlayerSay Vertigo VFX Loaded &>'
+      )
 
-        it('should handle select all functionality', () => {
-            // Clear existing effects
-            mockVertigoManager.clearAllEffects();
-            
-            // Select all space effects
-            mockVertigoManager.selectAllEffects('space');
-            
-            // Verify effects were added
-            expect(mockVertigoManager.selectedEffects.space.size).toBe(3);
-            expect(mockVertigoManager.selectedEffects.space.has('Fx_Effect1')).toBe(true);
-            expect(mockVertigoManager.selectedEffects.space.has('Fx_Effect2')).toBe(true);
-            expect(mockVertigoManager.selectedEffects.space.has('Fx_Effect3')).toBe(true);
-            
-            // Generate alias with all effects
-            const spaceAlias = mockVertigoManager.generateAlias('space');
-            expect(spaceAlias).toContain('Fx_Effect1,Fx_Effect2,Fx_Effect3');
-        });
-    });
+      // Step 2: Extract commands for profile storage
+      const spaceCommands = spaceAlias
+        .replace('alias dynFxSetFXExlusionList_Space <& ', '')
+        .replace(' &>', '')
+      const groundCommands = groundAlias
+        .replace('alias dynFxSetFXExlusionList_Ground <& ', '')
+        .replace(' &>', '')
 
-    describe('Alias Integration with Command System', () => {
-        it('should integrate generated aliases with existing alias system', () => {
-            // Start with existing alias
-            expect(mockProfile.aliases['ExistingAlias']).toBeDefined();
-            
-            // Generate and add Vertigo aliases
-            const spaceAlias = mockVertigoManager.generateAlias('space');
-            const spaceCommands = spaceAlias.replace('alias dynFxSetFXExlusionList_Space <& ', '').replace(' &>', '');
-            
-            mockProfile.aliases['dynFxSetFXExlusionList_Space'] = {
-                name: 'dynFxSetFXExlusionList_Space',
-                description: 'Vertigo - Disable Space Visual Effects',
-                commands: spaceCommands
-            };
-            
-            // Verify both aliases coexist
-            expect(Object.keys(mockProfile.aliases)).toHaveLength(2);
-            expect(mockProfile.aliases['ExistingAlias']).toBeDefined();
-            expect(mockProfile.aliases['dynFxSetFXExlusionList_Space']).toBeDefined();
-            
-            // Verify they have different purposes
-            expect(mockProfile.aliases['ExistingAlias'].commands).toBe('target_nearest_enemy $$ FireAll');
-            expect(mockProfile.aliases['dynFxSetFXExlusionList_Space'].commands).toContain('dynFxSetFXExlusionList');
-        });
+      // Step 3: Add to profile
+      mockProfile.aliases['dynFxSetFXExlusionList_Space'] = {
+        name: 'dynFxSetFXExlusionList_Space',
+        description: 'Vertigo - Disable Space Visual Effects',
+        commands: spaceCommands,
+      }
 
-        it('should update existing Vertigo aliases when regenerated', () => {
-            // First generation
-            const firstAlias = mockVertigoManager.generateAlias('space');
-            const firstCommands = firstAlias.replace('alias dynFxSetFXExlusionList_Space <& ', '').replace(' &>', '');
-            
-            mockProfile.aliases['dynFxSetFXExlusionList_Space'] = {
-                name: 'dynFxSetFXExlusionList_Space',
-                description: 'Vertigo - Disable Space Visual Effects',
-                commands: firstCommands
-            };
-            
-            // Change selection
-            mockVertigoManager.selectedEffects.space.clear();
-            mockVertigoManager.selectedEffects.space.add('Fx_NewEffect');
-            
-            // Regenerate
-            const secondAlias = mockVertigoManager.generateAlias('space');
-            const secondCommands = secondAlias.replace('alias dynFxSetFXExlusionList_Space <& ', '').replace(' &>', '');
-            
-            mockProfile.aliases['dynFxSetFXExlusionList_Space'].commands = secondCommands;
-            
-            // Verify alias was updated
-            expect(mockProfile.aliases['dynFxSetFXExlusionList_Space'].commands).toContain('Fx_NewEffect');
-            expect(mockProfile.aliases['dynFxSetFXExlusionList_Space'].commands).not.toContain('Fx_Explosion_Large');
-        });
+      mockProfile.aliases['dynFxSetFXExlusionList_Ground'] = {
+        name: 'dynFxSetFXExlusionList_Ground',
+        description: 'Vertigo - Disable Ground Visual Effects',
+        commands: groundCommands,
+      }
 
-        it('should maintain correct alias format with many effects', () => {
-            // Clear existing effects first and add 10 new ones
-            mockVertigoManager.selectedEffects.space.clear();
-            for (let i = 1; i <= 10; i++) {
-                mockVertigoManager.selectedEffects.space.add(`Fx_Effect_${i}`);
-            }
-            
-            const alias = mockVertigoManager.generateAlias('space');
-            
-            // Should still maintain correct format
-            expect(alias).toMatch(/^alias\s+dynFxSetFXExlusionList_Space\s+<&\s+dynFxSetFXExlusionList\s+.+\s+&>$/);
-            expect(alias).toContain('Fx_Effect_1');
-            expect(alias).toContain('Fx_Effect_10');
-            
-            // Should be comma-separated - check the actual count in the generated alias
-            const effectsPart = alias.match(/dynFxSetFXExlusionList\s+([^$]+)/)[1].trim();
-            const effectsArray = effectsPart.split(',');
-            expect(effectsArray.length).toBe(10);
-        });
-    });
+      // Verify profile was updated correctly
+      expect(mockProfile.aliases['dynFxSetFXExlusionList_Space']).toEqual({
+        name: 'dynFxSetFXExlusionList_Space',
+        description: 'Vertigo - Disable Space Visual Effects',
+        commands:
+          'dynFxSetFXExlusionList Fx_Explosion_Large,Fx_Weapon_Beam $$ PlayerSay Vertigo VFX Loaded',
+      })
 
-    describe('Error Handling and Edge Cases', () => {
-        it('should handle missing profile gracefully', () => {
-            mockApp.getCurrentProfile.mockReturnValue(null);
-            
-            // Should handle null profile without crashing
-            expect(() => {
-                const alias = mockVertigoManager.generateAlias('space');
-                expect(alias).toBeDefined();
-            }).not.toThrow();
-        });
+      expect(mockProfile.aliases['dynFxSetFXExlusionList_Ground']).toEqual({
+        name: 'dynFxSetFXExlusionList_Ground',
+        description: 'Vertigo - Disable Ground Visual Effects',
+        commands:
+          'dynFxSetFXExlusionList Fx_Ground_Impact $$ PlayerSay Vertigo VFX Loaded',
+      })
 
-        it('should handle invalid environment names', () => {
-            // Mock the generateAlias to handle invalid environments properly
-            const originalGenerate = mockVertigoManager.generateAlias;
-            mockVertigoManager.generateAlias = function(environment) {
-                if (!this.selectedEffects[environment]) {
-                    return '';
-                }
-                return originalGenerate.call(this, environment);
-            };
-            
-            const invalidAlias = mockVertigoManager.generateAlias('invalid');
-            expect(invalidAlias).toBe('');
-            
-            // Restore original method
-            mockVertigoManager.generateAlias = originalGenerate;
-        });
+      // Verify we now have 3 aliases total (including existing one)
+      expect(Object.keys(mockProfile.aliases)).toHaveLength(3)
+    })
 
-        it('should handle special characters in effect names', () => {
-            mockVertigoManager.selectedEffects.space.clear();
-            mockVertigoManager.selectedEffects.space.add('Fx_Effect-With_Special.Characters');
-            
-            const alias = mockVertigoManager.generateAlias('space');
-            expect(alias).toContain('Fx_Effect-With_Special.Characters');
-            expect(alias).toMatch(/^alias\s+\w+\s+<&\s+.+\s+&>$/);
-        });
-    });
+    it('should handle PlayerSay toggle correctly', () => {
+      // Test with PlayerSay enabled
+      mockVertigoManager.showPlayerSay = true
+      const aliasWithPlayerSay = mockVertigoManager.generateAlias('space')
+      expect(aliasWithPlayerSay).toContain('PlayerSay Vertigo VFX Loaded')
 
-    describe('State Management', () => {
-        it('should preserve selection state during modal operations', () => {
-            const initialSelection = new Set(mockVertigoManager.selectedEffects.space);
-            
-            // Simulate modal operations that shouldn't affect selection
-            mockUI.showModal('vertigoModal');
-            mockUI.hideModal('vertigoModal');
-            
-            // Selection should be preserved
-            expect(mockVertigoManager.selectedEffects.space).toEqual(initialSelection);
-        });
+      // Test with PlayerSay disabled
+      mockVertigoManager.showPlayerSay = false
+      const aliasWithoutPlayerSay = mockVertigoManager.generateAlias('space')
+      expect(aliasWithoutPlayerSay).not.toContain(
+        'PlayerSay Vertigo VFX Loaded'
+      )
+      expect(aliasWithoutPlayerSay).toBe(
+        'alias dynFxSetFXExlusionList_Space <& dynFxSetFXExlusionList Fx_Explosion_Large,Fx_Weapon_Beam &>'
+      )
+    })
 
-        it('should handle concurrent modifications safely', () => {
-            const originalEffects = Array.from(mockVertigoManager.selectedEffects.space);
-            
-            // Simulate concurrent modifications
-            mockVertigoManager.selectedEffects.space.add('NewEffect1');
-            const alias1 = mockVertigoManager.generateAlias('space');
-            
-            mockVertigoManager.selectedEffects.space.add('NewEffect2');
-            const alias2 = mockVertigoManager.generateAlias('space');
-            
-            // Both operations should succeed
-            expect(alias1).toContain('NewEffect1');
-            expect(alias2).toContain('NewEffect1');
-            expect(alias2).toContain('NewEffect2');
-            
-            // Should maintain all effects
-            expect(mockVertigoManager.selectedEffects.space.size).toBe(originalEffects.length + 2);
-        });
-    });
-}); 
+    it('should handle empty effect selections', () => {
+      // Clear all effects
+      mockVertigoManager.clearAllEffects()
+
+      // Attempt to generate aliases
+      const spaceAlias = mockVertigoManager.generateAlias('space')
+      const groundAlias = mockVertigoManager.generateAlias('ground')
+
+      // Should return empty strings
+      expect(spaceAlias).toBe('')
+      expect(groundAlias).toBe('')
+    })
+
+    it('should handle select all functionality', () => {
+      // Clear existing effects
+      mockVertigoManager.clearAllEffects()
+
+      // Select all space effects
+      mockVertigoManager.selectAllEffects('space')
+
+      // Verify effects were added
+      expect(mockVertigoManager.selectedEffects.space.size).toBe(3)
+      expect(mockVertigoManager.selectedEffects.space.has('Fx_Effect1')).toBe(
+        true
+      )
+      expect(mockVertigoManager.selectedEffects.space.has('Fx_Effect2')).toBe(
+        true
+      )
+      expect(mockVertigoManager.selectedEffects.space.has('Fx_Effect3')).toBe(
+        true
+      )
+
+      // Generate alias with all effects
+      const spaceAlias = mockVertigoManager.generateAlias('space')
+      expect(spaceAlias).toContain('Fx_Effect1,Fx_Effect2,Fx_Effect3')
+    })
+  })
+
+  describe('Alias Integration with Command System', () => {
+    it('should integrate generated aliases with existing alias system', () => {
+      // Start with existing alias
+      expect(mockProfile.aliases['ExistingAlias']).toBeDefined()
+
+      // Generate and add Vertigo aliases
+      const spaceAlias = mockVertigoManager.generateAlias('space')
+      const spaceCommands = spaceAlias
+        .replace('alias dynFxSetFXExlusionList_Space <& ', '')
+        .replace(' &>', '')
+
+      mockProfile.aliases['dynFxSetFXExlusionList_Space'] = {
+        name: 'dynFxSetFXExlusionList_Space',
+        description: 'Vertigo - Disable Space Visual Effects',
+        commands: spaceCommands,
+      }
+
+      // Verify both aliases coexist
+      expect(Object.keys(mockProfile.aliases)).toHaveLength(2)
+      expect(mockProfile.aliases['ExistingAlias']).toBeDefined()
+      expect(mockProfile.aliases['dynFxSetFXExlusionList_Space']).toBeDefined()
+
+      // Verify they have different purposes
+      expect(mockProfile.aliases['ExistingAlias'].commands).toBe(
+        'target_nearest_enemy $$ FireAll'
+      )
+      expect(
+        mockProfile.aliases['dynFxSetFXExlusionList_Space'].commands
+      ).toContain('dynFxSetFXExlusionList')
+    })
+
+    it('should update existing Vertigo aliases when regenerated', () => {
+      // First generation
+      const firstAlias = mockVertigoManager.generateAlias('space')
+      const firstCommands = firstAlias
+        .replace('alias dynFxSetFXExlusionList_Space <& ', '')
+        .replace(' &>', '')
+
+      mockProfile.aliases['dynFxSetFXExlusionList_Space'] = {
+        name: 'dynFxSetFXExlusionList_Space',
+        description: 'Vertigo - Disable Space Visual Effects',
+        commands: firstCommands,
+      }
+
+      // Change selection
+      mockVertigoManager.selectedEffects.space.clear()
+      mockVertigoManager.selectedEffects.space.add('Fx_NewEffect')
+
+      // Regenerate
+      const secondAlias = mockVertigoManager.generateAlias('space')
+      const secondCommands = secondAlias
+        .replace('alias dynFxSetFXExlusionList_Space <& ', '')
+        .replace(' &>', '')
+
+      mockProfile.aliases['dynFxSetFXExlusionList_Space'].commands =
+        secondCommands
+
+      // Verify alias was updated
+      expect(
+        mockProfile.aliases['dynFxSetFXExlusionList_Space'].commands
+      ).toContain('Fx_NewEffect')
+      expect(
+        mockProfile.aliases['dynFxSetFXExlusionList_Space'].commands
+      ).not.toContain('Fx_Explosion_Large')
+    })
+
+    it('should maintain correct alias format with many effects', () => {
+      // Clear existing effects first and add 10 new ones
+      mockVertigoManager.selectedEffects.space.clear()
+      for (let i = 1; i <= 10; i++) {
+        mockVertigoManager.selectedEffects.space.add(`Fx_Effect_${i}`)
+      }
+
+      const alias = mockVertigoManager.generateAlias('space')
+
+      // Should still maintain correct format
+      expect(alias).toMatch(
+        /^alias\s+dynFxSetFXExlusionList_Space\s+<&\s+dynFxSetFXExlusionList\s+.+\s+&>$/
+      )
+      expect(alias).toContain('Fx_Effect_1')
+      expect(alias).toContain('Fx_Effect_10')
+
+      // Should be comma-separated - check the actual count in the generated alias
+      const effectsPart = alias
+        .match(/dynFxSetFXExlusionList\s+([^$]+)/)[1]
+        .trim()
+      const effectsArray = effectsPart.split(',')
+      expect(effectsArray.length).toBe(10)
+    })
+  })
+
+  describe('Error Handling and Edge Cases', () => {
+    it('should handle missing profile gracefully', () => {
+      mockApp.getCurrentProfile.mockReturnValue(null)
+
+      // Should handle null profile without crashing
+      expect(() => {
+        const alias = mockVertigoManager.generateAlias('space')
+        expect(alias).toBeDefined()
+      }).not.toThrow()
+    })
+
+    it('should handle invalid environment names', () => {
+      // Mock the generateAlias to handle invalid environments properly
+      const originalGenerate = mockVertigoManager.generateAlias
+      mockVertigoManager.generateAlias = function (environment) {
+        if (!this.selectedEffects[environment]) {
+          return ''
+        }
+        return originalGenerate.call(this, environment)
+      }
+
+      const invalidAlias = mockVertigoManager.generateAlias('invalid')
+      expect(invalidAlias).toBe('')
+
+      // Restore original method
+      mockVertigoManager.generateAlias = originalGenerate
+    })
+
+    it('should handle special characters in effect names', () => {
+      mockVertigoManager.selectedEffects.space.clear()
+      mockVertigoManager.selectedEffects.space.add(
+        'Fx_Effect-With_Special.Characters'
+      )
+
+      const alias = mockVertigoManager.generateAlias('space')
+      expect(alias).toContain('Fx_Effect-With_Special.Characters')
+      expect(alias).toMatch(/^alias\s+\w+\s+<&\s+.+\s+&>$/)
+    })
+  })
+
+  describe('State Management', () => {
+    it('should preserve selection state during modal operations', () => {
+      const initialSelection = new Set(mockVertigoManager.selectedEffects.space)
+
+      // Simulate modal operations that shouldn't affect selection
+      mockUI.showModal('vertigoModal')
+      mockUI.hideModal('vertigoModal')
+
+      // Selection should be preserved
+      expect(mockVertigoManager.selectedEffects.space).toEqual(initialSelection)
+    })
+
+    it('should handle concurrent modifications safely', () => {
+      const originalEffects = Array.from(
+        mockVertigoManager.selectedEffects.space
+      )
+
+      // Simulate concurrent modifications
+      mockVertigoManager.selectedEffects.space.add('NewEffect1')
+      const alias1 = mockVertigoManager.generateAlias('space')
+
+      mockVertigoManager.selectedEffects.space.add('NewEffect2')
+      const alias2 = mockVertigoManager.generateAlias('space')
+
+      // Both operations should succeed
+      expect(alias1).toContain('NewEffect1')
+      expect(alias2).toContain('NewEffect1')
+      expect(alias2).toContain('NewEffect2')
+
+      // Should maintain all effects
+      expect(mockVertigoManager.selectedEffects.space.size).toBe(
+        originalEffects.length + 2
+      )
+    })
+  })
+})

--- a/tests/integration/vfx-aliases-reload.test.js
+++ b/tests/integration/vfx-aliases-reload.test.js
@@ -1,210 +1,218 @@
 // Integration test for VFX aliases reload issue
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import eventBus from '../../src/js/eventBus.js'
 
 describe('VFX Aliases Reload Integration', () => {
-    let mockApp, mockProfile, mockUI, mockStorage;
+  let mockApp, mockProfile, mockUI, mockStorage
 
-    beforeEach(() => {
-        // Mock profile with VFX aliases
-        mockProfile = {
-            name: 'Test Profile',
-            aliases: {
-                'RegularAlias': {
-                    name: 'RegularAlias',
-                    description: 'A regular alias',
-                    commands: 'target_nearest_enemy $$ FireAll'
-                },
-                'dynFxSetFXExlusionList_Space': {
-                    name: 'dynFxSetFXExlusionList_Space',
-                    description: 'VFX - Disable Space Visual Effects',
-                    commands: 'dynFxSetFXExlusionList Fx_Test_Effect_1,Fx_Test_Effect_2'
-                },
-                'dynFxSetFXExlusionList_Ground': {
-                    name: 'dynFxSetFXExlusionList_Ground',
-                    description: 'VFX - Disable Ground Visual Effects',
-                    commands: 'dynFxSetFXExlusionList Fx_Ground_Effect_1'
-                }
-            },
-            keys: {}
-        };
+  beforeEach(() => {
+    // Mock profile with VFX aliases
+    mockProfile = {
+      name: 'Test Profile',
+      aliases: {
+        RegularAlias: {
+          name: 'RegularAlias',
+          description: 'A regular alias',
+          commands: 'target_nearest_enemy $$ FireAll',
+        },
+        dynFxSetFXExlusionList_Space: {
+          name: 'dynFxSetFXExlusionList_Space',
+          description: 'VFX - Disable Space Visual Effects',
+          commands: 'dynFxSetFXExlusionList Fx_Test_Effect_1,Fx_Test_Effect_2',
+        },
+        dynFxSetFXExlusionList_Ground: {
+          name: 'dynFxSetFXExlusionList_Ground',
+          description: 'VFX - Disable Ground Visual Effects',
+          commands: 'dynFxSetFXExlusionList Fx_Ground_Effect_1',
+        },
+      },
+      keys: {},
+    }
 
-        // Mock storage
-        mockStorage = {
-            getProfile: vi.fn(() => mockProfile),
-            getAllData: vi.fn(() => ({
-                currentProfile: 'test-profile',
-                profiles: {
-                    'test-profile': mockProfile
-                }
-            }))
-        };
+    // Mock storage
+    mockStorage = {
+      getProfile: vi.fn(() => mockProfile),
+      getAllData: vi.fn(() => ({
+        currentProfile: 'test-profile',
+        profiles: {
+          'test-profile': mockProfile,
+        },
+      })),
+    }
 
-        // Mock app
-        mockApp = {
-            getCurrentProfile: vi.fn(() => mockProfile),
-            currentProfile: 'test-profile',
-            currentEnvironment: 'space',
-            init: vi.fn().mockResolvedValue(undefined),
-            setupCommandLibrary: vi.fn(),
-            loadData: vi.fn().mockResolvedValue(undefined)
-        };
+    // Mock app
+    mockApp = {
+      getCurrentProfile: vi.fn(() => mockProfile),
+      currentProfile: 'test-profile',
+      currentEnvironment: 'space',
+      init: vi.fn().mockResolvedValue(undefined),
+      setupCommandLibrary: vi.fn(),
+      loadData: vi.fn().mockResolvedValue(undefined),
+    }
 
-        // Mock UI
-        mockUI = {
-            showModal: vi.fn(),
-            hideModal: vi.fn(),
-            showToast: vi.fn()
-        };
+    // Mock UI
+    mockUI = {
+      showModal: vi.fn(),
+      hideModal: vi.fn(),
+      showToast: vi.fn(),
+    }
 
-        // Set up globals
-        global.app = mockApp;
-        global.stoUI = mockUI;
-        global.stoStorage = mockStorage;
-        
-        // Mock DOM
-        document.body.innerHTML = `
+    // Set up globals
+    global.app = mockApp
+    global.stoUI = mockUI
+    global.stoStorage = mockStorage
+
+    // Mock DOM
+    document.body.innerHTML = `
             <div id="commandCategories"></div>
-        `;
-        
-        // Clear all mocks
-        vi.clearAllMocks();
+        `
 
-        // Ensure fresh module imports for each test
-        vi.resetModules();
-    });
+    // Clear all mocks
+    vi.clearAllMocks()
 
-    afterEach(() => {
-        delete global.app;
-        delete global.stoUI;
-        delete global.stoStorage;
-        delete global.stoAliases;
-        delete window.stoAliases;
-    });
+    // Ensure fresh module imports for each test
+    vi.resetModules()
+  })
 
-    it('should initialize aliases in command library after app ready event', async () => {
-        // Import the aliases.js module and create a new instance for testing
-        const { default: STOAliasManager } = await import('../../src/js/aliases.js');
+  afterEach(() => {
+    delete global.app
+    delete global.stoUI
+    delete global.stoStorage
+    delete global.stoAliases
+    delete window.stoAliases
+  })
 
-        // Create alias manager instance manually for testing
-        const aliasManager = new STOAliasManager();
-        global.stoAliases = aliasManager;
-        window.stoAliases = aliasManager;
-        
-        // Spy on updateCommandLibrary
-        const updateLibrarySpy = vi.spyOn(aliasManager, 'updateCommandLibrary');
-        
-        // Simulate the app initialization sequence
-        // 1. App is created but not yet initialized
-        expect(updateLibrarySpy).not.toHaveBeenCalled();
-        
-        // 2. App ready event is dispatched (simulating app.init() completion)
-        const appReadyPayload = { app: mockApp };
-        
-        // 3. Initialize alias manager (this should happen after app ready)
-        aliasManager.init();
-        
-        // 4. Verify updateCommandLibrary was called during initialization
-        expect(updateLibrarySpy).toHaveBeenCalled();
-        
-        // 5. Verify command library contains VFX aliases
-        const commandCategories = document.getElementById('commandCategories');
-        const vfxCategory = commandCategories.querySelector('[data-category="vertigo-aliases"]');
-        const regularCategory = commandCategories.querySelector('[data-category="aliases"]');
-        
-        expect(vfxCategory).toBeTruthy();
-        expect(regularCategory).toBeTruthy();
-        
-        // Check VFX aliases are present
-        const vfxAliases = vfxCategory.querySelectorAll('.vertigo-alias-item');
-        expect(vfxAliases).toHaveLength(2); // Space and Ground VFX aliases
-        
-        const aliasNames = Array.from(vfxAliases).map(el => el.dataset.alias);
-        expect(aliasNames).toContain('dynFxSetFXExlusionList_Space');
-        expect(aliasNames).toContain('dynFxSetFXExlusionList_Ground');
-    });
+  it('should initialize aliases in command library after app ready event', async () => {
+    // Import the aliases.js module and create a new instance for testing
+    const { default: STOAliasManager } = await import('../../src/js/aliases.js')
 
-    it('should handle app ready event timing correctly', async () => {
-        // Import and instantiate the alias manager
-        const { default: STOAliasManager } = await import('../../src/js/aliases.js');
-        const aliasManager = new STOAliasManager();
-        global.stoAliases = aliasManager;
-        const updateLibrarySpy = vi.spyOn(aliasManager, 'updateCommandLibrary');
-        
-        // Simulate the real application flow:
-        // 1. App dispatches ready event
-        const appReadyPayload = { app: mockApp };
-        
-        // 2. Set up event listener (this is what the fixed app.js does)
-        let aliasManagerInitialized = false;
-        eventBus.on('sto-app-ready', () => {
-            aliasManager.init();
-            aliasManagerInitialized = true;
-        });
-        
-        // 3. Dispatch the event
-        eventBus.emit('sto-app-ready', appReadyPayload);
-        
-        // 4. Verify alias manager was initialized after app ready
-        expect(aliasManagerInitialized).toBe(true);
-        expect(updateLibrarySpy).toHaveBeenCalled();
-        
-        // Clean up event listener
-        eventBus.off('sto-app-ready', () => {});
-    });
+    // Create alias manager instance manually for testing
+    const aliasManager = new STOAliasManager()
+    global.stoAliases = aliasManager
+    window.stoAliases = aliasManager
 
-    it('should maintain VFX aliases across simulated reload', async () => {
-        // Import and instantiate the alias manager
-        const { default: STOAliasManager } = await import('../../src/js/aliases.js');
-        const aliasManager1 = new STOAliasManager();
-        global.stoAliases = aliasManager1;
-        aliasManager1.init();
-        
-        let commandCategories = document.getElementById('commandCategories');
-        let vfxCategory = commandCategories.querySelector('[data-category="vertigo-aliases"]');
-        expect(vfxCategory).toBeTruthy();
-        
-        // Simulate page reload - clear DOM and recreate
-        document.body.innerHTML = `<div id="commandCategories"></div>`;
-        
-        // Simulate second load (after reload) - aliases should still be visible
-        // Note: In reality this would be a new instance, but for testing we reuse the same one
-        aliasManager1.init();
-        
-        commandCategories = document.getElementById('commandCategories');
-        vfxCategory = commandCategories.querySelector('[data-category="vertigo-aliases"]');
-        
-        // VFX aliases should still be present after "reload"
-        expect(vfxCategory).toBeTruthy();
-        
-        const vfxAliases = vfxCategory.querySelectorAll('.vertigo-alias-item');
-        expect(vfxAliases).toHaveLength(2);
-        
-        const aliasNames = Array.from(vfxAliases).map(el => el.dataset.alias);
-        expect(aliasNames).toContain('dynFxSetFXExlusionList_Space');
-        expect(aliasNames).toContain('dynFxSetFXExlusionList_Ground');
-    });
+    // Spy on updateCommandLibrary
+    const updateLibrarySpy = vi.spyOn(aliasManager, 'updateCommandLibrary')
 
-    it('should handle empty aliases gracefully during initialization', async () => {
-        // Mock profile with no aliases
-        mockApp.getCurrentProfile.mockReturnValue({
-            name: 'Empty Profile',
-            aliases: {},
-            keys: {}
-        });
-        
-        // Import and instantiate the alias manager
-        const { default: STOAliasManager } = await import('../../src/js/aliases.js');
-        const aliasManager = new STOAliasManager();
-        global.stoAliases = aliasManager;
-        const updateLibrarySpy = vi.spyOn(aliasManager, 'updateCommandLibrary');
-        
-        // Should not throw error with empty aliases
-        expect(() => aliasManager.init()).not.toThrow();
-        expect(updateLibrarySpy).toHaveBeenCalled();
-        
-        // Command library should be empty but not broken
-        const commandCategories = document.getElementById('commandCategories');
-        expect(commandCategories.children).toHaveLength(0);
-    });
-}); 
+    // Simulate the app initialization sequence
+    // 1. App is created but not yet initialized
+    expect(updateLibrarySpy).not.toHaveBeenCalled()
+
+    // 2. App ready event is dispatched (simulating app.init() completion)
+    const appReadyPayload = { app: mockApp }
+
+    // 3. Initialize alias manager (this should happen after app ready)
+    aliasManager.init()
+
+    // 4. Verify updateCommandLibrary was called during initialization
+    expect(updateLibrarySpy).toHaveBeenCalled()
+
+    // 5. Verify command library contains VFX aliases
+    const commandCategories = document.getElementById('commandCategories')
+    const vfxCategory = commandCategories.querySelector(
+      '[data-category="vertigo-aliases"]'
+    )
+    const regularCategory = commandCategories.querySelector(
+      '[data-category="aliases"]'
+    )
+
+    expect(vfxCategory).toBeTruthy()
+    expect(regularCategory).toBeTruthy()
+
+    // Check VFX aliases are present
+    const vfxAliases = vfxCategory.querySelectorAll('.vertigo-alias-item')
+    expect(vfxAliases).toHaveLength(2) // Space and Ground VFX aliases
+
+    const aliasNames = Array.from(vfxAliases).map((el) => el.dataset.alias)
+    expect(aliasNames).toContain('dynFxSetFXExlusionList_Space')
+    expect(aliasNames).toContain('dynFxSetFXExlusionList_Ground')
+  })
+
+  it('should handle app ready event timing correctly', async () => {
+    // Import and instantiate the alias manager
+    const { default: STOAliasManager } = await import('../../src/js/aliases.js')
+    const aliasManager = new STOAliasManager()
+    global.stoAliases = aliasManager
+    const updateLibrarySpy = vi.spyOn(aliasManager, 'updateCommandLibrary')
+
+    // Simulate the real application flow:
+    // 1. App dispatches ready event
+    const appReadyPayload = { app: mockApp }
+
+    // 2. Set up event listener (this is what the fixed app.js does)
+    let aliasManagerInitialized = false
+    eventBus.on('sto-app-ready', () => {
+      aliasManager.init()
+      aliasManagerInitialized = true
+    })
+
+    // 3. Dispatch the event
+    eventBus.emit('sto-app-ready', appReadyPayload)
+
+    // 4. Verify alias manager was initialized after app ready
+    expect(aliasManagerInitialized).toBe(true)
+    expect(updateLibrarySpy).toHaveBeenCalled()
+
+    // Clean up event listener
+    eventBus.off('sto-app-ready', () => {})
+  })
+
+  it('should maintain VFX aliases across simulated reload', async () => {
+    // Import and instantiate the alias manager
+    const { default: STOAliasManager } = await import('../../src/js/aliases.js')
+    const aliasManager1 = new STOAliasManager()
+    global.stoAliases = aliasManager1
+    aliasManager1.init()
+
+    let commandCategories = document.getElementById('commandCategories')
+    let vfxCategory = commandCategories.querySelector(
+      '[data-category="vertigo-aliases"]'
+    )
+    expect(vfxCategory).toBeTruthy()
+
+    // Simulate page reload - clear DOM and recreate
+    document.body.innerHTML = `<div id="commandCategories"></div>`
+
+    // Simulate second load (after reload) - aliases should still be visible
+    // Note: In reality this would be a new instance, but for testing we reuse the same one
+    aliasManager1.init()
+
+    commandCategories = document.getElementById('commandCategories')
+    vfxCategory = commandCategories.querySelector(
+      '[data-category="vertigo-aliases"]'
+    )
+
+    // VFX aliases should still be present after "reload"
+    expect(vfxCategory).toBeTruthy()
+
+    const vfxAliases = vfxCategory.querySelectorAll('.vertigo-alias-item')
+    expect(vfxAliases).toHaveLength(2)
+
+    const aliasNames = Array.from(vfxAliases).map((el) => el.dataset.alias)
+    expect(aliasNames).toContain('dynFxSetFXExlusionList_Space')
+    expect(aliasNames).toContain('dynFxSetFXExlusionList_Ground')
+  })
+
+  it('should handle empty aliases gracefully during initialization', async () => {
+    // Mock profile with no aliases
+    mockApp.getCurrentProfile.mockReturnValue({
+      name: 'Empty Profile',
+      aliases: {},
+      keys: {},
+    })
+
+    // Import and instantiate the alias manager
+    const { default: STOAliasManager } = await import('../../src/js/aliases.js')
+    const aliasManager = new STOAliasManager()
+    global.stoAliases = aliasManager
+    const updateLibrarySpy = vi.spyOn(aliasManager, 'updateCommandLibrary')
+
+    // Should not throw error with empty aliases
+    expect(() => aliasManager.init()).not.toThrow()
+    expect(updateLibrarySpy).toHaveBeenCalled()
+
+    // Command library should be empty but not broken
+    const commandCategories = document.getElementById('commandCategories')
+    expect(commandCategories.children).toHaveLength(0)
+  })
+})

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -4,7 +4,7 @@ import { beforeEach, afterEach, vi } from 'vitest'
 // Mock browser APIs that aren't available in jsdom
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
-  value: vi.fn().mockImplementation(query => ({
+  value: vi.fn().mockImplementation((query) => ({
     matches: false,
     media: query,
     onchange: null,
@@ -36,7 +36,7 @@ global.FileReader = class FileReader {
     this.onerror = null
     this.onabort = null
   }
-  
+
   readAsText(file) {
     setTimeout(() => {
       this.readyState = 2
@@ -44,7 +44,7 @@ global.FileReader = class FileReader {
       if (this.onload) this.onload({ target: this })
     }, 0)
   }
-  
+
   abort() {
     this.readyState = 2
     if (this.onabort) this.onabort({ target: this })
@@ -68,7 +68,7 @@ global.stoUI = {
   showToast: vi.fn(),
   showModal: vi.fn(),
   hideModal: vi.fn(),
-  confirm: vi.fn().mockResolvedValue(true)
+  confirm: vi.fn().mockResolvedValue(true),
 }
 
 // Provide a minimal modalManager for modules that expect it
@@ -97,7 +97,7 @@ global.modalManager = {
       return true
     }
     return false
-  })
+  }),
 }
 
 // Clean up after each test
@@ -110,4 +110,4 @@ afterEach(() => {
   // Clean up DOM after each test
   document.body.innerHTML = ''
   document.head.innerHTML = ''
-}) 
+})

--- a/tests/unit/aliases.test.js
+++ b/tests/unit/aliases.test.js
@@ -5,7 +5,7 @@ import { join } from 'path'
 // Import real data first to ensure STO_DATA is available
 import '../../src/js/data.js'
 
-import eventBus from "../../src/js/eventBus.js"
+import eventBus from '../../src/js/eventBus.js'
 // Load the aliases module (it creates a global instance)
 import STOAliasManager from '../../src/js/aliases.js'
 import store, { resetStore } from '../../src/js/store.js'
@@ -18,31 +18,31 @@ beforeEach(() => {
   resetStore()
   // Set up the real DOM
   document.documentElement.innerHTML = htmlContent
-  
+
   // Mock only the UI methods that would show actual UI
   global.stoUI = {
     showToast: vi.fn(),
-    confirm: vi.fn().mockResolvedValue(true)
+    confirm: vi.fn().mockResolvedValue(true),
   }
 
   global.modalManager = {
     show: vi.fn(),
-    hide: vi.fn()
+    hide: vi.fn(),
   }
-  
+
   // Mock only the app methods that would modify actual DOM
   global.app = {
     getCurrentProfile: vi.fn(() => ({
       keys: {},
       aliases: {},
       name: 'Test Profile',
-      mode: 'Space'
+      mode: 'Space',
     })),
     selectedKey: null,
     saveProfile: vi.fn(),
     setModified: vi.fn(),
     generateCommandId: vi.fn(() => `cmd_${Date.now()}`),
-    addCommand: vi.fn()
+    addCommand: vi.fn(),
   }
 })
 
@@ -74,10 +74,12 @@ describe('STOAliasManager', () => {
 
   describe('alias manager modal', () => {
     it('should show alias manager modal', () => {
-      const renderSpy = vi.spyOn(aliasManager, 'renderAliasList').mockImplementation(() => {})
-      
+      const renderSpy = vi
+        .spyOn(aliasManager, 'renderAliasList')
+        .mockImplementation(() => {})
+
       aliasManager.showAliasManager()
-      
+
       expect(renderSpy).toHaveBeenCalled()
       expect(modalManager.show).toHaveBeenCalledWith('aliasManagerModal')
     })
@@ -85,19 +87,19 @@ describe('STOAliasManager', () => {
     it('should render alias list with existing aliases', () => {
       const container = document.getElementById('aliasList')
       expect(container).toBeTruthy()
-      
+
       global.app.getCurrentProfile.mockReturnValue({
         aliases: {
-          'TestAlias': {
+          TestAlias: {
             name: 'TestAlias',
             description: 'Test description',
-            commands: 'say hello'
-          }
-        }
+            commands: 'say hello',
+          },
+        },
       })
-      
+
       aliasManager.renderAliasList()
-      
+
       expect(container.innerHTML).toContain('alias-grid')
       expect(container.innerHTML).toContain('TestAlias')
       expect(container.innerHTML).toContain('Test description')
@@ -105,13 +107,13 @@ describe('STOAliasManager', () => {
 
     it('should show empty state when no aliases exist', () => {
       const container = document.getElementById('aliasList')
-      
+
       global.app.getCurrentProfile.mockReturnValue({
-        aliases: {}
+        aliases: {},
       })
-      
+
       aliasManager.renderAliasList()
-      
+
       expect(container.innerHTML).toContain('empty-state')
       expect(container.innerHTML).toContain('No Aliases')
     })
@@ -120,11 +122,11 @@ describe('STOAliasManager', () => {
       const alias = {
         name: 'TestAlias',
         description: 'Test description',
-        commands: 'say hello world'
+        commands: 'say hello world',
       }
-      
+
       const card = aliasManager.createAliasCard('TestAlias', alias)
-      
+
       expect(card).toContain('alias-card')
       expect(card).toContain('TestAlias')
       expect(card).toContain('Test description')
@@ -138,11 +140,12 @@ describe('STOAliasManager', () => {
       const alias = {
         name: 'LongAlias',
         description: 'Long command test',
-        commands: 'this is a very long command sequence that should be truncated when displayed'
+        commands:
+          'this is a very long command sequence that should be truncated when displayed',
       }
-      
+
       const card = aliasManager.createAliasCard('LongAlias', alias)
-      
+
       expect(card).toContain('...')
     })
   })
@@ -153,16 +156,18 @@ describe('STOAliasManager', () => {
       const nameInput = document.getElementById('aliasName')
       const descInput = document.getElementById('aliasDescription')
       const commandsInput = document.getElementById('aliasCommands')
-      
+
       expect(title).toBeTruthy()
       expect(nameInput).toBeTruthy()
       expect(descInput).toBeTruthy()
       expect(commandsInput).toBeTruthy()
-      
-      const updatePreviewSpy = vi.spyOn(aliasManager, 'updateAliasPreview').mockImplementation(() => {})
-      
+
+      const updatePreviewSpy = vi
+        .spyOn(aliasManager, 'updateAliasPreview')
+        .mockImplementation(() => {})
+
       aliasManager.showEditAliasModal()
-      
+
       expect(title.textContent).toBe('New Alias')
       expect(nameInput.value).toBe('')
       expect(nameInput.disabled).toBe(false)
@@ -179,21 +184,23 @@ describe('STOAliasManager', () => {
       const nameInput = document.getElementById('aliasName')
       const descInput = document.getElementById('aliasDescription')
       const commandsInput = document.getElementById('aliasCommands')
-      
+
       global.app.getCurrentProfile.mockReturnValue({
         aliases: {
-          'ExistingAlias': {
+          ExistingAlias: {
             name: 'ExistingAlias',
             description: 'Existing description',
-            commands: 'existing command'
-          }
-        }
+            commands: 'existing command',
+          },
+        },
       })
-      
-      const updatePreviewSpy = vi.spyOn(aliasManager, 'updateAliasPreview').mockImplementation(() => {})
-      
+
+      const updatePreviewSpy = vi
+        .spyOn(aliasManager, 'updateAliasPreview')
+        .mockImplementation(() => {})
+
       aliasManager.showEditAliasModal('ExistingAlias')
-      
+
       expect(title.textContent).toBe('Edit Alias')
       expect(nameInput.value).toBe('ExistingAlias')
       expect(nameInput.disabled).toBe(true)
@@ -205,19 +212,19 @@ describe('STOAliasManager', () => {
 
     it('should disable name field when editing existing alias', () => {
       const nameInput = document.getElementById('aliasName')
-      
+
       global.app.getCurrentProfile.mockReturnValue({
         aliases: {
-          'ExistingAlias': {
+          ExistingAlias: {
             name: 'ExistingAlias',
             description: 'Test',
-            commands: 'test command'
-          }
-        }
+            commands: 'test command',
+          },
+        },
       })
-      
+
       aliasManager.showEditAliasModal('ExistingAlias')
-      
+
       expect(nameInput.disabled).toBe(true)
     })
 
@@ -225,16 +232,16 @@ describe('STOAliasManager', () => {
       const preview = document.getElementById('aliasPreview')
       const nameInput = document.getElementById('aliasName')
       const commandsInput = document.getElementById('aliasCommands')
-      
+
       expect(preview).toBeTruthy()
       expect(nameInput).toBeTruthy()
       expect(commandsInput).toBeTruthy()
-      
+
       nameInput.value = 'TestAlias'
       commandsInput.value = 'say hello'
-      
+
       aliasManager.updateAliasPreview()
-      
+
       expect(preview.textContent).toBe('alias TestAlias <& say hello &>')
     })
 
@@ -242,12 +249,12 @@ describe('STOAliasManager', () => {
       const preview = document.getElementById('aliasPreview')
       const nameInput = document.getElementById('aliasName')
       const commandsInput = document.getElementById('aliasCommands')
-      
+
       nameInput.value = ''
       commandsInput.value = ''
-      
+
       aliasManager.updateAliasPreview()
-      
+
       expect(preview.textContent).toBe('alias AliasName <& command sequence &>')
     })
   })
@@ -257,28 +264,37 @@ describe('STOAliasManager', () => {
       const nameInput = document.getElementById('aliasName')
       const descInput = document.getElementById('aliasDescription')
       const commandsInput = document.getElementById('aliasCommands')
-      
+
       nameInput.value = 'ValidAlias'
       descInput.value = 'Test description'
       commandsInput.value = 'say hello'
-      
+
       const mockProfile = { aliases: {} }
       global.app.getCurrentProfile.mockReturnValue(mockProfile)
-      
-      const updateLibrarySpy = vi.spyOn(aliasManager, 'updateCommandLibrary').mockImplementation(() => {})
-      const showManagerSpy = vi.spyOn(aliasManager, 'showAliasManager').mockImplementation(() => {})
-      
+
+      const updateLibrarySpy = vi
+        .spyOn(aliasManager, 'updateCommandLibrary')
+        .mockImplementation(() => {})
+      const showManagerSpy = vi
+        .spyOn(aliasManager, 'showAliasManager')
+        .mockImplementation(() => {})
+
       aliasManager.currentAlias = null
       aliasManager.saveAlias()
-      
+
       expect(mockProfile.aliases.ValidAlias).toBeDefined()
       expect(mockProfile.aliases.ValidAlias.name).toBe('ValidAlias')
-      expect(mockProfile.aliases.ValidAlias.description).toBe('Test description')
+      expect(mockProfile.aliases.ValidAlias.description).toBe(
+        'Test description'
+      )
       expect(mockProfile.aliases.ValidAlias.commands).toBe('say hello')
       expect(app.saveProfile).toHaveBeenCalled()
       expect(app.setModified).toHaveBeenCalledWith(true)
       expect(updateLibrarySpy).toHaveBeenCalled()
-      expect(stoUI.showToast).toHaveBeenCalledWith('Alias "ValidAlias" created', 'success')
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Alias "ValidAlias" created',
+        'success'
+      )
       expect(modalManager.hide).toHaveBeenCalledWith('editAliasModal')
       expect(showManagerSpy).toHaveBeenCalled()
     })
@@ -287,36 +303,43 @@ describe('STOAliasManager', () => {
       const nameInput = document.getElementById('aliasName')
       const descInput = document.getElementById('aliasDescription')
       const commandsInput = document.getElementById('aliasCommands')
-      
+
       nameInput.value = 'ExistingAlias'
       descInput.value = 'Updated description'
       commandsInput.value = 'updated command'
-      
+
       const mockProfile = {
         aliases: {
           ExistingAlias: {
             name: 'ExistingAlias',
             description: 'Old description',
             commands: 'old command',
-            created: '2023-01-01T00:00:00.000Z'
-          }
-        }
+            created: '2023-01-01T00:00:00.000Z',
+          },
+        },
       }
       global.app.getCurrentProfile.mockReturnValue(mockProfile)
-      
+
       aliasManager.currentAlias = 'ExistingAlias'
       aliasManager.saveAlias()
-      
-      expect(mockProfile.aliases.ExistingAlias.description).toBe('Updated description')
+
+      expect(mockProfile.aliases.ExistingAlias.description).toBe(
+        'Updated description'
+      )
       expect(mockProfile.aliases.ExistingAlias.commands).toBe('updated command')
-      expect(mockProfile.aliases.ExistingAlias.created).toBe('2023-01-01T00:00:00.000Z')
+      expect(mockProfile.aliases.ExistingAlias.created).toBe(
+        '2023-01-01T00:00:00.000Z'
+      )
       expect(mockProfile.aliases.ExistingAlias.lastModified).toBeDefined()
-      expect(stoUI.showToast).toHaveBeenCalledWith('Alias "ExistingAlias" updated', 'success')
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Alias "ExistingAlias" updated',
+        'success'
+      )
     })
 
     it('should validate alias name format', () => {
       const result = aliasManager.validateAlias('ValidName123', 'say hello')
-      
+
       expect(result.valid).toBe(true)
     })
 
@@ -327,10 +350,10 @@ describe('STOAliasManager', () => {
         { name: '123invalid', expected: 'Invalid alias name' },
         { name: 'a'.repeat(31), expected: 'Alias name is too long' },
         { name: 'alias', expected: 'This is a reserved command name' },
-        { name: 'bind', expected: 'This is a reserved command name' }
+        { name: 'bind', expected: 'This is a reserved command name' },
       ]
-      
-      tests.forEach(test => {
+
+      tests.forEach((test) => {
         const result = aliasManager.validateAlias(test.name, 'valid commands')
         expect(result.valid).toBe(false)
         expect(result.error).toContain(test.expected)
@@ -340,10 +363,10 @@ describe('STOAliasManager', () => {
     it('should validate alias commands', () => {
       const tests = [
         { commands: '', expected: 'Commands are required' },
-        { commands: 'a'.repeat(501), expected: 'Command sequence is too long' }
+        { commands: 'a'.repeat(501), expected: 'Command sequence is too long' },
       ]
-      
-      tests.forEach(test => {
+
+      tests.forEach((test) => {
         const result = aliasManager.validateAlias('ValidName', test.commands)
         expect(result.valid).toBe(false)
         expect(result.error).toContain(test.expected)
@@ -353,25 +376,28 @@ describe('STOAliasManager', () => {
     it('should prevent duplicate alias names', () => {
       const nameInput = document.getElementById('aliasName')
       const commandsInput = document.getElementById('aliasCommands')
-      
+
       nameInput.value = 'ExistingAlias'
       commandsInput.value = 'say hello'
-      
+
       global.app.getCurrentProfile.mockReturnValue({
         aliases: {
-          ExistingAlias: { name: 'ExistingAlias', commands: 'existing' }
-        }
+          ExistingAlias: { name: 'ExistingAlias', commands: 'existing' },
+        },
       })
-      
+
       aliasManager.currentAlias = null
       aliasManager.saveAlias()
-      
-      expect(stoUI.showToast).toHaveBeenCalledWith('An alias with this name already exists', 'error')
+
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'An alias with this name already exists',
+        'error'
+      )
     })
 
     it('should delete alias with confirmation', async () => {
       aliasManager.confirmDeleteAlias('TestAlias')
-      
+
       expect(stoUI.confirm).toHaveBeenCalledWith(
         'Are you sure you want to delete the alias "TestAlias"?',
         'Delete Alias',
@@ -383,23 +409,30 @@ describe('STOAliasManager', () => {
       const mockProfile = {
         aliases: {
           TestAlias: { name: 'TestAlias', commands: 'test' },
-          KeepAlias: { name: 'KeepAlias', commands: 'keep' }
-        }
+          KeepAlias: { name: 'KeepAlias', commands: 'keep' },
+        },
       }
       global.app.getCurrentProfile.mockReturnValue(mockProfile)
-      
-      const renderSpy = vi.spyOn(aliasManager, 'renderAliasList').mockImplementation(() => {})
-      const updateLibrarySpy = vi.spyOn(aliasManager, 'updateCommandLibrary').mockImplementation(() => {})
-      
+
+      const renderSpy = vi
+        .spyOn(aliasManager, 'renderAliasList')
+        .mockImplementation(() => {})
+      const updateLibrarySpy = vi
+        .spyOn(aliasManager, 'updateCommandLibrary')
+        .mockImplementation(() => {})
+
       aliasManager.deleteAlias('TestAlias')
-      
+
       expect(mockProfile.aliases.TestAlias).toBeUndefined()
       expect(mockProfile.aliases.KeepAlias).toBeDefined()
       expect(app.saveProfile).toHaveBeenCalled()
       expect(app.setModified).toHaveBeenCalledWith(true)
       expect(renderSpy).toHaveBeenCalled()
       expect(updateLibrarySpy).toHaveBeenCalled()
-      expect(stoUI.showToast).toHaveBeenCalledWith('Alias "TestAlias" deleted', 'success')
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Alias "TestAlias" deleted',
+        'success'
+      )
     })
   })
 
@@ -407,26 +440,35 @@ describe('STOAliasManager', () => {
     it('should add alias to selected key', () => {
       global.app.selectedKey = 'F1'
       store.selectedKey = 'F1'
-      
+
       aliasManager.useAlias('TestAlias')
-      
-      expect(app.addCommand).toHaveBeenCalledWith('F1', expect.objectContaining({
-        command: 'TestAlias',
-        type: 'alias',
-        icon: '🎭',
-        text: 'Alias: TestAlias'
-      }))
+
+      expect(app.addCommand).toHaveBeenCalledWith(
+        'F1',
+        expect.objectContaining({
+          command: 'TestAlias',
+          type: 'alias',
+          icon: '🎭',
+          text: 'Alias: TestAlias',
+        })
+      )
       expect(modalManager.hide).toHaveBeenCalledWith('aliasManagerModal')
-      expect(stoUI.showToast).toHaveBeenCalledWith('Alias "TestAlias" added to F1', 'success')
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Alias "TestAlias" added to F1',
+        'success'
+      )
     })
 
     it('should require key selection before adding alias', () => {
       global.app.selectedKey = null
       store.selectedKey = null
-      
+
       aliasManager.useAlias('TestAlias')
-      
-      expect(stoUI.showToast).toHaveBeenCalledWith('Please select a key first', 'warning')
+
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Please select a key first',
+        'warning'
+      )
       expect(app.addCommand).not.toHaveBeenCalled()
     })
 
@@ -438,29 +480,32 @@ describe('STOAliasManager', () => {
           TestAlias: {
             name: 'TestAlias',
             description: 'Test description',
-            commands: 'say hello'
-          }
-        }
+            commands: 'say hello',
+          },
+        },
       })
-      
+
       aliasManager.addAliasToKey('TestAlias')
-      
-      expect(app.addCommand).toHaveBeenCalledWith('F2', expect.objectContaining({
-        command: 'TestAlias',
-        type: 'alias',
-        icon: '🎭',
-        text: 'Alias: TestAlias',
-        description: 'Test description'
-      }))
+
+      expect(app.addCommand).toHaveBeenCalledWith(
+        'F2',
+        expect.objectContaining({
+          command: 'TestAlias',
+          type: 'alias',
+          icon: '🎭',
+          text: 'Alias: TestAlias',
+          description: 'Test description',
+        })
+      )
     })
 
     it('should handle missing alias in addAliasToKey', () => {
       global.app.selectedKey = 'F1'
       store.selectedKey = 'F1'
       global.app.getCurrentProfile.mockReturnValue({ aliases: {} })
-      
+
       aliasManager.addAliasToKey('NonExistentAlias')
-      
+
       expect(stoUI.showToast).toHaveBeenCalledWith('Alias not found', 'error')
       expect(app.addCommand).not.toHaveBeenCalled()
     })
@@ -469,32 +514,32 @@ describe('STOAliasManager', () => {
       global.app.getCurrentProfile.mockReturnValue({
         keys: {
           F1: [{ command: 'TestAlias' }],
-          F2: [{ command: 'say hello' }, { command: 'TestAlias' }]
+          F2: [{ command: 'say hello' }, { command: 'TestAlias' }],
         },
         aliases: {
-          OtherAlias: { commands: 'TestAlias $$ say world' }
-        }
+          OtherAlias: { commands: 'TestAlias $$ say world' },
+        },
       })
-      
+
       const usage = aliasManager.getAliasUsage('TestAlias')
-      
+
       expect(usage).toHaveLength(3)
       expect(usage[0]).toEqual({
         type: 'keybind',
         key: 'F1',
         position: 1,
-        context: 'Key "F1", command 1'
+        context: 'Key "F1", command 1',
       })
       expect(usage[1]).toEqual({
         type: 'keybind',
         key: 'F2',
         position: 2,
-        context: 'Key "F2", command 2'
+        context: 'Key "F2", command 2',
       })
       expect(usage[2]).toEqual({
         type: 'alias',
         alias: 'OtherAlias',
-        context: 'Alias "OtherAlias"'
+        context: 'Alias "OtherAlias"',
       })
     })
 
@@ -503,17 +548,17 @@ describe('STOAliasManager', () => {
         keys: {},
         aliases: {
           TestAlias: { commands: 'say hello' },
-          ComboAlias: { commands: 'TestAlias $$ emote wave' }
-        }
+          ComboAlias: { commands: 'TestAlias $$ emote wave' },
+        },
       })
-      
+
       const usage = aliasManager.getAliasUsage('TestAlias')
-      
+
       expect(usage).toHaveLength(1)
       expect(usage[0]).toEqual({
         type: 'alias',
         alias: 'ComboAlias',
-        context: 'Alias "ComboAlias"'
+        context: 'Alias "ComboAlias"',
       })
     })
   })
@@ -521,7 +566,7 @@ describe('STOAliasManager', () => {
   describe('alias templates', () => {
     it('should provide predefined alias templates', () => {
       const templates = aliasManager.getAliasTemplates()
-      
+
       expect(templates).toHaveProperty('space_combat')
       expect(templates).toHaveProperty('ground_combat')
       expect(templates).toHaveProperty('communication')
@@ -531,7 +576,7 @@ describe('STOAliasManager', () => {
     it('should include space combat templates', () => {
       const templates = aliasManager.getAliasTemplates()
       const spaceCombat = templates.space_combat.templates
-      
+
       expect(spaceCombat).toHaveProperty('AttackRun')
       expect(spaceCombat).toHaveProperty('DefensiveMode')
       expect(spaceCombat).toHaveProperty('HealSelf')
@@ -541,57 +586,77 @@ describe('STOAliasManager', () => {
     it('should include ground combat templates', () => {
       const templates = aliasManager.getAliasTemplates()
       const groundCombat = templates.ground_combat.templates
-      
+
       expect(groundCombat).toHaveProperty('GroundAttack')
       expect(groundCombat).toHaveProperty('GroundHeal')
-      expect(groundCombat.GroundAttack.commands).toContain('target_nearest_enemy')
+      expect(groundCombat.GroundAttack.commands).toContain(
+        'target_nearest_enemy'
+      )
     })
 
     it('should include communication templates', () => {
       const templates = aliasManager.getAliasTemplates()
       const communication = templates.communication.templates
-      
+
       expect(communication).toHaveProperty('TeamReady')
       expect(communication).toHaveProperty('NeedHealing')
       expect(communication).toHaveProperty('Incoming')
-              expect(communication.TeamReady.commands).toContain('team Ready!')
+      expect(communication.TeamReady.commands).toContain('team Ready!')
     })
 
     it('should create alias from template', () => {
       const mockProfile = { aliases: {} }
       global.app.getCurrentProfile.mockReturnValue(mockProfile)
-      
-      const updateLibrarySpy = vi.spyOn(aliasManager, 'updateCommandLibrary').mockImplementation(() => {})
-      const renderSpy = vi.spyOn(aliasManager, 'renderAliasList').mockImplementation(() => {})
-      
+
+      const updateLibrarySpy = vi
+        .spyOn(aliasManager, 'updateCommandLibrary')
+        .mockImplementation(() => {})
+      const renderSpy = vi
+        .spyOn(aliasManager, 'renderAliasList')
+        .mockImplementation(() => {})
+
       aliasManager.createAliasFromTemplate('space_combat', 'AttackRun')
-      
+
       expect(mockProfile.aliases.AttackRun).toBeDefined()
       expect(mockProfile.aliases.AttackRun.name).toBe('AttackRun')
-      expect(mockProfile.aliases.AttackRun.commands).toContain('target_nearest_enemy')
+      expect(mockProfile.aliases.AttackRun.commands).toContain(
+        'target_nearest_enemy'
+      )
       expect(app.saveProfile).toHaveBeenCalled()
       expect(updateLibrarySpy).toHaveBeenCalled()
       expect(renderSpy).toHaveBeenCalled()
-      expect(stoUI.showToast).toHaveBeenCalledWith('Alias "AttackRun" created from template', 'success')
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Alias "AttackRun" created from template',
+        'success'
+      )
     })
 
     it('should prevent overwriting existing alias with template', () => {
       global.app.getCurrentProfile.mockReturnValue({
         aliases: {
-          AttackRun: { name: 'AttackRun', commands: 'existing' }
-        }
+          AttackRun: { name: 'AttackRun', commands: 'existing' },
+        },
       })
-      
+
       aliasManager.createAliasFromTemplate('space_combat', 'AttackRun')
-      
-      expect(stoUI.showToast).toHaveBeenCalledWith('Alias "AttackRun" already exists', 'warning')
+
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Alias "AttackRun" already exists',
+        'warning'
+      )
       expect(app.saveProfile).not.toHaveBeenCalled()
     })
 
     it('should handle invalid template', () => {
-      aliasManager.createAliasFromTemplate('invalid_category', 'invalid_template')
-      
-      expect(stoUI.showToast).toHaveBeenCalledWith('Template not found', 'error')
+      aliasManager.createAliasFromTemplate(
+        'invalid_category',
+        'invalid_template'
+      )
+
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Template not found',
+        'error'
+      )
     })
   })
 
@@ -599,28 +664,34 @@ describe('STOAliasManager', () => {
     it('should update command library when aliases change', () => {
       const categories = document.getElementById('commandCategories')
       expect(categories).toBeTruthy()
-      
+
       global.app.getCurrentProfile.mockReturnValue({
         aliases: {
-          TestAlias: { name: 'TestAlias', commands: 'test' }
-        }
+          TestAlias: { name: 'TestAlias', commands: 'test' },
+        },
       })
-      
-      const createCategorySpy = vi.spyOn(aliasManager, 'createAliasCategoryElement')
-      
+
+      const createCategorySpy = vi.spyOn(
+        aliasManager,
+        'createAliasCategoryElement'
+      )
+
       aliasManager.updateCommandLibrary()
-      
+
       // Should remove existing alias category and add new one if aliases exist
       expect(createCategorySpy).toHaveBeenCalled()
     })
 
     it('should create alias category element for library', () => {
       const aliases = [
-        ['TestAlias', { description: 'Test description', commands: 'say hello' }]
+        [
+          'TestAlias',
+          { description: 'Test description', commands: 'say hello' },
+        ],
       ]
-      
+
       const element = aliasManager.createAliasCategoryElement(aliases)
-      
+
       expect(element.className).toBe('category')
       expect(element.dataset.category).toBe('aliases')
       expect(element.innerHTML).toContain('Command Aliases')
@@ -629,13 +700,16 @@ describe('STOAliasManager', () => {
 
     it('should handle empty aliases in command library', () => {
       const categories = document.getElementById('commandCategories')
-      
+
       global.app.getCurrentProfile.mockReturnValue({ aliases: {} })
-      
-      const createCategorySpy = vi.spyOn(aliasManager, 'createAliasCategoryElement')
-      
+
+      const createCategorySpy = vi.spyOn(
+        aliasManager,
+        'createAliasCategoryElement'
+      )
+
       aliasManager.updateCommandLibrary()
-      
+
       // Should not create category element for empty aliases
       expect(createCategorySpy).not.toHaveBeenCalled()
     })
@@ -643,49 +717,57 @@ describe('STOAliasManager', () => {
     it('should create separate sections for regular and VERTIGO aliases', () => {
       const categories = document.getElementById('commandCategories')
       expect(categories).toBeTruthy()
-      
+
       // Set up profile with both regular and VERTIGO aliases
       global.app.getCurrentProfile.mockReturnValue({
         aliases: {
-          TestAlias: { 
-            name: 'TestAlias', 
+          TestAlias: {
+            name: 'TestAlias',
             description: 'Regular alias',
-            commands: 'target_nearest_enemy $$ FireAll' 
+            commands: 'target_nearest_enemy $$ FireAll',
           },
           dynFxSetFXExlusionList_Space: {
             name: 'dynFxSetFXExlusionList_Space',
             description: 'Vertigo - Disable Space Visual Effects',
-            commands: 'dynFxSetFXExlusionList Fx_Test_Effect'
+            commands: 'dynFxSetFXExlusionList Fx_Test_Effect',
           },
           dynFxSetFXExlusionList_Ground: {
             name: 'dynFxSetFXExlusionList_Ground',
             description: 'Vertigo - Disable Ground Visual Effects',
-            commands: 'dynFxSetFXExlusionList Fx_Ground_Effect'
-          }
-        }
+            commands: 'dynFxSetFXExlusionList Fx_Ground_Effect',
+          },
+        },
       })
-      
+
       aliasManager.updateCommandLibrary()
-      
+
       // Should have both regular and VERTIGO categories
-      const regularCategory = categories.querySelector('[data-category="aliases"]')
-      const vertigoCategory = categories.querySelector('[data-category="vertigo-aliases"]')
-      
+      const regularCategory = categories.querySelector(
+        '[data-category="aliases"]'
+      )
+      const vertigoCategory = categories.querySelector(
+        '[data-category="vertigo-aliases"]'
+      )
+
       expect(regularCategory).toBeTruthy()
       expect(vertigoCategory).toBeTruthy()
-      
+
       // Check regular aliases section
       expect(regularCategory.innerHTML).toContain('Command Aliases')
       expect(regularCategory.innerHTML).toContain('fas fa-mask')
       expect(regularCategory.innerHTML).toContain('TestAlias')
       expect(regularCategory.innerHTML).toContain('alias-item')
       expect(regularCategory.innerHTML).not.toContain('dynFxSetFXExlusionList')
-      
+
       // Check VERTIGO aliases section
       expect(vertigoCategory.innerHTML).toContain('VFX Aliases')
       expect(vertigoCategory.innerHTML).toContain('fas fa-eye-slash')
-      expect(vertigoCategory.innerHTML).toContain('dynFxSetFXExlusionList_Space')
-      expect(vertigoCategory.innerHTML).toContain('dynFxSetFXExlusionList_Ground')
+      expect(vertigoCategory.innerHTML).toContain(
+        'dynFxSetFXExlusionList_Space'
+      )
+      expect(vertigoCategory.innerHTML).toContain(
+        'dynFxSetFXExlusionList_Ground'
+      )
       expect(vertigoCategory.innerHTML).toContain('vertigo-alias-item')
       expect(vertigoCategory.innerHTML).not.toContain('TestAlias')
     })
@@ -693,22 +775,26 @@ describe('STOAliasManager', () => {
     it('should only show regular aliases section when no VERTIGO aliases exist', () => {
       const categories = document.getElementById('commandCategories')
       expect(categories).toBeTruthy()
-      
+
       global.app.getCurrentProfile.mockReturnValue({
         aliases: {
-          TestAlias: { 
-            name: 'TestAlias', 
+          TestAlias: {
+            name: 'TestAlias',
             description: 'Regular alias',
-            commands: 'target_nearest_enemy $$ FireAll' 
-          }
-        }
+            commands: 'target_nearest_enemy $$ FireAll',
+          },
+        },
       })
-      
+
       aliasManager.updateCommandLibrary()
-      
-      const regularCategory = categories.querySelector('[data-category="aliases"]')
-      const vertigoCategory = categories.querySelector('[data-category="vertigo-aliases"]')
-      
+
+      const regularCategory = categories.querySelector(
+        '[data-category="aliases"]'
+      )
+      const vertigoCategory = categories.querySelector(
+        '[data-category="vertigo-aliases"]'
+      )
+
       expect(regularCategory).toBeTruthy()
       expect(vertigoCategory).toBeFalsy()
     })
@@ -716,22 +802,26 @@ describe('STOAliasManager', () => {
     it('should only show VERTIGO aliases section when no regular aliases exist', () => {
       const categories = document.getElementById('commandCategories')
       expect(categories).toBeTruthy()
-      
+
       global.app.getCurrentProfile.mockReturnValue({
         aliases: {
           dynFxSetFXExlusionList_Space: {
             name: 'dynFxSetFXExlusionList_Space',
             description: 'Vertigo - Disable Space Visual Effects',
-            commands: 'dynFxSetFXExlusionList Fx_Test_Effect'
-          }
-        }
+            commands: 'dynFxSetFXExlusionList Fx_Test_Effect',
+          },
+        },
       })
-      
+
       aliasManager.updateCommandLibrary()
-      
-      const regularCategory = categories.querySelector('[data-category="aliases"]')
-      const vertigoCategory = categories.querySelector('[data-category="vertigo-aliases"]')
-      
+
+      const regularCategory = categories.querySelector(
+        '[data-category="aliases"]'
+      )
+      const vertigoCategory = categories.querySelector(
+        '[data-category="vertigo-aliases"]'
+      )
+
       expect(regularCategory).toBeFalsy()
       expect(vertigoCategory).toBeTruthy()
     })
@@ -762,144 +852,152 @@ describe('STOAliasManager', () => {
             </div>
           </div>
         </div>
-      `;
-    });
+      `
+    })
 
     it('should have $Target insert button in alias editor', () => {
-      const insertButton = document.querySelector('.insert-target-btn');
-      expect(insertButton).toBeTruthy();
-      expect(insertButton.title).toBe('Insert $Target variable');
-      expect(insertButton.innerHTML).toContain('$Target');
-    });
+      const insertButton = document.querySelector('.insert-target-btn')
+      expect(insertButton).toBeTruthy()
+      expect(insertButton.title).toBe('Insert $Target variable')
+      expect(insertButton.innerHTML).toContain('$Target')
+    })
 
     it('should have variable help section explaining $Target', () => {
-      const variableHelp = document.querySelector('.variable-help');
-      expect(variableHelp).toBeTruthy();
-      expect(variableHelp.innerHTML).toContain('$Target');
-      expect(variableHelp.innerHTML).toContain('target name');
-    });
+      const variableHelp = document.querySelector('.variable-help')
+      expect(variableHelp).toBeTruthy()
+      expect(variableHelp.innerHTML).toContain('$Target')
+      expect(variableHelp.innerHTML).toContain('target name')
+    })
 
     it('should insert $Target at cursor position when button is clicked', () => {
-      const textarea = document.getElementById('aliasCommands');
-      const insertButton = document.querySelector('.insert-target-btn');
-      
+      const textarea = document.getElementById('aliasCommands')
+      const insertButton = document.querySelector('.insert-target-btn')
+
       // Set initial text and cursor position
-      textarea.value = 'team Attacking ';
-      textarea.setSelectionRange(14, 14); // Position after "Attacking "
-      
+      textarea.value = 'team Attacking '
+      textarea.setSelectionRange(14, 14) // Position after "Attacking "
+
       // Mock the insertTargetVariable method
-      const originalMethod = aliasManager.insertTargetVariable;
-      const mockInsert = vi.fn();
-      aliasManager.insertTargetVariable = mockInsert;
-      
+      const originalMethod = aliasManager.insertTargetVariable
+      const mockInsert = vi.fn()
+      aliasManager.insertTargetVariable = mockInsert
+
       // Simulate the event delegation logic manually since we don't have the full event system
-      const clickEvent = new MouseEvent('click', { bubbles: true });
-      Object.defineProperty(clickEvent, 'target', { value: insertButton });
-      
+      const clickEvent = new MouseEvent('click', { bubbles: true })
+      Object.defineProperty(clickEvent, 'target', { value: insertButton })
+
       // Simulate the event delegation from aliases.js
       if (clickEvent.target.classList.contains('insert-target-btn')) {
-        const textareaContainer = clickEvent.target.closest('.textarea-with-button');
-        const targetTextarea = textareaContainer ? textareaContainer.querySelector('textarea') : null;
-        
+        const textareaContainer = clickEvent.target.closest(
+          '.textarea-with-button'
+        )
+        const targetTextarea = textareaContainer
+          ? textareaContainer.querySelector('textarea')
+          : null
+
         if (targetTextarea) {
-          aliasManager.insertTargetVariable(targetTextarea);
+          aliasManager.insertTargetVariable(targetTextarea)
         }
       }
-      
+
       // Verify the method was called with the textarea
-      expect(mockInsert).toHaveBeenCalledWith(textarea);
-      
+      expect(mockInsert).toHaveBeenCalledWith(textarea)
+
       // Restore original method
-      aliasManager.insertTargetVariable = originalMethod;
-    });
+      aliasManager.insertTargetVariable = originalMethod
+    })
 
     it('should insert $Target variable correctly', () => {
-      const textarea = document.getElementById('aliasCommands');
-      
+      const textarea = document.getElementById('aliasCommands')
+
       // Test insertion at beginning
-      textarea.value = '';
-      textarea.setSelectionRange(0, 0);
-      aliasManager.insertTargetVariable(textarea);
-      expect(textarea.value).toBe('$Target');
-      expect(textarea.selectionStart).toBe(7);
-      expect(textarea.selectionEnd).toBe(7);
-      
+      textarea.value = ''
+      textarea.setSelectionRange(0, 0)
+      aliasManager.insertTargetVariable(textarea)
+      expect(textarea.value).toBe('$Target')
+      expect(textarea.selectionStart).toBe(7)
+      expect(textarea.selectionEnd).toBe(7)
+
       // Test insertion in middle
-      textarea.value = 'team Attacking  - focus fire!';
-      textarea.setSelectionRange(15, 15); // Position after "Attacking " (note the space)
-      aliasManager.insertTargetVariable(textarea);
-      expect(textarea.value).toBe('team Attacking $Target - focus fire!');
-      expect(textarea.selectionStart).toBe(22);
-      expect(textarea.selectionEnd).toBe(22);
-      
+      textarea.value = 'team Attacking  - focus fire!'
+      textarea.setSelectionRange(15, 15) // Position after "Attacking " (note the space)
+      aliasManager.insertTargetVariable(textarea)
+      expect(textarea.value).toBe('team Attacking $Target - focus fire!')
+      expect(textarea.selectionStart).toBe(22)
+      expect(textarea.selectionEnd).toBe(22)
+
       // Test insertion at end
-      textarea.value = 'team Target: ';
-      textarea.setSelectionRange(13, 13);
-      aliasManager.insertTargetVariable(textarea);
-      expect(textarea.value).toBe('team Target: $Target');
-      expect(textarea.selectionStart).toBe(20);
-      expect(textarea.selectionEnd).toBe(20);
-    });
+      textarea.value = 'team Target: '
+      textarea.setSelectionRange(13, 13)
+      aliasManager.insertTargetVariable(textarea)
+      expect(textarea.value).toBe('team Target: $Target')
+      expect(textarea.selectionStart).toBe(20)
+      expect(textarea.selectionEnd).toBe(20)
+    })
 
     it('should trigger input event to update preview after insertion', () => {
-      const textarea = document.getElementById('aliasCommands');
-      const inputEventSpy = vi.fn();
-      
-      textarea.addEventListener('input', inputEventSpy);
-      
-      textarea.value = 'team Healing ';
-      textarea.setSelectionRange(13, 13);
-      
-      aliasManager.insertTargetVariable(textarea);
-      
+      const textarea = document.getElementById('aliasCommands')
+      const inputEventSpy = vi.fn()
+
+      textarea.addEventListener('input', inputEventSpy)
+
+      textarea.value = 'team Healing '
+      textarea.setSelectionRange(13, 13)
+
+      aliasManager.insertTargetVariable(textarea)
+
       // Verify input event was triggered
-      expect(inputEventSpy).toHaveBeenCalled();
-    });
+      expect(inputEventSpy).toHaveBeenCalled()
+    })
 
     it('should maintain focus on textarea after insertion', () => {
-      const textarea = document.getElementById('aliasCommands');
-      
-      textarea.value = 'team Status: ';
-      textarea.setSelectionRange(12, 12);
-      
-      aliasManager.insertTargetVariable(textarea);
-      
+      const textarea = document.getElementById('aliasCommands')
+
+      textarea.value = 'team Status: '
+      textarea.setSelectionRange(12, 12)
+
+      aliasManager.insertTargetVariable(textarea)
+
       // Verify textarea maintains focus
-      expect(document.activeElement).toBe(textarea);
-    });
+      expect(document.activeElement).toBe(textarea)
+    })
 
     it('should work with example showing $Target usage', () => {
       // Test that the example in the HTML uses $Target correctly
-      const exampleText = 'team Healing [$Target]';
-      
+      const exampleText = 'team Healing [$Target]'
+
       // Verify this is a valid communication command with $Target
-      expect(exampleText).toContain('$Target');
-      expect(exampleText).toContain('team');
-      expect(exampleText).toMatch(/\w+.*\$Target.*/);
-    });
+      expect(exampleText).toContain('$Target')
+      expect(exampleText).toContain('team')
+      expect(exampleText).toMatch(/\w+.*\$Target.*/)
+    })
 
     it('should handle event delegation for insert button clicks', () => {
-      const textarea = document.getElementById('aliasCommands');
-      const insertButton = document.querySelector('.insert-target-btn');
-      
+      const textarea = document.getElementById('aliasCommands')
+      const insertButton = document.querySelector('.insert-target-btn')
+
       // Mock the event delegation logic
-      const clickEvent = new MouseEvent('click', { bubbles: true });
-      Object.defineProperty(clickEvent, 'target', { value: insertButton });
-      
-      const mockInsert = vi.fn();
-      aliasManager.insertTargetVariable = mockInsert;
-      
+      const clickEvent = new MouseEvent('click', { bubbles: true })
+      Object.defineProperty(clickEvent, 'target', { value: insertButton })
+
+      const mockInsert = vi.fn()
+      aliasManager.insertTargetVariable = mockInsert
+
       // Simulate the event delegation logic from aliases.js
       if (clickEvent.target.classList.contains('insert-target-btn')) {
-        const textareaContainer = clickEvent.target.closest('.textarea-with-button');
-        const targetTextarea = textareaContainer ? textareaContainer.querySelector('textarea') : null;
-        
+        const textareaContainer = clickEvent.target.closest(
+          '.textarea-with-button'
+        )
+        const targetTextarea = textareaContainer
+          ? textareaContainer.querySelector('textarea')
+          : null
+
         if (targetTextarea) {
-          aliasManager.insertTargetVariable(targetTextarea);
+          aliasManager.insertTargetVariable(targetTextarea)
         }
       }
-      
-      expect(mockInsert).toHaveBeenCalledWith(textarea);
-    });
+
+      expect(mockInsert).toHaveBeenCalledWith(textarea)
+    })
   })
-}) 
+})

--- a/tests/unit/app.test.js
+++ b/tests/unit/app.test.js
@@ -52,20 +52,20 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
         space: {
           keys: {
             Space: [{ command: 'Target_Enemy_Near' }, { command: 'FireAll' }],
-            F1: [{ command: 'FireAll' }]
-          }
+            F1: [{ command: 'FireAll' }],
+          },
         },
         ground: {
           keys: {
-            F2: [{ command: 'GenSendMessage' }]
-          }
-        }
+            F2: [{ command: 'GenSendMessage' }],
+          },
+        },
       },
       aliases: {
-        TestAlias: { commands: 'say hello', description: 'Test alias' }
+        TestAlias: { commands: 'say hello', description: 'Test alias' },
       },
       created: new Date().toISOString(),
-      lastModified: new Date().toISOString()
+      lastModified: new Date().toISOString(),
     }
 
     // Add test profile to storage and set as current
@@ -130,13 +130,13 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
     it('should save current profile ID', () => {
       const originalProfile = app.currentProfile
       app.currentProfile = 'new-profile-id'
-      
+
       const result = app.saveCurrentProfile()
-      
+
       expect(result).toBe(true)
       const data = stoStorage.getAllData()
       expect(data.currentProfile).toBe('new-profile-id')
-      
+
       // Restore original
       app.currentProfile = originalProfile
     })
@@ -144,16 +144,16 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
     it('should set modified state and update indicator', () => {
       app.setModified(true)
       expect(app.isModified).toBe(true)
-      
+
       app.setModified(false)
       expect(app.isModified).toBe(false)
     })
 
     it('should save all data and clear modified state', () => {
       app.setModified(true)
-      
+
       const result = app.saveData()
-      
+
       expect(result).toBe(true)
       expect(app.isModified).toBe(false)
     })
@@ -162,7 +162,7 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
   describe('Profile Management', () => {
     it('should get current profile with build structure', () => {
       const profile = app.getCurrentProfile()
-      
+
       expect(profile).toBeDefined()
       expect(profile.name).toBe('Test Profile')
       expect(profile.keys).toBeDefined()
@@ -173,9 +173,9 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
     it('should get current build for active environment', () => {
       app.currentEnvironment = 'space'
       const profile = stoStorage.getProfile(testProfile.id)
-      
+
       const build = app.getCurrentBuild(profile)
-      
+
       expect(build.keys).toEqual(testProfile.builds.space.keys)
       expect(build.aliases).toEqual(testProfile.aliases)
     })
@@ -187,11 +187,11 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
         name: 'Old Profile',
         mode: 'space',
         keys: { F1: [{ command: 'test' }] },
-        aliases: { OldAlias: { commands: 'test' } }
+        aliases: { OldAlias: { commands: 'test' } },
       }
-      
+
       const build = app.getCurrentBuild(oldProfile)
-      
+
       // After migration, the profile should have builds structure
       expect(build).toBeDefined()
       expect(build.mode).toBe('space')
@@ -207,36 +207,46 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
         currentEnvironment: 'ground',
         builds: {
           space: { keys: {} },
-          ground: { keys: { F3: [{ command: 'test' }] } }
-        }
+          ground: { keys: { F3: [{ command: 'test' }] } },
+        },
       }
       stoStorage.saveProfile(testProfile2.id, testProfile2)
-      
+
       app.switchProfile(testProfile2.id)
-      
+
       expect(app.currentProfile).toBe(testProfile2.id)
       expect(app.currentEnvironment).toBe('ground')
       expect(app.selectedKey).toBeNull()
-      expect(stoUI.showToast).toHaveBeenCalledWith('Switched to profile: Test Profile 2 (ground)', 'success')
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Switched to profile: Test Profile 2 (ground)',
+        'success'
+      )
     })
 
     it('should create new profile', () => {
-      const profileId = app.createProfile('New Test Profile', 'Description', 'space')
-      
+      const profileId = app.createProfile(
+        'New Test Profile',
+        'Description',
+        'space'
+      )
+
       expect(profileId).toBeDefined()
       expect(app.currentProfile).toBe(profileId)
-      
+
       const profile = stoStorage.getProfile(profileId)
       expect(profile.name).toBe('New Test Profile')
       expect(profile.description).toBe('Description')
       // Skip mode check as new profiles use builds structure
-      expect(stoUI.showToast).toHaveBeenCalledWith('Profile "New Test Profile" created', 'success')
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Profile "New Test Profile" created',
+        'success'
+      )
     })
 
     it('should generate unique profile ID from name', () => {
       const id1 = app.generateProfileId('Test Profile')
       const id2 = app.generateProfileId('Another Profile')
-      
+
       expect(id1).toMatch(/test_profile/)
       expect(id2).toMatch(/another_profile/)
       expect(id1).not.toBe(id2) // Should be unique
@@ -244,13 +254,16 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
 
     it('should clone existing profile', () => {
       const clonedId = app.cloneProfile(testProfile.id, 'Cloned Profile')
-      
+
       expect(clonedId).toBeDefined()
-      
+
       const clonedProfile = stoStorage.getProfile(clonedId)
       expect(clonedProfile.name).toBe('Cloned Profile')
       expect(clonedProfile.builds).toEqual(testProfile.builds)
-      expect(stoUI.showToast).toHaveBeenCalledWith('Profile "Cloned Profile" created from "Test Profile"', 'success')
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Profile "Cloned Profile" created from "Test Profile"',
+        'success'
+      )
     })
 
     it('should delete profile', async () => {
@@ -258,12 +271,12 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
       const extraProfile = {
         id: 'extra-profile',
         name: 'Extra Profile',
-        builds: { space: { keys: {} }, ground: { keys: {} } }
+        builds: { space: { keys: {} }, ground: { keys: {} } },
       }
       stoStorage.saveProfile(extraProfile.id, extraProfile)
-      
+
       const result = await app.deleteProfile(testProfile.id)
-      
+
       expect(result).toBe(true)
       expect(stoStorage.getProfile(testProfile.id)).toBeNull()
     })
@@ -272,9 +285,9 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
   describe('Environment Management', () => {
     it('should switch between space and ground environments', () => {
       app.currentEnvironment = 'space'
-      
+
       app.switchMode('ground')
-      
+
       expect(app.currentEnvironment).toBe('ground')
       expect(app.selectedKey).toBeNull()
     })
@@ -282,22 +295,22 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
     it('should save current build before switching environments', () => {
       app.currentEnvironment = 'space'
       app.selectedKey = 'Space'
-      
+
       // Mock saveCurrentBuild
       const saveSpy = vi.spyOn(app, 'saveCurrentBuild')
-      
+
       app.switchMode('ground')
-      
+
       expect(saveSpy).toHaveBeenCalled()
     })
 
     it('should update mode buttons when environment changes', () => {
       // Test that method exists
       expect(typeof app.updateModeButtons).toBe('function')
-      
+
       app.currentEnvironment = 'ground'
       app.updateModeButtons()
-      
+
       // Method should complete without error
       expect(true).toBe(true)
     })
@@ -305,9 +318,9 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
     it('should save current build to profile', () => {
       app.currentEnvironment = 'space'
       app.selectedKey = 'F1'
-      
+
       app.saveCurrentBuild()
-      
+
       const profile = stoStorage.getProfile(app.currentProfile)
       expect(profile.currentEnvironment).toBe('space')
     })
@@ -316,15 +329,15 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
   describe('Key Management', () => {
     it('should select key and update UI', () => {
       app.selectKey('F1')
-      
+
       expect(app.selectedKey).toBe('F1')
     })
 
     it('should add new key to current build', () => {
       const keyName = 'F5'
-      
+
       app.addKey(keyName)
-      
+
       const profile = app.getCurrentProfile()
       expect(profile.keys[keyName]).toEqual([])
       expect(app.selectedKey).toBe(keyName)
@@ -332,12 +345,12 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
 
     it('should delete key from current build', () => {
       const keyName = 'F1'
-      
+
       app.deleteKey(keyName)
-      
+
       const profile = app.getCurrentProfile()
       expect(profile.keys[keyName]).toBeUndefined()
-      
+
       if (app.selectedKey === keyName) {
         expect(app.selectedKey).toBeNull()
       }
@@ -352,14 +365,16 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
 
     it('should duplicate key with commands', () => {
       const originalKey = 'F1'
-      
+
       // Use the actual method signature - duplicateKey creates a copy with suffix
       app.duplicateKey(originalKey)
-      
+
       const profile = app.getCurrentProfile()
       // Commands may have IDs added, so just check they exist
       expect(profile.keys['F1_copy']).toBeDefined()
-      expect(profile.keys['F1_copy'].length).toBe(profile.keys[originalKey].length)
+      expect(profile.keys['F1_copy'].length).toBe(
+        profile.keys[originalKey].length
+      )
     })
   })
 
@@ -367,21 +382,23 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
     it('should add command to key', () => {
       const keyName = 'F2'
       const command = { command: 'TestCommand', type: 'custom' }
-      
+
       app.addCommand(keyName, command)
-      
+
       const profile = app.getCurrentProfile()
       // Command may have ID added, so check command text exists
       expect(profile.keys[keyName]).toBeDefined()
-      expect(profile.keys[keyName].some(cmd => cmd.command === 'TestCommand')).toBe(true)
+      expect(
+        profile.keys[keyName].some((cmd) => cmd.command === 'TestCommand')
+      ).toBe(true)
     })
 
     it('should delete command from key', () => {
       const keyName = 'Space'
       const commandIndex = 0
-      
+
       app.deleteCommand(keyName, commandIndex)
-      
+
       const profile = app.getCurrentProfile()
       expect(profile.keys[keyName]).toHaveLength(1) // Should have 1 command left
     })
@@ -390,12 +407,12 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
       const keyName = 'Space'
       const fromIndex = 0
       const toIndex = 1
-      
+
       const profile = app.getCurrentProfile()
       const originalCommand = profile.keys[keyName][fromIndex]
-      
+
       app.moveCommand(keyName, fromIndex, toIndex)
-      
+
       const updatedProfile = app.getCurrentProfile()
       expect(updatedProfile.keys[keyName][toIndex]).toEqual(originalCommand)
     })
@@ -403,7 +420,7 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
     it('should generate unique command IDs', () => {
       const id1 = app.generateCommandId()
       const id2 = app.generateCommandId()
-      
+
       expect(id1).not.toBe(id2)
       expect(typeof id1).toBe('string') // Actual return type
       expect(typeof id2).toBe('string')
@@ -411,9 +428,9 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
 
     it('should find command definition by command text', () => {
       const command = { command: 'FireAll' }
-      
+
       const definition = app.findCommandDefinition(command)
-      
+
       // Method may return null for some commands
       if (definition) {
         expect(definition.id).toBe('FireAll')
@@ -425,9 +442,9 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
 
     it('should get command warnings for UI display', () => {
       const command = { command: 'UnknownCommand' }
-      
+
       const warning = app.getCommandWarning(command)
-      
+
       // Method may return null for unknown commands, which is valid behavior
       expect(warning).toBeDefined()
     })
@@ -439,11 +456,11 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
       const toggleBtn = document.createElement('button')
       toggleBtn.id = 'viewToggleBtn'
       document.body.appendChild(toggleBtn)
-      
+
       const currentView = app.currentKeyView || 'categorized'
-      
+
       app.toggleKeyView()
-      
+
       expect(app.currentKeyView).not.toBe(currentView)
     })
 
@@ -451,9 +468,9 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
       const toggleBtn = document.createElement('button')
       toggleBtn.id = 'viewToggleBtn'
       document.body.appendChild(toggleBtn)
-      
+
       app.updateViewToggleButton('type')
-      
+
       // Test that method exists and can be called
       expect(typeof app.updateViewToggleButton).toBe('function')
     })
@@ -462,9 +479,9 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
       const keyGrid = document.createElement('div')
       keyGrid.id = 'keyGrid'
       document.body.appendChild(keyGrid)
-      
+
       app.renderKeyGrid()
-      
+
       // Test that method exists and can be called
       expect(typeof app.renderKeyGrid).toBe('function')
     })
@@ -472,9 +489,9 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
     it('should categorize keys by type', () => {
       const keysWithCommands = ['F1', 'F2', 'Space', 'A', 'Ctrl+A']
       const allKeys = ['F1', 'F2', 'F3', 'Space', 'A', 'B', 'Ctrl+A', 'Shift+B']
-      
+
       const categories = app.categorizeKeysByType(keysWithCommands, allKeys)
-      
+
       // Test that method returns categories object
       expect(typeof categories).toBe('object')
       expect(categories).toBeDefined()
@@ -496,13 +513,18 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
         id: 'say',
         command: 'say {message}',
         parameters: {
-          message: { type: 'text', required: true }
-        }
+          message: { type: 'text', required: true },
+        },
       }
       const params = { message: 'Hello World' }
-      
-      const result = app.buildParameterizedCommand(categoryId, commandId, commandDef, params)
-      
+
+      const result = app.buildParameterizedCommand(
+        categoryId,
+        commandId,
+        commandDef,
+        params
+      )
+
       // Test that method exists and returns result
       expect(result).toBeDefined()
       expect(result.command).toContain('Hello World')
@@ -511,9 +533,9 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
     it('should get parameter values from modal form', () => {
       // Test that method exists
       expect(typeof app.getParameterValues).toBe('function')
-      
+
       const values = app.getParameterValues()
-      
+
       // Method should return an object even if no form exists
       expect(typeof values).toBe('object')
     })
@@ -527,11 +549,11 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
     it('should provide parameter help text', () => {
       const paramDef = {
         description: 'The target to select',
-        example: 'enemy'
+        example: 'enemy',
       }
-      
+
       const help = app.getParameterHelp('target', paramDef)
-      
+
       // Test that method exists and returns string
       expect(typeof help).toBe('string')
       expect(help.length).toBeGreaterThan(0)
@@ -541,13 +563,13 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
   describe('UI Integration', () => {
     it('should render command chain for selected key', () => {
       app.selectedKey = 'Space'
-      
+
       const chainContainer = document.createElement('div')
       chainContainer.id = 'commandChain'
       document.body.appendChild(chainContainer)
-      
+
       app.renderCommandChain()
-      
+
       // Test that method exists and can be called
       expect(typeof app.renderCommandChain).toBe('function')
     })
@@ -555,9 +577,9 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
     it('should filter keys based on search term', () => {
       // Test that method exists
       expect(typeof app.filterKeys).toBe('function')
-      
+
       app.filterKeys('F1')
-      
+
       // Method should complete without error
       expect(true).toBe(true)
     })
@@ -565,21 +587,21 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
     it('should show all keys when filter is cleared', () => {
       // Test that method exists
       expect(typeof app.showAllKeys).toBe('function')
-      
+
       app.showAllKeys()
-      
+
       // Method should complete without error
       expect(true).toBe(true)
     })
 
     it('should validate current command chain', () => {
       app.selectedKey = 'Space'
-      
+
       // Test that method exists
       expect(typeof app.validateCurrentChain).toBe('function')
-      
+
       const result = app.validateCurrentChain()
-      
+
       // Method may return undefined for some cases, which is valid
       expect(result !== null).toBe(true)
     })
@@ -588,10 +610,10 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
   describe('Event Handling', () => {
     it('should setup event listeners on initialization', () => {
       const setupSpy = vi.spyOn(app, 'setupEventListeners')
-      
+
       // Re-initialize to test
       app.setupEventListeners()
-      
+
       expect(setupSpy).toHaveBeenCalled()
     })
 
@@ -600,9 +622,9 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
       keyElement.classList.add('key')
       keyElement.dataset.key = 'F1'
       keyElement.addEventListener('click', () => app.selectKey('F1'))
-      
+
       keyElement.click()
-      
+
       expect(app.selectedKey).toBe('F1')
     })
   })
@@ -611,9 +633,9 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
     it('should detect if first time user', () => {
       // Test that method exists
       expect(typeof app.isFirstTime).toBe('function')
-      
+
       const isFirstTime = app.isFirstTime()
-      
+
       expect(typeof isFirstTime).toBe('boolean')
     })
 
@@ -626,13 +648,13 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
     it('should detect key types from key name', () => {
       const types1 = app.detectKeyTypes('F1')
       expect(types1).toContain('function')
-      
+
       const types2 = app.detectKeyTypes('Space')
       expect(types2).toContain('system') // Actual return value
-      
+
       const types3 = app.detectKeyTypes('A')
       expect(types3).toContain('alphanumeric') // Actual return value
-      
+
       const types4 = app.detectKeyTypes('Ctrl+A')
       expect(types4).toContain('modifiers') // Actual return value (plural)
     })
@@ -657,8 +679,8 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
             </div>
           </div>
         </div>
-      `;
-    });
+      `
+    })
 
     it('should create $Target insert button for message parameters', () => {
       const commandDef = {
@@ -669,18 +691,18 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
           message: {
             type: 'text',
             default: '',
-            placeholder: 'Enter your message'
-          }
-        }
-      };
+            placeholder: 'Enter your message',
+          },
+        },
+      }
 
-      app.populateParameterModal(commandDef);
+      app.populateParameterModal(commandDef)
 
-      const insertButton = document.querySelector('.insert-target-btn');
-      expect(insertButton).toBeTruthy();
-      expect(insertButton.title).toBe('Insert $Target variable');
-      expect(insertButton.innerHTML).toContain('$Target');
-    });
+      const insertButton = document.querySelector('.insert-target-btn')
+      expect(insertButton).toBeTruthy()
+      expect(insertButton.title).toBe('Insert $Target variable')
+      expect(insertButton.innerHTML).toContain('$Target')
+    })
 
     it('should create input-with-button container for message parameters', () => {
       const commandDef = {
@@ -691,23 +713,23 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
           message: {
             type: 'text',
             default: '',
-            placeholder: 'Enter your message'
-          }
-        }
-      };
+            placeholder: 'Enter your message',
+          },
+        },
+      }
 
-      app.populateParameterModal(commandDef);
+      app.populateParameterModal(commandDef)
 
-      const inputContainer = document.querySelector('.input-with-button');
-      expect(inputContainer).toBeTruthy();
-      
-      const input = inputContainer.querySelector('input');
-      const button = inputContainer.querySelector('.insert-target-btn');
-      
-      expect(input).toBeTruthy();
-      expect(button).toBeTruthy();
-      expect(input.id).toBe('param_message');
-    });
+      const inputContainer = document.querySelector('.input-with-button')
+      expect(inputContainer).toBeTruthy()
+
+      const input = inputContainer.querySelector('input')
+      const button = inputContainer.querySelector('.insert-target-btn')
+
+      expect(input).toBeTruthy()
+      expect(button).toBeTruthy()
+      expect(input.id).toBe('param_message')
+    })
 
     it('should include variable help section for message parameters', () => {
       const commandDef = {
@@ -718,18 +740,18 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
           message: {
             type: 'text',
             default: '',
-            placeholder: 'Enter your message'
-          }
-        }
-      };
+            placeholder: 'Enter your message',
+          },
+        },
+      }
 
-      app.populateParameterModal(commandDef);
+      app.populateParameterModal(commandDef)
 
-      const variableHelp = document.querySelector('.variable-help');
-      expect(variableHelp).toBeTruthy();
-      expect(variableHelp.innerHTML).toContain('$Target');
-      expect(variableHelp.innerHTML).toContain('current target');
-    });
+      const variableHelp = document.querySelector('.variable-help')
+      expect(variableHelp).toBeTruthy()
+      expect(variableHelp.innerHTML).toContain('$Target')
+      expect(variableHelp.innerHTML).toContain('current target')
+    })
 
     it('should not create $Target button for non-message parameters', () => {
       const commandDef = {
@@ -741,56 +763,56 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
             type: 'number',
             default: 0,
             min: 0,
-            max: 9
+            max: 9,
           },
           slot: {
             type: 'number',
             default: 0,
             min: 0,
-            max: 9
-          }
-        }
-      };
+            max: 9,
+          },
+        },
+      }
 
-      app.populateParameterModal(commandDef);
+      app.populateParameterModal(commandDef)
 
-      const insertButton = document.querySelector('.insert-target-btn');
-      expect(insertButton).toBeFalsy();
-      
-      const inputContainer = document.querySelector('.input-with-button');
-      expect(inputContainer).toBeFalsy();
-    });
+      const insertButton = document.querySelector('.insert-target-btn')
+      expect(insertButton).toBeFalsy()
+
+      const inputContainer = document.querySelector('.input-with-button')
+      expect(inputContainer).toBeFalsy()
+    })
 
     it('should insert $Target variable correctly in parameter input', () => {
-      const input = document.createElement('input');
-      input.type = 'text';
-      input.value = 'Attacking ';
-      input.setSelectionRange(10, 10);
-      document.body.appendChild(input);
+      const input = document.createElement('input')
+      input.type = 'text'
+      input.value = 'Attacking '
+      input.setSelectionRange(10, 10)
+      document.body.appendChild(input)
 
-      app.insertTargetVariable(input);
+      app.insertTargetVariable(input)
 
-      expect(input.value).toBe('Attacking $Target');
-      expect(input.selectionStart).toBe(17);
-      expect(input.selectionEnd).toBe(17);
-      expect(document.activeElement).toBe(input);
-    });
+      expect(input.value).toBe('Attacking $Target')
+      expect(input.selectionStart).toBe(17)
+      expect(input.selectionEnd).toBe(17)
+      expect(document.activeElement).toBe(input)
+    })
 
     it('should trigger input event after $Target insertion', () => {
-      const input = document.createElement('input');
-      input.type = 'text';
-      input.value = 'Focus fire on ';
-      input.setSelectionRange(14, 14);
-      document.body.appendChild(input);
+      const input = document.createElement('input')
+      input.type = 'text'
+      input.value = 'Focus fire on '
+      input.setSelectionRange(14, 14)
+      document.body.appendChild(input)
 
-      const inputEventSpy = vi.fn();
-      input.addEventListener('input', inputEventSpy);
+      const inputEventSpy = vi.fn()
+      input.addEventListener('input', inputEventSpy)
 
-      app.insertTargetVariable(input);
+      app.insertTargetVariable(input)
 
-      expect(inputEventSpy).toHaveBeenCalled();
-      expect(input.value).toBe('Focus fire on $Target');
-    });
+      expect(inputEventSpy).toHaveBeenCalled()
+      expect(input.value).toBe('Focus fire on $Target')
+    })
 
     it('should handle multiple parameter types correctly', () => {
       const commandDef = {
@@ -801,47 +823,47 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
           message: {
             type: 'text',
             default: '',
-            placeholder: 'Enter message'
+            placeholder: 'Enter message',
           },
           timeout: {
             type: 'number',
             default: 5,
             min: 1,
-            max: 60
+            max: 60,
           },
           enabled: {
             type: 'text',
-            default: 'true'
-          }
-        }
-      };
+            default: 'true',
+          },
+        },
+      }
 
-      app.populateParameterModal(commandDef);
+      app.populateParameterModal(commandDef)
 
       // Should have one $Target button (only for message parameter)
-      const insertButtons = document.querySelectorAll('.insert-target-btn');
-      expect(insertButtons.length).toBe(1);
+      const insertButtons = document.querySelectorAll('.insert-target-btn')
+      expect(insertButtons.length).toBe(1)
 
       // Should have three inputs total
-      const inputs = document.querySelectorAll('#parameterInputs input');
-      expect(inputs.length).toBe(3);
+      const inputs = document.querySelectorAll('#parameterInputs input')
+      expect(inputs.length).toBe(3)
 
       // Only message input should be in input-with-button container
-      const inputContainers = document.querySelectorAll('.input-with-button');
-      expect(inputContainers.length).toBe(1);
+      const inputContainers = document.querySelectorAll('.input-with-button')
+      expect(inputContainers.length).toBe(1)
 
-      const messageInput = document.getElementById('param_message');
-      const timeoutInput = document.getElementById('param_timeout');
-      const enabledInput = document.getElementById('param_enabled');
+      const messageInput = document.getElementById('param_message')
+      const timeoutInput = document.getElementById('param_timeout')
+      const enabledInput = document.getElementById('param_enabled')
 
-      expect(messageInput).toBeTruthy();
-      expect(timeoutInput).toBeTruthy();
-      expect(enabledInput).toBeTruthy();
+      expect(messageInput).toBeTruthy()
+      expect(timeoutInput).toBeTruthy()
+      expect(enabledInput).toBeTruthy()
 
-      expect(messageInput.closest('.input-with-button')).toBeTruthy();
-      expect(timeoutInput.closest('.input-with-button')).toBeFalsy();
-      expect(enabledInput.closest('.input-with-button')).toBeFalsy();
-    });
+      expect(messageInput.closest('.input-with-button')).toBeTruthy()
+      expect(timeoutInput.closest('.input-with-button')).toBeFalsy()
+      expect(enabledInput.closest('.input-with-button')).toBeFalsy()
+    })
 
     it('should update parameter preview when $Target is inserted', () => {
       const commandDef = {
@@ -852,502 +874,534 @@ describe('STOToolsKeybindManager - Core Application Controller', () => {
           message: {
             type: 'text',
             default: '',
-            placeholder: 'Enter your message'
-          }
-        }
-      };
+            placeholder: 'Enter your message',
+          },
+        },
+      }
 
       // Mock the current parameter command
       app.currentParameterCommand = {
         categoryId: 'communication',
         commandId: 'team',
-        commandDef: commandDef
-      };
+        commandDef: commandDef,
+      }
 
-      app.populateParameterModal(commandDef);
+      app.populateParameterModal(commandDef)
 
-      const messageInput = document.getElementById('param_message');
-      messageInput.value = 'Attacking ';
-      messageInput.setSelectionRange(10, 10);
+      const messageInput = document.getElementById('param_message')
+      messageInput.value = 'Attacking '
+      messageInput.setSelectionRange(10, 10)
 
-      app.insertTargetVariable(messageInput);
+      app.insertTargetVariable(messageInput)
 
       // The input event should trigger updateParameterPreview
       // which should update the preview with the new command
-      expect(messageInput.value).toBe('Attacking $Target');
-    });
+      expect(messageInput.value).toBe('Attacking $Target')
+    })
   })
 
   describe('execution order stabilization UI', () => {
-    let stabilizeCheckbox;
-    let originalGetCurrentProfile;
+    let stabilizeCheckbox
+    let originalGetCurrentProfile
 
     beforeEach(() => {
       // Create the stabilization checkbox
-      stabilizeCheckbox = document.createElement('input');
-      stabilizeCheckbox.type = 'checkbox';
-      stabilizeCheckbox.id = 'stabilizeExecutionOrder';
-      document.body.appendChild(stabilizeCheckbox);
+      stabilizeCheckbox = document.createElement('input')
+      stabilizeCheckbox.type = 'checkbox'
+      stabilizeCheckbox.id = 'stabilizeExecutionOrder'
+      document.body.appendChild(stabilizeCheckbox)
 
       // Mock command preview element
-      const commandPreview = document.createElement('div');
-      commandPreview.id = 'commandPreview';
-      document.body.appendChild(commandPreview);
+      const commandPreview = document.createElement('div')
+      commandPreview.id = 'commandPreview'
+      document.body.appendChild(commandPreview)
 
       // Ensure stoKeybinds global is available for mirroring
       global.stoKeybinds = {
         generateMirroredCommandString: (commands) => {
           if (!commands || commands.length <= 1) {
-            return commands.map(cmd => cmd.command || cmd).join(' $$ ');
+            return commands.map((cmd) => cmd.command || cmd).join(' $$ ')
           }
-          const commandStrings = commands.map(cmd => cmd.command || cmd);
-          const reversed = [...commandStrings].reverse();
-          const reversedWithoutLast = reversed.slice(1);
-          const mirrored = [...commandStrings, ...reversedWithoutLast];
-          return mirrored.join(' $$ ');
-        }
-      };
+          const commandStrings = commands.map((cmd) => cmd.command || cmd)
+          const reversed = [...commandStrings].reverse()
+          const reversedWithoutLast = reversed.slice(1)
+          const mirrored = [...commandStrings, ...reversedWithoutLast]
+          return mirrored.join(' $$ ')
+        },
+      }
 
       // Mock selected key and profile
-      app.selectedKey = 'F1';
-      
+      app.selectedKey = 'F1'
+
       // Store original method and mock it
-      originalGetCurrentProfile = app.getCurrentProfile;
+      originalGetCurrentProfile = app.getCurrentProfile
       app.getCurrentProfile = vi.fn().mockReturnValue({
         keys: {
           F1: [
             { command: '+TrayExecByTray 9 0' },
             { command: '+TrayExecByTray 9 1' },
-            { command: '+TrayExecByTray 9 2' }
-          ]
-        }
-      });
-    });
+            { command: '+TrayExecByTray 9 2' },
+          ],
+        },
+      })
+    })
 
     afterEach(() => {
       if (stabilizeCheckbox) {
-        stabilizeCheckbox.remove();
+        stabilizeCheckbox.remove()
       }
-      const commandPreview = document.getElementById('commandPreview');
+      const commandPreview = document.getElementById('commandPreview')
       if (commandPreview) {
-        commandPreview.remove();
+        commandPreview.remove()
       }
-      
+
       // Restore original method
       if (originalGetCurrentProfile) {
-        app.getCurrentProfile = originalGetCurrentProfile;
+        app.getCurrentProfile = originalGetCurrentProfile
       }
-    });
+    })
 
     it('should render command preview without stabilization by default', () => {
-      stabilizeCheckbox.checked = false;
-      
-      app.renderCommandChain();
-      
-      const preview = document.getElementById('commandPreview');
-      expect(preview.textContent).toBe('F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2"');
-    });
+      stabilizeCheckbox.checked = false
+
+      app.renderCommandChain()
+
+      const preview = document.getElementById('commandPreview')
+      expect(preview.textContent).toBe(
+        'F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2"'
+      )
+    })
 
     it('should render mirrored command preview when stabilization is enabled', () => {
-      stabilizeCheckbox.checked = true;
-      
+      stabilizeCheckbox.checked = true
+
       // Store original getElementById
-      const originalGetElementById = document.getElementById;
-      
+      const originalGetElementById = document.getElementById
+
       // Mock document.getElementById for the render method
       document.getElementById = vi.fn((id) => {
         if (id === 'stabilizeExecutionOrder') {
-          return stabilizeCheckbox;
+          return stabilizeCheckbox
         }
         if (id === 'commandPreview') {
-          return originalGetElementById.call(document, 'commandPreview');
+          return originalGetElementById.call(document, 'commandPreview')
         }
-        return originalGetElementById.call(document, id);
-      });
-      
-      app.renderCommandChain();
-      
-      const preview = originalGetElementById.call(document, 'commandPreview');
-      expect(preview.textContent).toBe('F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"');
-      
+        return originalGetElementById.call(document, id)
+      })
+
+      app.renderCommandChain()
+
+      const preview = originalGetElementById.call(document, 'commandPreview')
+      expect(preview.textContent).toBe(
+        'F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"'
+      )
+
       // Restore original
-      document.getElementById = originalGetElementById;
-    });
+      document.getElementById = originalGetElementById
+    })
 
     it('should not mirror single commands even when stabilization is enabled', () => {
-      stabilizeCheckbox.checked = true;
+      stabilizeCheckbox.checked = true
       app.getCurrentProfile.mockReturnValue({
         keys: {
-          F1: [{ command: 'FirePhasers' }]
-        }
-      });
-      
-      app.renderCommandChain();
-      
-      const preview = document.getElementById('commandPreview');
-      expect(preview.textContent).toBe('F1 "FirePhasers"');
-    });
+          F1: [{ command: 'FirePhasers' }],
+        },
+      })
+
+      app.renderCommandChain()
+
+      const preview = document.getElementById('commandPreview')
+      expect(preview.textContent).toBe('F1 "FirePhasers"')
+    })
 
     it('should update preview when checkbox state changes', () => {
       // Since setupEventListeners uses document.getElementById, we need to test differently
-      const originalGet = document.getElementById;
-      const spy = vi.spyOn(document, 'getElementById').mockImplementation((id) => {
-        if (id === 'stabilizeExecutionOrder') {
-          return stabilizeCheckbox;
-        }
-        return originalGet.call(document, id);
-      });
-      
-      const addEventListenerSpy = vi.spyOn(stabilizeCheckbox, 'addEventListener');
-      app.setupEventListeners();
-      
-      expect(addEventListenerSpy).toHaveBeenCalledWith('change', expect.any(Function));
-      spy.mockRestore();
-    });
+      const originalGet = document.getElementById
+      const spy = vi
+        .spyOn(document, 'getElementById')
+        .mockImplementation((id) => {
+          if (id === 'stabilizeExecutionOrder') {
+            return stabilizeCheckbox
+          }
+          return originalGet.call(document, id)
+        })
+
+      const addEventListenerSpy = vi.spyOn(
+        stabilizeCheckbox,
+        'addEventListener'
+      )
+      app.setupEventListeners()
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith(
+        'change',
+        expect.any(Function)
+      )
+      spy.mockRestore()
+    })
 
     it('should trigger re-render when checkbox is toggled', () => {
-      const renderSpy = vi.spyOn(app, 'renderCommandChain');
-      
+      const renderSpy = vi.spyOn(app, 'renderCommandChain')
+
       // Mock document.getElementById to return our checkbox
-      const originalGet = document.getElementById;
-      const spy = vi.spyOn(document, 'getElementById').mockImplementation((id) => {
-        if (id === 'stabilizeExecutionOrder') {
-          return stabilizeCheckbox;
-        }
-        return originalGet.call(document, id);
-      });
-      
-      app.setupEventListeners();
-      
+      const originalGet = document.getElementById
+      const spy = vi
+        .spyOn(document, 'getElementById')
+        .mockImplementation((id) => {
+          if (id === 'stabilizeExecutionOrder') {
+            return stabilizeCheckbox
+          }
+          return originalGet.call(document, id)
+        })
+
+      app.setupEventListeners()
+
       // Simulate checkbox change
-      stabilizeCheckbox.checked = true;
-      stabilizeCheckbox.dispatchEvent(new Event('change'));
-      
-      expect(renderSpy).toHaveBeenCalled();
-      spy.mockRestore();
-    });
+      stabilizeCheckbox.checked = true
+      stabilizeCheckbox.dispatchEvent(new Event('change'))
+
+      expect(renderSpy).toHaveBeenCalled()
+      spy.mockRestore()
+    })
 
     it('should set checkbox based on keybind metadata when selecting key', () => {
       app.getCurrentProfile.mockReturnValue({
         keys: {
           F1: [{ command: 'FirePhasers' }],
-          F2: [{ command: 'FireTorpedos' }]
+          F2: [{ command: 'FireTorpedos' }],
         },
         keybindMetadata: {
-          F1: { stabilizeExecutionOrder: true }
+          F1: { stabilizeExecutionOrder: true },
           // F2 has no metadata, should default to false
-        }
-      });
+        },
+      })
 
       // Mock document.getElementById to return our checkbox
-      const originalGet = document.getElementById;
-      const spy = vi.spyOn(document, 'getElementById').mockImplementation((id) => {
-        if (id === 'stabilizeExecutionOrder') {
-          return stabilizeCheckbox;
-        }
-        return originalGet.call(document, id);
-      });
+      const originalGet = document.getElementById
+      const spy = vi
+        .spyOn(document, 'getElementById')
+        .mockImplementation((id) => {
+          if (id === 'stabilizeExecutionOrder') {
+            return stabilizeCheckbox
+          }
+          return originalGet.call(document, id)
+        })
 
       // Test selecting key with stabilization enabled
-      app.selectKey('F1');
-      expect(stabilizeCheckbox.checked).toBe(true);
+      app.selectKey('F1')
+      expect(stabilizeCheckbox.checked).toBe(true)
 
       // Test selecting key without stabilization metadata
-      app.selectKey('F2');
-      expect(stabilizeCheckbox.checked).toBe(false);
+      app.selectKey('F2')
+      expect(stabilizeCheckbox.checked).toBe(false)
 
-      spy.mockRestore();
-    });
+      spy.mockRestore()
+    })
 
     it('should handle missing keybindMetadata gracefully', () => {
       app.getCurrentProfile.mockReturnValue({
         keys: {
-          F1: [{ command: 'FirePhasers' }]
-        }
+          F1: [{ command: 'FirePhasers' }],
+        },
         // No keybindMetadata property
-      });
+      })
 
       // Mock document.getElementById to return our checkbox
-      const originalGet = document.getElementById;
-      const spy = vi.spyOn(document, 'getElementById').mockImplementation((id) => {
-        if (id === 'stabilizeExecutionOrder') {
-          return stabilizeCheckbox;
-        }
-        return originalGet.call(document, id);
-      });
+      const originalGet = document.getElementById
+      const spy = vi
+        .spyOn(document, 'getElementById')
+        .mockImplementation((id) => {
+          if (id === 'stabilizeExecutionOrder') {
+            return stabilizeCheckbox
+          }
+          return originalGet.call(document, id)
+        })
 
-      app.selectKey('F1');
-      expect(stabilizeCheckbox.checked).toBe(false);
+      app.selectKey('F1')
+      expect(stabilizeCheckbox.checked).toBe(false)
 
-      spy.mockRestore();
-    });
+      spy.mockRestore()
+    })
 
     it('should save stabilization state to metadata when checkbox changes', () => {
-      app.selectedKey = 'F2';
+      app.selectedKey = 'F2'
       const mockProfile = {
         keys: {
-          F2: [{ command: 'FirePhasers' }]
+          F2: [{ command: 'FirePhasers' }],
         },
-        keybindMetadata: {}
-      };
-      app.getCurrentProfile.mockReturnValue(mockProfile);
-      vi.spyOn(stoStorage, 'getProfile').mockReturnValue(mockProfile);
-      const saveProfileSpy = vi.spyOn(stoStorage, 'saveProfile').mockImplementation(() => {});
-      const setModifiedSpy = vi.spyOn(app, 'setModified');
+        keybindMetadata: {},
+      }
+      app.getCurrentProfile.mockReturnValue(mockProfile)
+      vi.spyOn(stoStorage, 'getProfile').mockReturnValue(mockProfile)
+      const saveProfileSpy = vi
+        .spyOn(stoStorage, 'saveProfile')
+        .mockImplementation(() => {})
+      const setModifiedSpy = vi.spyOn(app, 'setModified')
 
       // Mock document.getElementById to return our checkbox
-      const originalGet = document.getElementById;
-      const spy = vi.spyOn(document, 'getElementById').mockImplementation((id) => {
-        if (id === 'stabilizeExecutionOrder') {
-          return stabilizeCheckbox;
-        }
-        return originalGet.call(document, id);
-      });
+      const originalGet = document.getElementById
+      const spy = vi
+        .spyOn(document, 'getElementById')
+        .mockImplementation((id) => {
+          if (id === 'stabilizeExecutionOrder') {
+            return stabilizeCheckbox
+          }
+          return originalGet.call(document, id)
+        })
 
-      app.setupEventListeners();
+      app.setupEventListeners()
 
       // Simulate checkbox change
-      stabilizeCheckbox.checked = true;
-      stabilizeCheckbox.dispatchEvent(new Event('change'));
+      stabilizeCheckbox.checked = true
+      stabilizeCheckbox.dispatchEvent(new Event('change'))
 
       // Check that metadata was saved
       expect(stoStorage.saveProfile).toHaveBeenCalledWith(
         app.currentProfile,
         expect.objectContaining({
           keybindMetadata: {
-            space: { F2: { stabilizeExecutionOrder: true } }
-          }
+            space: { F2: { stabilizeExecutionOrder: true } },
+          },
         })
-      );
-      expect(setModifiedSpy).toHaveBeenCalledWith(true);
+      )
+      expect(setModifiedSpy).toHaveBeenCalledWith(true)
 
-      spy.mockRestore();
-    });
+      spy.mockRestore()
+    })
 
     it('should create keybindMetadata structure if it does not exist', () => {
-      app.selectedKey = 'F3';
+      app.selectedKey = 'F3'
       const mockProfile = {
         keys: {
-          F3: [{ command: 'FirePhasers' }]
-        }
+          F3: [{ command: 'FirePhasers' }],
+        },
         // No keybindMetadata at all
-      };
-      app.getCurrentProfile.mockReturnValue(mockProfile);
-      vi.spyOn(stoStorage, 'getProfile').mockReturnValue(mockProfile);
-      vi.spyOn(stoStorage, 'saveProfile').mockImplementation(() => {});
+      }
+      app.getCurrentProfile.mockReturnValue(mockProfile)
+      vi.spyOn(stoStorage, 'getProfile').mockReturnValue(mockProfile)
+      vi.spyOn(stoStorage, 'saveProfile').mockImplementation(() => {})
 
       // Mock document.getElementById to return our checkbox
-      const originalGet = document.getElementById;
-      const spy = vi.spyOn(document, 'getElementById').mockImplementation((id) => {
-        if (id === 'stabilizeExecutionOrder') {
-          return stabilizeCheckbox;
-        }
-        return originalGet.call(document, id);
-      });
+      const originalGet = document.getElementById
+      const spy = vi
+        .spyOn(document, 'getElementById')
+        .mockImplementation((id) => {
+          if (id === 'stabilizeExecutionOrder') {
+            return stabilizeCheckbox
+          }
+          return originalGet.call(document, id)
+        })
 
-      app.setupEventListeners();
+      app.setupEventListeners()
 
       // Simulate checkbox change
-      stabilizeCheckbox.checked = true;
-      stabilizeCheckbox.dispatchEvent(new Event('change'));
+      stabilizeCheckbox.checked = true
+      stabilizeCheckbox.dispatchEvent(new Event('change'))
 
       // Check that metadata structure was created and saved
       expect(stoStorage.saveProfile).toHaveBeenCalledWith(
         app.currentProfile,
         expect.objectContaining({
           keybindMetadata: {
-            space: { F3: { stabilizeExecutionOrder: true } }
-          }
+            space: { F3: { stabilizeExecutionOrder: true } },
+          },
         })
-      );
+      )
 
-      spy.mockRestore();
-    });
+      spy.mockRestore()
+    })
   })
 
   describe('stabilized export functionality', () => {
-    let stabilizeCheckbox;
-    let originalGetCurrentProfile;
+    let stabilizeCheckbox
+    let originalGetCurrentProfile
 
     beforeEach(() => {
       // Create the stabilization checkbox
-      stabilizeCheckbox = document.createElement('input');
-      stabilizeCheckbox.type = 'checkbox';
-      stabilizeCheckbox.id = 'stabilizeExecutionOrder';
-      document.body.appendChild(stabilizeCheckbox);
+      stabilizeCheckbox = document.createElement('input')
+      stabilizeCheckbox.type = 'checkbox'
+      stabilizeCheckbox.id = 'stabilizeExecutionOrder'
+      document.body.appendChild(stabilizeCheckbox)
 
       // Mock export functionality
       global.stoExport = {
-        generateSTOKeybindFile: vi.fn().mockReturnValue('mocked keybind content')
-      };
+        generateSTOKeybindFile: vi
+          .fn()
+          .mockReturnValue('mocked keybind content'),
+      }
 
       // Ensure stoKeybinds global is available for mirroring
       global.stoKeybinds = {
         generateMirroredCommandString: (commands) => {
           if (!commands || commands.length <= 1) {
-            return commands.map(cmd => cmd.command || cmd).join(' $$ ');
+            return commands.map((cmd) => cmd.command || cmd).join(' $$ ')
           }
-          const commandStrings = commands.map(cmd => cmd.command || cmd);
-          const reversed = [...commandStrings].reverse();
-          const reversedWithoutLast = reversed.slice(1);
-          const mirrored = [...commandStrings, ...reversedWithoutLast];
-          return mirrored.join(' $$ ');
-        }
-      };
+          const commandStrings = commands.map((cmd) => cmd.command || cmd)
+          const reversed = [...commandStrings].reverse()
+          const reversedWithoutLast = reversed.slice(1)
+          const mirrored = [...commandStrings, ...reversedWithoutLast]
+          return mirrored.join(' $$ ')
+        },
+      }
 
       // Store original method and mock profile
-      originalGetCurrentProfile = app.getCurrentProfile;
+      originalGetCurrentProfile = app.getCurrentProfile
       app.getCurrentProfile = vi.fn().mockReturnValue({
         name: 'Test Profile',
         keys: {
           F1: [
             { command: '+TrayExecByTray 9 0' },
-            { command: '+TrayExecByTray 9 1' }
-          ]
-        }
-      });
+            { command: '+TrayExecByTray 9 1' },
+          ],
+        },
+      })
 
       // Mock DOM elements for file download
       global.URL = {
         createObjectURL: vi.fn().mockReturnValue('blob:url'),
-        revokeObjectURL: vi.fn()
-      };
-      global.Blob = vi.fn();
+        revokeObjectURL: vi.fn(),
+      }
+      global.Blob = vi.fn()
 
       const mockAnchor = {
         click: vi.fn(),
         href: '',
-        download: ''
-      };
-      vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor);
-    });
+        download: '',
+      }
+      vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
+    })
 
     afterEach(() => {
       if (stabilizeCheckbox) {
-        stabilizeCheckbox.remove();
+        stabilizeCheckbox.remove()
       }
-      delete global.stoExport;
-      delete global.URL;
-      delete global.Blob;
-      
+      delete global.stoExport
+      delete global.URL
+      delete global.Blob
+
       // Restore original method
       if (originalGetCurrentProfile) {
-        app.getCurrentProfile = originalGetCurrentProfile;
+        app.getCurrentProfile = originalGetCurrentProfile
       }
-    });
+    })
 
     it('should export with stabilization disabled by default', () => {
-      stabilizeCheckbox.checked = false;
+      stabilizeCheckbox.checked = false
 
-      app.exportKeybinds();
+      app.exportKeybinds()
 
       expect(stoExport.generateSTOKeybindFile).toHaveBeenCalledWith(
         expect.any(Object),
         { environment: app.currentEnvironment }
-      );
-    });
+      )
+    })
 
     it('should export with stabilization enabled when checkbox is checked', () => {
-      stabilizeCheckbox.checked = true;
-      
+      stabilizeCheckbox.checked = true
+
       // Mock document.getElementById for the export method
-      const spy = vi.spyOn(document, 'getElementById').mockImplementation((id) => {
-        if (id === 'stabilizeExecutionOrder') {
-          return stabilizeCheckbox;
-        }
-        return originalGet.call(document, id);
-      });
-      
-      app.exportKeybinds();
+      const spy = vi
+        .spyOn(document, 'getElementById')
+        .mockImplementation((id) => {
+          if (id === 'stabilizeExecutionOrder') {
+            return stabilizeCheckbox
+          }
+          return originalGet.call(document, id)
+        })
+
+      app.exportKeybinds()
 
       expect(stoExport.generateSTOKeybindFile).toHaveBeenCalledWith(
         expect.any(Object),
         { environment: app.currentEnvironment }
-      );
+      )
 
-      spy.mockRestore();
-    });
+      spy.mockRestore()
+    })
 
     it('should include environment in filename', () => {
-      stabilizeCheckbox.checked = true;
-      app.currentEnvironment = 'space';
-      
-      const mockAnchor = document.createElement('a');
-      vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor);
-      
+      stabilizeCheckbox.checked = true
+      app.currentEnvironment = 'space'
+
+      const mockAnchor = document.createElement('a')
+      vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
+
       // Mock document.getElementById for the export method
-      const spy = vi.spyOn(document, 'getElementById').mockImplementation((id) => {
-        if (id === 'stabilizeExecutionOrder') {
-          return stabilizeCheckbox;
-        }
-        return originalGet.call(document, id);
-      });
-      
-      app.exportKeybinds();
-      
-      expect(mockAnchor.download).toContain('space');
-      expect(mockAnchor.download).toContain('.txt');
-      
-      spy.mockRestore();
-    });
+      const spy = vi
+        .spyOn(document, 'getElementById')
+        .mockImplementation((id) => {
+          if (id === 'stabilizeExecutionOrder') {
+            return stabilizeCheckbox
+          }
+          return originalGet.call(document, id)
+        })
+
+      app.exportKeybinds()
+
+      expect(mockAnchor.download).toContain('space')
+      expect(mockAnchor.download).toContain('.txt')
+
+      spy.mockRestore()
+    })
 
     it('should not include stabilization flag in filename when disabled', () => {
-      stabilizeCheckbox.checked = false;
-      app.currentEnvironment = 'ground';
-      
-      const mockAnchor = document.createElement('a');
-      vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor);
-      
-      app.exportKeybinds();
+      stabilizeCheckbox.checked = false
+      app.currentEnvironment = 'ground'
 
-      expect(mockAnchor.download).not.toContain('_stabilized');
-      expect(mockAnchor.download).toContain('ground');
-      expect(mockAnchor.download).toContain('.txt');
-    });
+      const mockAnchor = document.createElement('a')
+      vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
+
+      app.exportKeybinds()
+
+      expect(mockAnchor.download).not.toContain('_stabilized')
+      expect(mockAnchor.download).toContain('ground')
+      expect(mockAnchor.download).toContain('.txt')
+    })
 
     it('should show appropriate toast message with stabilization status', () => {
-      stabilizeCheckbox.checked = true;
-      app.currentEnvironment = 'space';
-      
+      stabilizeCheckbox.checked = true
+      app.currentEnvironment = 'space'
+
       // Mock document.getElementById for the export method
-      const spy = vi.spyOn(document, 'getElementById').mockImplementation((id) => {
-        if (id === 'stabilizeExecutionOrder') {
-          return stabilizeCheckbox;
-        }
-        return originalGet.call(document, id);
-      });
-      
-      app.exportKeybinds();
-      
+      const spy = vi
+        .spyOn(document, 'getElementById')
+        .mockImplementation((id) => {
+          if (id === 'stabilizeExecutionOrder') {
+            return stabilizeCheckbox
+          }
+          return originalGet.call(document, id)
+        })
+
+      app.exportKeybinds()
+
       expect(stoUI.showToast).toHaveBeenCalledWith(
         'space keybinds exported successfully',
         'success'
-      );
-      
-      spy.mockRestore();
-    });
+      )
+
+      spy.mockRestore()
+    })
 
     it('should show normal toast message without stabilization', () => {
-      stabilizeCheckbox.checked = false;
-      app.currentEnvironment = 'ground';
-      
-      app.exportKeybinds();
-      
+      stabilizeCheckbox.checked = false
+      app.currentEnvironment = 'ground'
+
+      app.exportKeybinds()
+
       expect(stoUI.showToast).toHaveBeenCalledWith(
         'ground keybinds exported successfully',
         'success'
-      );
-    });
+      )
+    })
 
     it('should handle missing checkbox gracefully', () => {
-      stabilizeCheckbox.remove();
-      
-      app.exportKeybinds();
-      
+      stabilizeCheckbox.remove()
+
+      app.exportKeybinds()
+
       expect(stoExport.generateSTOKeybindFile).toHaveBeenCalledWith(
         expect.any(Object),
         { environment: app.currentEnvironment }
-      );
-    });
+      )
+    })
   })
-}) 
+})

--- a/tests/unit/data.test.js
+++ b/tests/unit/data.test.js
@@ -1,12 +1,15 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { describe, it, expect, beforeEach } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
 
 // Load the real HTML content
-const htmlContent = readFileSync(resolve(__dirname, '../../src/index.html'), 'utf-8');
+const htmlContent = readFileSync(
+  resolve(__dirname, '../../src/index.html'),
+  'utf-8'
+)
 
 // Import real data module
-let STO_DATA;
+let STO_DATA
 
 /**
  * High-Value Data Validation Tests
@@ -15,318 +18,387 @@ let STO_DATA;
  */
 
 describe('STO Data Module - Critical Validation', () => {
-    beforeEach(async () => {
-        // Set up DOM with real HTML content
-        document.documentElement.innerHTML = htmlContent;
-        
-        // Import the real data module
-        await import('../../src/js/data.js');
-        STO_DATA = window.STO_DATA;
-        
-        // Ensure data module loaded
-        if (!STO_DATA) {
-            throw new Error('STO_DATA not loaded');
+  beforeEach(async () => {
+    // Set up DOM with real HTML content
+    document.documentElement.innerHTML = htmlContent
+
+    // Import the real data module
+    await import('../../src/js/data.js')
+    STO_DATA = window.STO_DATA
+
+    // Ensure data module loaded
+    if (!STO_DATA) {
+      throw new Error('STO_DATA not loaded')
+    }
+  })
+
+  describe('Core Data Structure Integrity', () => {
+    it('should have commands object with valid structure', () => {
+      expect(STO_DATA.commands).toBeDefined()
+      expect(typeof STO_DATA.commands).toBe('object')
+      expect(Object.keys(STO_DATA.commands).length).toBeGreaterThan(0)
+    })
+
+    it('should have all command categories with required fields', () => {
+      Object.entries(STO_DATA.commands).forEach(([categoryKey, category]) => {
+        expect(category.name).toBeDefined()
+        expect(typeof category.name).toBe('string')
+        expect(category.icon).toBeDefined()
+        expect(category.description).toBeDefined()
+        expect(category.commands).toBeDefined()
+        expect(typeof category.commands).toBe('object')
+      })
+    })
+
+    it('should have all commands with critical required fields', () => {
+      Object.entries(STO_DATA.commands).forEach(([categoryKey, category]) => {
+        Object.entries(category.commands).forEach(([commandKey, command]) => {
+          // Critical fields that prevent runtime errors
+          expect(
+            command.name,
+            `${categoryKey}.${commandKey} missing name`
+          ).toBeDefined()
+          expect(
+            command.command,
+            `${categoryKey}.${commandKey} missing command`
+          ).toBeDefined()
+          expect(
+            command.description,
+            `${categoryKey}.${commandKey} missing description`
+          ).toBeDefined()
+          expect(
+            command.syntax,
+            `${categoryKey}.${commandKey} missing syntax`
+          ).toBeDefined()
+          expect(
+            command.icon,
+            `${categoryKey}.${commandKey} missing icon`
+          ).toBeDefined()
+        })
+      })
+    })
+
+    it('should have unique command keys within categories', () => {
+      Object.entries(STO_DATA.commands).forEach(([categoryKey, category]) => {
+        const commandKeys = Object.keys(category.commands)
+        const uniqueKeys = new Set(commandKeys)
+        expect(uniqueKeys.size).toBe(commandKeys.length)
+      })
+    })
+  })
+
+  describe('Business Logic Validation', () => {
+    it('should have warnings for combat commands that affect firing cycles', () => {
+      const combatCommands = STO_DATA.commands.combat?.commands || {}
+      const fireCommands = [
+        'fire_all',
+        'fire_phasers',
+        'fire_torps',
+        'fire_mines',
+      ]
+
+      fireCommands.forEach((commandKey) => {
+        if (combatCommands[commandKey]) {
+          expect(
+            combatCommands[commandKey].warning,
+            `${commandKey} should have firing cycle warning`
+          ).toBeDefined()
+          expect(combatCommands[commandKey].warning).toContain('firing cycles')
         }
-    });
+      })
+    })
 
-    describe('Core Data Structure Integrity', () => {
-        it('should have commands object with valid structure', () => {
-            expect(STO_DATA.commands).toBeDefined();
-            expect(typeof STO_DATA.commands).toBe('object');
-            expect(Object.keys(STO_DATA.commands).length).toBeGreaterThan(0);
-        });
+    it('should have warnings for shield distribution commands', () => {
+      const powerCommands = STO_DATA.commands.power?.commands || {}
 
-        it('should have all command categories with required fields', () => {
-            Object.entries(STO_DATA.commands).forEach(([categoryKey, category]) => {
-                expect(category.name).toBeDefined();
-                expect(typeof category.name).toBe('string');
-                expect(category.icon).toBeDefined();
-                expect(category.description).toBeDefined();
-                expect(category.commands).toBeDefined();
-                expect(typeof category.commands).toBe('object');
-            });
-        });
+      if (powerCommands.distribute_shields) {
+        expect(powerCommands.distribute_shields.warning).toBeDefined()
+        expect(powerCommands.distribute_shields.warning).toContain(
+          'firing cycles'
+        )
+      }
+    })
 
-        it('should have all commands with critical required fields', () => {
-            Object.entries(STO_DATA.commands).forEach(([categoryKey, category]) => {
-                Object.entries(category.commands).forEach(([commandKey, command]) => {
-                    // Critical fields that prevent runtime errors
-                    expect(command.name, `${categoryKey}.${commandKey} missing name`).toBeDefined();
-                    expect(command.command, `${categoryKey}.${commandKey} missing command`).toBeDefined();
-                    expect(command.description, `${categoryKey}.${commandKey} missing description`).toBeDefined();
-                    expect(command.syntax, `${categoryKey}.${commandKey} missing syntax`).toBeDefined();
-                    expect(command.icon, `${categoryKey}.${commandKey} missing icon`).toBeDefined();
-                });
-            });
-        });
+    it('should properly mark space-only commands', () => {
+      const combatCommands = STO_DATA.commands.combat?.commands || {}
 
-        it('should have unique command keys within categories', () => {
-            Object.entries(STO_DATA.commands).forEach(([categoryKey, category]) => {
-                const commandKeys = Object.keys(category.commands);
-                const uniqueKeys = new Set(commandKeys);
-                expect(uniqueKeys.size).toBe(commandKeys.length);
-            });
-        });
-    });
+      Object.entries(combatCommands).forEach(([commandKey, command]) => {
+        if (command.environment) {
+          expect(['space', 'ground', 'both']).toContain(command.environment)
+        }
+      })
+    })
 
-    describe('Business Logic Validation', () => {
-        it('should have warnings for combat commands that affect firing cycles', () => {
-            const combatCommands = STO_DATA.commands.combat?.commands || {};
-            const fireCommands = ['fire_all', 'fire_phasers', 'fire_torps', 'fire_mines'];
-            
-            fireCommands.forEach(commandKey => {
-                if (combatCommands[commandKey]) {
-                    expect(combatCommands[commandKey].warning, 
-                        `${commandKey} should have firing cycle warning`).toBeDefined();
-                    expect(combatCommands[commandKey].warning).toContain('firing cycles');
+    it('should have valid STO command syntax patterns', () => {
+      Object.entries(STO_DATA.commands).forEach(([categoryKey, category]) => {
+        Object.entries(category.commands).forEach(([commandKey, command]) => {
+          // Basic STO command validation
+          expect(command.command).toBeTruthy()
+          expect(typeof command.command).toBe('string')
+
+          // Should not contain obvious syntax errors
+          expect(command.command).not.toMatch(/\s{2,}/) // No double spaces
+          expect(command.command).not.toMatch(/^\s|\s$/) // No leading/trailing spaces
+        })
+      })
+    })
+  })
+
+  describe('Parameterized Commands Validation', () => {
+    it('should have valid parameter definitions for customizable commands', () => {
+      Object.entries(STO_DATA.commands).forEach(([categoryKey, category]) => {
+        Object.entries(category.commands).forEach(([commandKey, command]) => {
+          if (command.customizable) {
+            expect(
+              command.parameters,
+              `${categoryKey}.${commandKey} marked customizable but missing parameters`
+            ).toBeDefined()
+            expect(typeof command.parameters).toBe('object')
+
+            // Each parameter should have type and default
+            Object.entries(command.parameters).forEach(([paramKey, param]) => {
+              expect(
+                param.type,
+                `${commandKey}.${paramKey} missing type`
+              ).toBeDefined()
+              expect(['text', 'number', 'boolean', 'select']).toContain(
+                param.type
+              )
+              expect(
+                param.default,
+                `${commandKey}.${paramKey} missing default`
+              ).toBeDefined()
+
+              // If it's a select type, it should have options
+              if (param.type === 'select') {
+                expect(
+                  param.options,
+                  `${commandKey}.${paramKey} select type missing options`
+                ).toBeDefined()
+                expect(
+                  Array.isArray(param.options),
+                  `${commandKey}.${paramKey} options should be array`
+                ).toBe(true)
+                expect(
+                  param.options.length,
+                  `${commandKey}.${paramKey} options should not be empty`
+                ).toBeGreaterThan(0)
+                expect(
+                  param.options,
+                  `${commandKey}.${paramKey} default should be in options`
+                ).toContain(param.default)
+              }
+            })
+          }
+        })
+      })
+    })
+
+    it('should have valid tray parameter ranges', () => {
+      Object.entries(STO_DATA.commands).forEach(([categoryKey, category]) => {
+        Object.entries(category.commands).forEach(([commandKey, command]) => {
+          if (command.parameters) {
+            Object.entries(command.parameters).forEach(([paramKey, param]) => {
+              if (paramKey.includes('tray') || paramKey.includes('slot')) {
+                if (param.type === 'number') {
+                  expect(param.min).toBeGreaterThanOrEqual(0)
+                  expect(param.max).toBeLessThanOrEqual(9)
+                  expect(param.min).toBeLessThanOrEqual(param.max)
                 }
-            });
-        });
+              }
+            })
+          }
+        })
+      })
+    })
+  })
 
-        it('should have warnings for shield distribution commands', () => {
-            const powerCommands = STO_DATA.commands.power?.commands || {};
-            
-            if (powerCommands.distribute_shields) {
-                expect(powerCommands.distribute_shields.warning).toBeDefined();
-                expect(powerCommands.distribute_shields.warning).toContain('firing cycles');
-            }
-        });
+  describe('Configuration Data Validation', () => {
+    it('should have valid default settings structure', () => {
+      if (STO_DATA.DEFAULT_SETTINGS) {
+        expect(typeof STO_DATA.DEFAULT_SETTINGS).toBe('object')
 
-        it('should properly mark space-only commands', () => {
-            const combatCommands = STO_DATA.commands.combat?.commands || {};
-            
-            Object.entries(combatCommands).forEach(([commandKey, command]) => {
-                if (command.environment) {
-                    expect(['space', 'ground', 'both']).toContain(command.environment);
-                }
-            });
-        });
+        // Check for critical settings that prevent errors
+        if (STO_DATA.DEFAULT_SETTINGS.keyLayout) {
+          expect(typeof STO_DATA.DEFAULT_SETTINGS.keyLayout).toBe('string')
+        }
+      }
+    })
 
-        it('should have valid STO command syntax patterns', () => {
-            Object.entries(STO_DATA.commands).forEach(([categoryKey, category]) => {
-                Object.entries(category.commands).forEach(([commandKey, command]) => {
-                    // Basic STO command validation
-                    expect(command.command).toBeTruthy();
-                    expect(typeof command.command).toBe('string');
-                    
-                    // Should not contain obvious syntax errors
-                    expect(command.command).not.toMatch(/\s{2,}/); // No double spaces
-                    expect(command.command).not.toMatch(/^\s|\s$/); // No leading/trailing spaces
-                });
-            });
-        });
-    });
+    it('should have valid key layouts if defined', () => {
+      if (STO_DATA.KEY_LAYOUTS) {
+        expect(typeof STO_DATA.KEY_LAYOUTS).toBe('object')
 
-    describe('Parameterized Commands Validation', () => {
-        it('should have valid parameter definitions for customizable commands', () => {
-            Object.entries(STO_DATA.commands).forEach(([categoryKey, category]) => {
-                Object.entries(category.commands).forEach(([commandKey, command]) => {
-                    if (command.customizable) {
-                        expect(command.parameters, 
-                            `${categoryKey}.${commandKey} marked customizable but missing parameters`).toBeDefined();
-                        expect(typeof command.parameters).toBe('object');
-                        
-                        // Each parameter should have type and default
-                        Object.entries(command.parameters).forEach(([paramKey, param]) => {
-                            expect(param.type, `${commandKey}.${paramKey} missing type`).toBeDefined();
-                            expect(['text', 'number', 'boolean', 'select']).toContain(param.type);
-                            expect(param.default, `${commandKey}.${paramKey} missing default`).toBeDefined();
-                            
-                            // If it's a select type, it should have options
-                            if (param.type === 'select') {
-                                expect(param.options, `${commandKey}.${paramKey} select type missing options`).toBeDefined();
-                                expect(Array.isArray(param.options), `${commandKey}.${paramKey} options should be array`).toBe(true);
-                                expect(param.options.length, `${commandKey}.${paramKey} options should not be empty`).toBeGreaterThan(0);
-                                expect(param.options, `${commandKey}.${paramKey} default should be in options`).toContain(param.default);
-                            }
-                        });
-                    }
-                });
-            });
-        });
+        Object.entries(STO_DATA.KEY_LAYOUTS).forEach(([layoutKey, layout]) => {
+          expect(layout.name).toBeDefined()
+          expect(Array.isArray(layout.rows)).toBe(true)
 
-        it('should have valid tray parameter ranges', () => {
-            Object.entries(STO_DATA.commands).forEach(([categoryKey, category]) => {
-                Object.entries(category.commands).forEach(([commandKey, command]) => {
-                    if (command.parameters) {
-                        Object.entries(command.parameters).forEach(([paramKey, param]) => {
-                            if (paramKey.includes('tray') || paramKey.includes('slot')) {
-                                if (param.type === 'number') {
-                                    expect(param.min).toBeGreaterThanOrEqual(0);
-                                    expect(param.max).toBeLessThanOrEqual(9);
-                                    expect(param.min).toBeLessThanOrEqual(param.max);
-                                }
-                            }
-                        });
-                    }
-                });
-            });
-        });
-    });
+          // Each row should have valid key definitions
+          layout.rows.forEach((row, rowIndex) => {
+            expect(
+              Array.isArray(row),
+              `Layout ${layoutKey} row ${rowIndex} should be array`
+            ).toBe(true)
 
-    describe('Configuration Data Validation', () => {
-        it('should have valid default settings structure', () => {
-            if (STO_DATA.DEFAULT_SETTINGS) {
-                expect(typeof STO_DATA.DEFAULT_SETTINGS).toBe('object');
-                
-                // Check for critical settings that prevent errors
-                if (STO_DATA.DEFAULT_SETTINGS.keyLayout) {
-                    expect(typeof STO_DATA.DEFAULT_SETTINGS.keyLayout).toBe('string');
-                }
-            }
-        });
+            row.forEach((key, keyIndex) => {
+              expect(
+                key.key,
+                `Layout ${layoutKey} row ${rowIndex} key ${keyIndex} missing key`
+              ).toBeDefined()
+              expect(
+                key.display,
+                `Layout ${layoutKey} row ${rowIndex} key ${keyIndex} missing display`
+              ).toBeDefined()
+            })
+          })
+        })
+      }
+    })
 
-        it('should have valid key layouts if defined', () => {
-            if (STO_DATA.KEY_LAYOUTS) {
-                expect(typeof STO_DATA.KEY_LAYOUTS).toBe('object');
-                
-                Object.entries(STO_DATA.KEY_LAYOUTS).forEach(([layoutKey, layout]) => {
-                    expect(layout.name).toBeDefined();
-                    expect(Array.isArray(layout.rows)).toBe(true);
-                    
-                    // Each row should have valid key definitions
-                    layout.rows.forEach((row, rowIndex) => {
-                        expect(Array.isArray(row), `Layout ${layoutKey} row ${rowIndex} should be array`).toBe(true);
-                        
-                        row.forEach((key, keyIndex) => {
-                            expect(key.key, `Layout ${layoutKey} row ${rowIndex} key ${keyIndex} missing key`).toBeDefined();
-                            expect(key.display, `Layout ${layoutKey} row ${rowIndex} key ${keyIndex} missing display`).toBeDefined();
-                        });
-                    });
-                });
-            }
-        });
+    it('should have valid tray configuration limits', () => {
+      if (STO_DATA.TRAY_CONFIG) {
+        expect(typeof STO_DATA.TRAY_CONFIG).toBe('object')
 
-        it('should have valid tray configuration limits', () => {
-            if (STO_DATA.TRAY_CONFIG) {
-                expect(typeof STO_DATA.TRAY_CONFIG).toBe('object');
-                
-                if (STO_DATA.TRAY_CONFIG.maxTrays) {
-                    expect(STO_DATA.TRAY_CONFIG.maxTrays).toBeGreaterThan(0);
-                    expect(STO_DATA.TRAY_CONFIG.maxTrays).toBeLessThanOrEqual(10); // STO limit
-                }
-                
-                if (STO_DATA.TRAY_CONFIG.slotsPerTray) {
-                    expect(STO_DATA.TRAY_CONFIG.slotsPerTray).toBeGreaterThan(0);
-                    expect(STO_DATA.TRAY_CONFIG.slotsPerTray).toBeLessThanOrEqual(10); // STO limit
-                }
-            }
-        });
-    });
+        if (STO_DATA.TRAY_CONFIG.maxTrays) {
+          expect(STO_DATA.TRAY_CONFIG.maxTrays).toBeGreaterThan(0)
+          expect(STO_DATA.TRAY_CONFIG.maxTrays).toBeLessThanOrEqual(10) // STO limit
+        }
 
-    describe('Sample Data Validation', () => {
-        it('should have valid sample profiles structure', () => {
-            if (STO_DATA.SAMPLE_PROFILES) {
-                expect(Array.isArray(STO_DATA.SAMPLE_PROFILES)).toBe(true);
-                
-                STO_DATA.SAMPLE_PROFILES.forEach((profile, index) => {
-                    expect(profile.name, `Sample profile ${index} missing name`).toBeDefined();
-                    expect(profile.description, `Sample profile ${index} missing description`).toBeDefined();
-                    
-                    if (profile.keys) {
-                        expect(typeof profile.keys).toBe('object');
-                    }
-                    
-                    if (profile.aliases) {
-                        expect(typeof profile.aliases).toBe('object');
-                    }
-                });
-            }
-        });
+        if (STO_DATA.TRAY_CONFIG.slotsPerTray) {
+          expect(STO_DATA.TRAY_CONFIG.slotsPerTray).toBeGreaterThan(0)
+          expect(STO_DATA.TRAY_CONFIG.slotsPerTray).toBeLessThanOrEqual(10) // STO limit
+        }
+      }
+    })
+  })
 
-        it('should have valid sample aliases structure', () => {
-            if (STO_DATA.SAMPLE_ALIASES) {
-                expect(Array.isArray(STO_DATA.SAMPLE_ALIASES)).toBe(true);
-                
-                STO_DATA.SAMPLE_ALIASES.forEach((alias, index) => {
-                    expect(alias.name, `Sample alias ${index} missing name`).toBeDefined();
-                    expect(alias.commands, `Sample alias ${index} missing commands`).toBeDefined();
-                    expect(alias.description, `Sample alias ${index} missing description`).toBeDefined();
-                });
-            }
-        });
-    });
+  describe('Sample Data Validation', () => {
+    it('should have valid sample profiles structure', () => {
+      if (STO_DATA.SAMPLE_PROFILES) {
+        expect(Array.isArray(STO_DATA.SAMPLE_PROFILES)).toBe(true)
 
-    describe('Integration Compatibility', () => {
-        it('should provide data compatible with command filtering', () => {
-            // Test that data structure supports common filtering operations
-            const categories = Object.keys(STO_DATA.commands);
-            expect(categories.length).toBeGreaterThan(0);
-            
-            // Should be able to filter by environment
-            let spaceCommands = 0;
-            Object.values(STO_DATA.commands).forEach(category => {
-                Object.values(category.commands).forEach(command => {
-                    if (command.environment === 'space') {
-                        spaceCommands++;
-                    }
-                });
-            });
-            
-            // Should have some space commands for filtering
-            expect(spaceCommands).toBeGreaterThan(0);
-        });
+        STO_DATA.SAMPLE_PROFILES.forEach((profile, index) => {
+          expect(
+            profile.name,
+            `Sample profile ${index} missing name`
+          ).toBeDefined()
+          expect(
+            profile.description,
+            `Sample profile ${index} missing description`
+          ).toBeDefined()
 
-        it('should support parameter substitution for exports', () => {
-            let customizableCommands = 0;
-            
-            Object.entries(STO_DATA.commands).forEach(([categoryKey, category]) => {
-                Object.entries(category.commands).forEach(([commandKey, command]) => {
-                    if (command.customizable && command.parameters) {
-                        customizableCommands++;
-                        
-                        // Should have valid syntax template for substitution
-                        expect(command.syntax).toBeDefined();
-                        expect(typeof command.syntax).toBe('string');
-                    }
-                });
-            });
-            
-            // Should have some customizable commands
-            expect(customizableCommands).toBeGreaterThan(0);
-        });
+          if (profile.keys) {
+            expect(typeof profile.keys).toBe('object')
+          }
 
-        it('should provide UI-compatible metadata', () => {
-            let commandsWithIcons = 0;
-            
-            Object.values(STO_DATA.commands).forEach(category => {
-                Object.values(category.commands).forEach(command => {
-                    if (command.icon && command.description) {
-                        commandsWithIcons++;
-                    }
-                });
-            });
-            
-            // Should have commands with UI metadata
-            expect(commandsWithIcons).toBeGreaterThan(0);
-        });
-    });
+          if (profile.aliases) {
+            expect(typeof profile.aliases).toBe('object')
+          }
+        })
+      }
+    })
 
-    describe('Data Consistency', () => {
-        it('should have consistent command naming patterns', () => {
-            const commandNames = [];
-            
-            Object.values(STO_DATA.commands).forEach(category => {
-                Object.values(category.commands).forEach(command => {
-                    commandNames.push(command.command);
-                });
-            });
-            
-            // Basic consistency checks
-            commandNames.forEach(commandName => {
-                // Should not have obvious typos or inconsistencies
-                expect(commandName).not.toMatch(/\s{2,}/); // No double spaces
-                expect(commandName.trim()).toBe(commandName); // No leading/trailing spaces
-            });
-        });
+    it('should have valid sample aliases structure', () => {
+      if (STO_DATA.SAMPLE_ALIASES) {
+        expect(Array.isArray(STO_DATA.SAMPLE_ALIASES)).toBe(true)
 
-        it('should maintain valid cross-references', () => {
-            // If default settings reference key layouts, they should exist
-            if (STO_DATA.DEFAULT_SETTINGS?.keyLayout && STO_DATA.KEY_LAYOUTS) {
-                const referencedLayout = STO_DATA.DEFAULT_SETTINGS.keyLayout;
-                expect(STO_DATA.KEY_LAYOUTS[referencedLayout], 
-                    `Default keyLayout '${referencedLayout}' not found in KEY_LAYOUTS`).toBeDefined();
-            }
-        });
-    });
-}); 
+        STO_DATA.SAMPLE_ALIASES.forEach((alias, index) => {
+          expect(alias.name, `Sample alias ${index} missing name`).toBeDefined()
+          expect(
+            alias.commands,
+            `Sample alias ${index} missing commands`
+          ).toBeDefined()
+          expect(
+            alias.description,
+            `Sample alias ${index} missing description`
+          ).toBeDefined()
+        })
+      }
+    })
+  })
+
+  describe('Integration Compatibility', () => {
+    it('should provide data compatible with command filtering', () => {
+      // Test that data structure supports common filtering operations
+      const categories = Object.keys(STO_DATA.commands)
+      expect(categories.length).toBeGreaterThan(0)
+
+      // Should be able to filter by environment
+      let spaceCommands = 0
+      Object.values(STO_DATA.commands).forEach((category) => {
+        Object.values(category.commands).forEach((command) => {
+          if (command.environment === 'space') {
+            spaceCommands++
+          }
+        })
+      })
+
+      // Should have some space commands for filtering
+      expect(spaceCommands).toBeGreaterThan(0)
+    })
+
+    it('should support parameter substitution for exports', () => {
+      let customizableCommands = 0
+
+      Object.entries(STO_DATA.commands).forEach(([categoryKey, category]) => {
+        Object.entries(category.commands).forEach(([commandKey, command]) => {
+          if (command.customizable && command.parameters) {
+            customizableCommands++
+
+            // Should have valid syntax template for substitution
+            expect(command.syntax).toBeDefined()
+            expect(typeof command.syntax).toBe('string')
+          }
+        })
+      })
+
+      // Should have some customizable commands
+      expect(customizableCommands).toBeGreaterThan(0)
+    })
+
+    it('should provide UI-compatible metadata', () => {
+      let commandsWithIcons = 0
+
+      Object.values(STO_DATA.commands).forEach((category) => {
+        Object.values(category.commands).forEach((command) => {
+          if (command.icon && command.description) {
+            commandsWithIcons++
+          }
+        })
+      })
+
+      // Should have commands with UI metadata
+      expect(commandsWithIcons).toBeGreaterThan(0)
+    })
+  })
+
+  describe('Data Consistency', () => {
+    it('should have consistent command naming patterns', () => {
+      const commandNames = []
+
+      Object.values(STO_DATA.commands).forEach((category) => {
+        Object.values(category.commands).forEach((command) => {
+          commandNames.push(command.command)
+        })
+      })
+
+      // Basic consistency checks
+      commandNames.forEach((commandName) => {
+        // Should not have obvious typos or inconsistencies
+        expect(commandName).not.toMatch(/\s{2,}/) // No double spaces
+        expect(commandName.trim()).toBe(commandName) // No leading/trailing spaces
+      })
+    })
+
+    it('should maintain valid cross-references', () => {
+      // If default settings reference key layouts, they should exist
+      if (STO_DATA.DEFAULT_SETTINGS?.keyLayout && STO_DATA.KEY_LAYOUTS) {
+        const referencedLayout = STO_DATA.DEFAULT_SETTINGS.keyLayout
+        expect(
+          STO_DATA.KEY_LAYOUTS[referencedLayout],
+          `Default keyLayout '${referencedLayout}' not found in KEY_LAYOUTS`
+        ).toBeDefined()
+      }
+    })
+  })
+})

--- a/tests/unit/export.test.js
+++ b/tests/unit/export.test.js
@@ -39,11 +39,11 @@ beforeEach(() => {
   Object.assign(global, { app, exportManager })
   store.currentProfile = 'test-profile'
   store.currentEnvironment = 'space'
-  
+
   // Mock only the UI methods that would show actual modals or toasts
   vi.spyOn(stoUI, 'showToast').mockImplementation(() => {})
   vi.spyOn(stoUI, 'copyToClipboard').mockImplementation(() => {})
-  
+
   // Create a test profile in the real storage system
   const testProfile = {
     id: 'test-profile',
@@ -52,37 +52,43 @@ beforeEach(() => {
     keys: {
       F1: [
         { command: 'FireAll', type: 'combat', text: 'Fire All Weapons' },
-        { command: 'target_nearest_enemy', type: 'targeting', text: 'Target Enemy' }
+        {
+          command: 'target_nearest_enemy',
+          type: 'targeting',
+          text: 'Target Enemy',
+        },
       ],
-      F2: [
-        { command: 'TestAlias', type: 'alias', text: 'Alias: TestAlias' }
-      ],
+      F2: [{ command: 'TestAlias', type: 'alias', text: 'Alias: TestAlias' }],
       A: [
-        { command: '+STOTrayExecByTray 0 0', type: 'tray', text: 'Tray 1 Slot 1' }
-      ]
+        {
+          command: '+STOTrayExecByTray 0 0',
+          type: 'tray',
+          text: 'Tray 1 Slot 1',
+        },
+      ],
     },
     aliases: {
       TestAlias: {
         name: 'TestAlias',
         description: 'Test alias description',
-        commands: 'say hello $$ emote wave'
+        commands: 'say hello $$ emote wave',
       },
       AttackRun: {
         name: 'AttackRun',
         description: 'Attack sequence',
-        commands: 'target_nearest_enemy $$ FireAll'
-      }
-    }
+        commands: 'target_nearest_enemy $$ FireAll',
+      },
+    },
   }
-  
+
   // Add the test profile to real storage and set as current
   stoStorage.saveProfile(testProfile.id, testProfile)
   app.currentProfile = testProfile.id
   app.saveCurrentProfile()
-  
+
   // Set selected key for copy tests
   app.selectedKey = 'F1'
-  
+
   // Set command preview content for copy tests
   const preview = document.getElementById('commandPreview')
   if (preview) {
@@ -107,22 +113,30 @@ describe('STOExportManager', () => {
   describe('initialization', () => {
     it('should initialize export formats map', () => {
       expect(exportManager.exportFormats).toBeDefined()
-      expect(exportManager.exportFormats.sto_keybind).toBe('STO Keybind File (.txt)')
-      expect(exportManager.exportFormats.json_profile).toBe('JSON Profile (.json)')
-      expect(exportManager.exportFormats.json_project).toBe('Complete Project (.json)')
+      expect(exportManager.exportFormats.sto_keybind).toBe(
+        'STO Keybind File (.txt)'
+      )
+      expect(exportManager.exportFormats.json_profile).toBe(
+        'JSON Profile (.json)'
+      )
+      expect(exportManager.exportFormats.json_project).toBe(
+        'Complete Project (.json)'
+      )
       expect(exportManager.exportFormats.csv_data).toBe('CSV Data (.csv)')
-      expect(exportManager.exportFormats.html_report).toBe('HTML Report (.html)')
+      expect(exportManager.exportFormats.html_report).toBe(
+        'HTML Report (.html)'
+      )
     })
 
     it('should setup event listeners', () => {
       const exportBtn = document.getElementById('exportKeybindsBtn')
       const copyPreviewBtn = document.getElementById('copyPreviewBtn')
-      
+
       expect(exportBtn).toBeTruthy()
       expect(copyPreviewBtn).toBeTruthy()
-      
+
       exportManager.setupEventListeners()
-      
+
       // Verify elements exist (real DOM test)
       expect(exportBtn.id).toBe('exportKeybindsBtn')
       expect(copyPreviewBtn.id).toBe('copyPreviewBtn')
@@ -131,28 +145,31 @@ describe('STOExportManager', () => {
 
   describe('STO keybind file export', () => {
     it('should export profile as STO keybind file', () => {
-      const mockAnchor = { 
-        click: vi.fn(), 
+      const mockAnchor = {
+        click: vi.fn(),
         download: '',
-        href: ''
+        href: '',
       }
       vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
       vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
       vi.spyOn(document.body, 'removeChild').mockImplementation(() => {})
-      
+
       const profile = app.getCurrentProfile()
       exportManager.exportSTOKeybindFile(profile)
-      
+
       expect(mockAnchor.click).toHaveBeenCalled()
       expect(mockAnchor.download).toContain('Test_Profile')
       expect(mockAnchor.download).toContain('.txt')
-      expect(stoUI.showToast).toHaveBeenCalledWith('Keybind file exported successfully', 'success')
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Keybind file exported successfully',
+        'success'
+      )
     })
 
     it('should generate file with proper header', () => {
       const profile = app.getCurrentProfile()
       const header = exportManager.generateFileHeader(profile)
-      
+
       expect(header).toContain('Test Profile - STO Keybind Configuration')
       expect(header).toContain('Mode: SPACE')
       expect(header).toContain('Generated:')
@@ -163,7 +180,7 @@ describe('STOExportManager', () => {
     it('should include profile statistics in header', () => {
       const profile = app.getCurrentProfile()
       const header = exportManager.generateFileHeader(profile)
-      
+
       expect(header).toContain('Keys bound: 3')
       expect(header).toContain('Total commands: 4')
       expect(header).toContain('Note: Aliases are exported separately')
@@ -172,7 +189,7 @@ describe('STOExportManager', () => {
     it('should include usage instructions in header', () => {
       const profile = app.getCurrentProfile()
       const header = exportManager.generateFileHeader(profile)
-      
+
       expect(header).toContain('To use this file in Star Trek Online:')
       expect(header).toContain('Save this file to your STO Live folder')
       expect(header).toContain('/bind_load_file')
@@ -181,7 +198,7 @@ describe('STOExportManager', () => {
     it('should generate keybind file without aliases', () => {
       const profile = app.getCurrentProfile()
       const content = exportManager.generateSTOKeybindFile(profile)
-      
+
       // Should not contain alias sections since they're exported separately
       expect(content).not.toContain('Command Aliases')
       expect(content).not.toContain('alias TestAlias')
@@ -192,7 +209,7 @@ describe('STOExportManager', () => {
     it('should export aliases separately', () => {
       const profile = app.getCurrentProfile()
       const content = exportManager.generateAliasFile(profile)
-      
+
       expect(content).toContain('STO Alias Configuration')
       expect(content).toContain('alias TestAlias')
       expect(content).toContain('alias AttackRun')
@@ -202,7 +219,7 @@ describe('STOExportManager', () => {
     it('should generate alias file with proper header', () => {
       const profile = app.getCurrentProfile()
       const content = exportManager.generateAliasFile(profile)
-      
+
       expect(content).toContain(profile.name + ' - STO Alias Configuration')
       expect(content).toContain('Total aliases:')
       expect(content).toContain('Save this file as "CommandAliases.txt"')
@@ -213,15 +230,15 @@ describe('STOExportManager', () => {
       const aliases = {
         ZebAlias: { commands: 'say zebra' },
         AlphaAlias: { commands: 'say alpha' },
-        BetaAlias: { commands: 'say beta' }
+        BetaAlias: { commands: 'say beta' },
       }
-      
+
       const section = exportManager.generateAliasSection(aliases)
-      
+
       const alphaIndex = section.indexOf('alias AlphaAlias')
       const betaIndex = section.indexOf('alias BetaAlias')
       const zebIndex = section.indexOf('alias ZebAlias')
-      
+
       expect(alphaIndex).toBeLessThan(betaIndex)
       expect(betaIndex).toBeLessThan(zebIndex)
     })
@@ -229,17 +246,19 @@ describe('STOExportManager', () => {
     it('should include alias descriptions as comments', () => {
       const profile = app.getCurrentProfile()
       const section = exportManager.generateAliasSection(profile.aliases)
-      
+
       expect(section).toContain('; Test alias description')
       expect(section).toContain('alias TestAlias <& say hello $$ emote wave &>')
       expect(section).toContain('; Attack sequence')
-              expect(section).toContain('alias AttackRun <& target_nearest_enemy $$ FireAll &>')
+      expect(section).toContain(
+        'alias AttackRun <& target_nearest_enemy $$ FireAll &>'
+      )
     })
 
     it('should generate keybind section with commands', () => {
       const profile = app.getCurrentProfile()
       const section = exportManager.generateKeybindSection(profile.keys)
-      
+
       expect(section).toContain('Keybind Commands')
       expect(section).toContain('F1 "FireAll $$ target_nearest_enemy"')
       expect(section).toContain('F2 "TestAlias"')
@@ -249,10 +268,12 @@ describe('STOExportManager', () => {
     it('should group keys by type for organization', () => {
       const keys = ['F1', 'F2', 'A', 'B', '1', '2', 'Space', 'Ctrl+A']
       const mockKeys = {}
-      keys.forEach(key => { mockKeys[key] = [{ command: 'test' }] })
-      
+      keys.forEach((key) => {
+        mockKeys[key] = [{ command: 'test' }]
+      })
+
       const groups = exportManager.groupKeysByType(keys, mockKeys)
-      
+
       expect(groups['Function Keys']).toContain('F1')
       expect(groups['Function Keys']).toContain('F2')
       expect(groups['Letter Keys']).toContain('A')
@@ -265,7 +286,7 @@ describe('STOExportManager', () => {
 
     it('should include footer with usage instructions', () => {
       const footer = exportManager.generateFileFooter()
-      
+
       expect(footer).toContain('End of keybind file')
       expect(footer).toContain('Additional STO Commands Reference')
       expect(footer).toContain('target_nearest_enemy')
@@ -279,7 +300,7 @@ describe('STOExportManager', () => {
     it('should sort keys using appropriate comparison', () => {
       const keys = ['B', 'F10', 'A', 'F2', '1', '10']
       const sorted = keys.sort(exportManager.compareKeys.bind(exportManager))
-      
+
       // Function keys should come first, then numbers, then letters
       expect(sorted.indexOf('F2')).toBeLessThan(sorted.indexOf('F10'))
       expect(sorted.indexOf('F10')).toBeLessThan(sorted.indexOf('1'))
@@ -290,18 +311,22 @@ describe('STOExportManager', () => {
     it('should handle function key numerical sorting', () => {
       const keys = ['F11', 'F2', 'F10', 'F1']
       const sorted = keys.sort(exportManager.compareKeys.bind(exportManager))
-      
+
       expect(sorted).toEqual(['F1', 'F2', 'F10', 'F11'])
     })
 
     it('should group function keys together', () => {
       const keys = ['F1', 'A', 'F2', 'B']
       const mockKeys = {}
-      keys.forEach(key => { mockKeys[key] = [{ command: 'test' }] })
-      
+      keys.forEach((key) => {
+        mockKeys[key] = [{ command: 'test' }]
+      })
+
       const groups = exportManager.groupKeysByType(keys, mockKeys)
-      
-      expect(groups['Function Keys']).toEqual(expect.arrayContaining(['F1', 'F2']))
+
+      expect(groups['Function Keys']).toEqual(
+        expect.arrayContaining(['F1', 'F2'])
+      )
       expect(groups['Function Keys']).not.toContain('A')
       expect(groups['Function Keys']).not.toContain('B')
     })
@@ -309,66 +334,81 @@ describe('STOExportManager', () => {
     it('should group letter keys together', () => {
       const keys = ['A', 'F1', 'Z', 'B']
       const mockKeys = {}
-      keys.forEach(key => { mockKeys[key] = [{ command: 'test' }] })
-      
+      keys.forEach((key) => {
+        mockKeys[key] = [{ command: 'test' }]
+      })
+
       const groups = exportManager.groupKeysByType(keys, mockKeys)
-      
-      expect(groups['Letter Keys']).toEqual(expect.arrayContaining(['A', 'B', 'Z']))
+
+      expect(groups['Letter Keys']).toEqual(
+        expect.arrayContaining(['A', 'B', 'Z'])
+      )
       expect(groups['Letter Keys']).not.toContain('F1')
     })
 
     it('should group special keys together', () => {
       const keys = ['Space', 'Tab', 'Enter', 'A']
       const mockKeys = {}
-      keys.forEach(key => { mockKeys[key] = [{ command: 'test' }] })
-      
+      keys.forEach((key) => {
+        mockKeys[key] = [{ command: 'test' }]
+      })
+
       const groups = exportManager.groupKeysByType(keys, mockKeys)
-      
-      expect(groups['Special Keys']).toEqual(expect.arrayContaining(['Space', 'Tab', 'Enter']))
+
+      expect(groups['Special Keys']).toEqual(
+        expect.arrayContaining(['Space', 'Tab', 'Enter'])
+      )
       expect(groups['Special Keys']).not.toContain('A')
     })
 
     it('should group modifier combinations appropriately', () => {
       const keys = ['Ctrl+A', 'Alt+F1', 'Shift+Space', 'A']
       const mockKeys = {}
-      keys.forEach(key => { mockKeys[key] = [{ command: 'test' }] })
-      
+      keys.forEach((key) => {
+        mockKeys[key] = [{ command: 'test' }]
+      })
+
       const groups = exportManager.groupKeysByType(keys, mockKeys)
-      
-      expect(groups['Modifier Combinations']).toEqual(expect.arrayContaining(['Ctrl+A', 'Alt+F1', 'Shift+Space']))
+
+      expect(groups['Modifier Combinations']).toEqual(
+        expect.arrayContaining(['Ctrl+A', 'Alt+F1', 'Shift+Space'])
+      )
       expect(groups['Modifier Combinations']).not.toContain('A')
     })
   })
 
   describe('JSON profile export', () => {
     it('should export profile as JSON', () => {
-      const mockAnchor = { 
-        click: vi.fn(), 
+      const mockAnchor = {
+        click: vi.fn(),
         download: '',
-        href: ''
+        href: '',
       }
       vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
       vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
       vi.spyOn(document.body, 'removeChild').mockImplementation(() => {})
-      
+
       const profile = app.getCurrentProfile()
       exportManager.exportJSONProfile(profile)
-      
+
       expect(mockAnchor.click).toHaveBeenCalled()
       expect(mockAnchor.download).toContain('.json')
-      expect(stoUI.showToast).toHaveBeenCalledWith('Profile exported as JSON', 'success')
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Profile exported as JSON',
+        'success'
+      )
     })
 
     it('should sanitize profile data for export', () => {
       const profile = {
         name: 'Test',
         keys: {
-          F1: [{ command: 'test', id: 'internal-id', type: 'combat' }]
-        }
+          F1: [{ command: 'test', id: 'internal-id', type: 'combat' }],
+        },
       }
-      
+
       const sanitized = exportManager.sanitizeProfileForExport(profile)
-      
+
       expect(sanitized.keys.F1[0]).not.toHaveProperty('id')
       expect(sanitized.keys.F1[0]).toHaveProperty('command')
       expect(sanitized.keys.F1[0]).toHaveProperty('type')
@@ -379,7 +419,7 @@ describe('STOExportManager', () => {
       vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
       vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
       vi.spyOn(document.body, 'removeChild').mockImplementation(() => {})
-      
+
       // Mock Blob to capture content
       let blobContent = ''
       const originalBlob = global.Blob
@@ -388,12 +428,12 @@ describe('STOExportManager', () => {
           blobContent = chunks[0]
         }
       }
-      
+
       const profile = app.getCurrentProfile()
       exportManager.exportJSONProfile(profile)
-      
+
       global.Blob = originalBlob
-      
+
       const exportData = JSON.parse(blobContent)
       expect(exportData.version).toBeDefined()
       expect(exportData.exported).toBeDefined()
@@ -404,7 +444,7 @@ describe('STOExportManager', () => {
     it('should validate JSON structure before export', () => {
       const profile = app.getCurrentProfile()
       const sanitized = exportManager.sanitizeProfileForExport(profile)
-      
+
       // Should be valid JSON
       expect(() => JSON.stringify(sanitized)).not.toThrow()
       expect(sanitized.name).toBe('Test Profile')
@@ -416,21 +456,24 @@ describe('STOExportManager', () => {
 
   describe('complete project export', () => {
     it('should export all profiles and settings', () => {
-      const mockAnchor = { 
-        click: vi.fn(), 
+      const mockAnchor = {
+        click: vi.fn(),
         download: '',
-        href: ''
+        href: '',
       }
       vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
       vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
       vi.spyOn(document.body, 'removeChild').mockImplementation(() => {})
-      
+
       exportManager.exportCompleteProject()
-      
+
       expect(mockAnchor.click).toHaveBeenCalled()
       expect(mockAnchor.download).toContain('STO_Tools_Keybinds_Project')
       expect(mockAnchor.download).toContain('.json')
-      expect(stoUI.showToast).toHaveBeenCalledWith('Complete project exported', 'success')
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Complete project exported',
+        'success'
+      )
     })
 
     it('should include application settings', () => {
@@ -438,7 +481,7 @@ describe('STOExportManager', () => {
       vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
       vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
       vi.spyOn(document.body, 'removeChild').mockImplementation(() => {})
-      
+
       // Mock Blob to capture content
       let blobContent = ''
       const originalBlob = global.Blob
@@ -447,11 +490,11 @@ describe('STOExportManager', () => {
           blobContent = chunks[0]
         }
       }
-      
+
       exportManager.exportCompleteProject()
-      
+
       global.Blob = originalBlob
-      
+
       const exportData = JSON.parse(blobContent)
       expect(exportData.type).toBe('project')
       expect(exportData.data.profiles).toBeDefined()
@@ -463,7 +506,7 @@ describe('STOExportManager', () => {
       vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
       vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
       vi.spyOn(document.body, 'removeChild').mockImplementation(() => {})
-      
+
       // Mock Blob to capture content
       let blobContent = ''
       const originalBlob = global.Blob
@@ -472,16 +515,16 @@ describe('STOExportManager', () => {
           blobContent = chunks[0]
         }
       }
-      
+
       exportManager.exportCompleteProject()
-      
+
       global.Blob = originalBlob
-      
+
       const exportData = JSON.parse(blobContent)
       expect(exportData.version).toBeDefined()
       expect(exportData.exported).toBeDefined()
       expect(exportData.type).toBe('project')
-      
+
       // Should be importable
       expect(() => JSON.parse(blobContent)).not.toThrow()
     })
@@ -489,27 +532,30 @@ describe('STOExportManager', () => {
 
   describe('CSV data export', () => {
     it('should export profile data as CSV', () => {
-      const mockAnchor = { 
-        click: vi.fn(), 
+      const mockAnchor = {
+        click: vi.fn(),
         download: '',
-        href: ''
+        href: '',
       }
       vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
       vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
       vi.spyOn(document.body, 'removeChild').mockImplementation(() => {})
-      
+
       const profile = app.getCurrentProfile()
       exportManager.exportCSVData(profile)
-      
+
       expect(mockAnchor.click).toHaveBeenCalled()
       expect(mockAnchor.download).toContain('.csv')
-      expect(stoUI.showToast).toHaveBeenCalledWith('Data exported as CSV', 'success')
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Data exported as CSV',
+        'success'
+      )
     })
 
     it('should generate CSV with proper headers', () => {
       const profile = app.getCurrentProfile()
       const csv = exportManager.generateCSVData(profile)
-      
+
       expect(csv).toMatch(/^Key,Command,Type,Description,Position/)
     })
 
@@ -523,7 +569,7 @@ describe('STOExportManager', () => {
     it('should include all relevant data fields', () => {
       const profile = app.getCurrentProfile()
       const csv = exportManager.generateCSVData(profile)
-      
+
       expect(csv).toContain('F1,FireAll,combat,Fire All Weapons,1')
       expect(csv).toContain('F1,target_nearest_enemy,targeting,Target Enemy,2')
       expect(csv).toContain('F2,TestAlias,alias,Alias: TestAlias,1')
@@ -532,31 +578,34 @@ describe('STOExportManager', () => {
 
   describe('HTML report export', () => {
     it('should generate HTML report', () => {
-      const mockAnchor = { 
-        click: vi.fn(), 
+      const mockAnchor = {
+        click: vi.fn(),
         download: '',
-        href: ''
+        href: '',
       }
       vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
       vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
       vi.spyOn(document.body, 'removeChild').mockImplementation(() => {})
-      
+
       const profile = app.getCurrentProfile()
       exportManager.exportHTMLReport(profile)
-      
+
       expect(mockAnchor.click).toHaveBeenCalled()
       expect(mockAnchor.download).toContain('.html')
-      expect(stoUI.showToast).toHaveBeenCalledWith('HTML report exported', 'success')
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'HTML report exported',
+        'success'
+      )
     })
 
     it('should include styled keybind sections', () => {
       const keys = {
         F1: [{ command: 'FireAll', type: 'combat', text: 'Fire All' }],
-        A: [{ command: 'target_self', type: 'targeting', text: 'Target Self' }]
+        A: [{ command: 'target_self', type: 'targeting', text: 'Target Self' }],
       }
-      
+
       const section = exportManager.generateHTMLKeybindSection(keys)
-      
+
       expect(section).toContain('<h2>Keybinds</h2>')
       expect(section).toContain('class="keybind"')
       expect(section).toContain('class="key">F1</div>')
@@ -568,12 +617,12 @@ describe('STOExportManager', () => {
         TestAlias: {
           name: 'TestAlias',
           description: 'Test description',
-          commands: 'say hello'
-        }
+          commands: 'say hello',
+        },
       }
-      
+
       const section = exportManager.generateHTMLAliasSection(aliases)
-      
+
       expect(section).toContain('<h2>Command Aliases</h2>')
       expect(section).toContain('class="alias"')
       expect(section).toContain('class="alias-name">TestAlias</div>')
@@ -584,7 +633,7 @@ describe('STOExportManager', () => {
     it('should include CSS styling for report', () => {
       const profile = app.getCurrentProfile()
       const html = exportManager.generateHTMLReport(profile)
-      
+
       expect(html).toContain('<style>')
       expect(html).toContain('body { font-family:')
       expect(html).toContain('.keybind {')
@@ -594,7 +643,7 @@ describe('STOExportManager', () => {
     it('should create printable format', () => {
       const profile = app.getCurrentProfile()
       const html = exportManager.generateHTMLReport(profile)
-      
+
       expect(html).toContain('<!DOCTYPE html>')
       expect(html).toContain('<html lang="en">')
       expect(html).toContain('<meta name="viewport"')
@@ -605,25 +654,28 @@ describe('STOExportManager', () => {
   describe('command preview and copying', () => {
     it('should copy command preview to clipboard', () => {
       exportManager.copyCommandPreview()
-      
-      expect(stoUI.copyToClipboard).toHaveBeenCalledWith('F1 "FireAll $$ target_nearest_enemy"')
+
+      expect(stoUI.copyToClipboard).toHaveBeenCalledWith(
+        'F1 "FireAll $$ target_nearest_enemy"'
+      )
     })
-
-
 
     it('should show success feedback on copy', () => {
       exportManager.copyCommandPreview()
-      
+
       expect(stoUI.copyToClipboard).toHaveBeenCalled()
     })
 
     it('should handle clipboard API errors', () => {
       const preview = document.getElementById('commandPreview')
       preview.textContent = ''
-      
+
       exportManager.copyCommandPreview()
-      
-      expect(stoUI.showToast).toHaveBeenCalledWith('No command to copy', 'warning')
+
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'No command to copy',
+        'warning'
+      )
     })
   })
 
@@ -631,20 +683,20 @@ describe('STOExportManager', () => {
     it('should generate appropriate filename', () => {
       const profile = { name: 'My Test Profile', mode: 'Space' }
       const filename = exportManager.generateFileName(profile, 'txt')
-      
+
       expect(filename).toMatch(/^My_Test_Profile_Space_\d{4}-\d{2}-\d{2}\.txt$/)
     })
 
     it('should sanitize profile names for filenames', () => {
       const profile = { name: 'Profile! @#$%^&*()Name', mode: 'Ground' }
       const filename = exportManager.generateFileName(profile, 'json')
-      
+
       expect(filename).toMatch(/^Profile_+Name_Ground_\d{4}-\d{2}-\d{2}\.json$/)
     })
 
     it('should include file extension in filename', () => {
       const profile = { name: 'Test', mode: 'Space' }
-      
+
       expect(exportManager.generateFileName(profile, 'txt')).toMatch(/\.txt$/)
       expect(exportManager.generateFileName(profile, 'json')).toMatch(/\.json$/)
       expect(exportManager.generateFileName(profile, 'csv')).toMatch(/\.csv$/)
@@ -652,17 +704,21 @@ describe('STOExportManager', () => {
     })
 
     it('should trigger file download', () => {
-      const mockAnchor = { 
+      const mockAnchor = {
         click: vi.fn(),
         download: '',
-        href: ''
+        href: '',
       }
-      const appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
-      const removeChildSpy = vi.spyOn(document.body, 'removeChild').mockImplementation(() => {})
+      const appendChildSpy = vi
+        .spyOn(document.body, 'appendChild')
+        .mockImplementation(() => {})
+      const removeChildSpy = vi
+        .spyOn(document.body, 'removeChild')
+        .mockImplementation(() => {})
       vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
-      
+
       exportManager.downloadFile('test content', 'test.txt', 'text/plain')
-      
+
       expect(mockAnchor.download).toBe('test.txt')
       expect(mockAnchor.click).toHaveBeenCalled()
       expect(appendChildSpy).toHaveBeenCalledWith(mockAnchor)
@@ -670,15 +726,15 @@ describe('STOExportManager', () => {
     })
 
     it('should set correct MIME type for download', () => {
-      const mockAnchor = { 
+      const mockAnchor = {
         click: vi.fn(),
         href: '',
-        download: ''
+        download: '',
       }
       vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
       vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
       vi.spyOn(document.body, 'removeChild').mockImplementation(() => {})
-      
+
       // Mock Blob to capture MIME type
       let mimeType = ''
       const originalBlob = global.Blob
@@ -687,30 +743,30 @@ describe('STOExportManager', () => {
           mimeType = options.type
         }
       }
-      
+
       exportManager.downloadFile('content', 'test.txt', 'text/plain')
-      
+
       global.Blob = originalBlob
-      
+
       expect(mimeType).toBe('text/plain')
     })
 
     it('should handle large file downloads', () => {
-      const mockAnchor = { 
+      const mockAnchor = {
         click: vi.fn(),
         href: '',
-        download: ''
+        download: '',
       }
       vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
       vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
       vi.spyOn(document.body, 'removeChild').mockImplementation(() => {})
-      
+
       const largeContent = 'x'.repeat(1000000) // 1MB of content
-      
+
       expect(() => {
         exportManager.downloadFile(largeContent, 'large.txt', 'text/plain')
       }).not.toThrow()
-      
+
       expect(mockAnchor.click).toHaveBeenCalled()
     })
   })
@@ -719,13 +775,13 @@ describe('STOExportManager', () => {
     it('should import from file', () => {
       // Test the import method exists and can handle file types
       expect(typeof exportManager.importFromFile).toBe('function')
-      
+
       // Test JSON import directly
       const validJSON = JSON.stringify({
         type: 'profile',
-        profile: { name: 'Test', keys: {}, aliases: {} }
+        profile: { name: 'Test', keys: {}, aliases: {} },
       })
-      
+
       expect(() => {
         exportManager.importJSONFile(validJSON)
       }).not.toThrow()
@@ -734,9 +790,9 @@ describe('STOExportManager', () => {
     it('should validate imported JSON structure', () => {
       const validJSON = JSON.stringify({
         type: 'profile',
-        profile: { name: 'Test', keys: {}, aliases: {} }
+        profile: { name: 'Test', keys: {}, aliases: {} },
       })
-      
+
       expect(() => {
         exportManager.importJSONFile(validJSON)
       }).not.toThrow()
@@ -744,7 +800,7 @@ describe('STOExportManager', () => {
 
     it('should handle import errors gracefully', () => {
       const invalidJSON = 'invalid json content'
-      
+
       expect(() => {
         exportManager.importJSONFile(invalidJSON)
       }).toThrow('Invalid JSON file')
@@ -753,9 +809,9 @@ describe('STOExportManager', () => {
     it('should merge imported data appropriately', () => {
       const projectJSON = JSON.stringify({
         type: 'project',
-        data: { profiles: {}, settings: {} }
+        data: { profiles: {}, settings: {} },
       })
-      
+
       expect(() => {
         exportManager.importJSONFile(projectJSON)
       }).not.toThrow()
@@ -764,18 +820,21 @@ describe('STOExportManager', () => {
 
   describe('bulk operations', () => {
     it('should export all profiles', () => {
-      const mockAnchor = { 
+      const mockAnchor = {
         click: vi.fn(),
         href: '',
-        download: ''
+        download: '',
       }
       vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
       vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
       vi.spyOn(document.body, 'removeChild').mockImplementation(() => {})
-      
+
       exportManager.exportAllProfiles()
-      
-      expect(stoUI.showToast).toHaveBeenCalledWith(expect.stringMatching(/Exporting \d+ profiles\.\.\./), 'info')
+
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        expect.stringMatching(/Exporting \d+ profiles\.\.\./),
+        'info'
+      )
     })
 
     it('should create archive of multiple exports', () => {
@@ -783,59 +842,67 @@ describe('STOExportManager', () => {
       const testProfile2 = {
         id: 'test-profile-2',
         name: 'Test Profile 2',
-        keys: { F1: [{ command: 'test' }] }
+        keys: { F1: [{ command: 'test' }] },
       }
       stoStorage.saveProfile(testProfile2.id, testProfile2)
-      
-      const mockAnchor = { 
+
+      const mockAnchor = {
         click: vi.fn(),
         href: '',
-        download: ''
+        download: '',
       }
       vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
       vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
       vi.spyOn(document.body, 'removeChild').mockImplementation(() => {})
-      
+
       exportManager.exportAllProfiles()
-      
-      expect(stoUI.showToast).toHaveBeenCalledWith('Exporting 2 profiles...', 'info')
+
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Exporting 2 profiles...',
+        'info'
+      )
     })
 
-          it('should handle export progress indication', () => {
-        // Mock the getAllData method to return empty profiles
-        const mockGetAllData = vi.spyOn(stoStorage, 'getAllData').mockReturnValue({
+    it('should handle export progress indication', () => {
+      // Mock the getAllData method to return empty profiles
+      const mockGetAllData = vi
+        .spyOn(stoStorage, 'getAllData')
+        .mockReturnValue({
           profiles: {},
-          currentProfile: null
+          currentProfile: null,
         })
-        
-        exportManager.exportAllProfiles()
-        
-        expect(stoUI.showToast).toHaveBeenCalledWith('No profiles to export', 'warning')
-        
-        mockGetAllData.mockRestore()
-      })
+
+      exportManager.exportAllProfiles()
+
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'No profiles to export',
+        'warning'
+      )
+
+      mockGetAllData.mockRestore()
+    })
   })
 
   describe('export options and configuration', () => {
     it('should show export options dialog', () => {
-      const mockAnchor = { 
+      const mockAnchor = {
         click: vi.fn(),
         href: '',
-        download: ''
+        download: '',
       }
       vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
       vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
       vi.spyOn(document.body, 'removeChild').mockImplementation(() => {})
-      
+
       exportManager.showExportOptions()
-      
+
       // For now it directly exports, but should show options in future
       expect(mockAnchor.click).toHaveBeenCalled()
     })
 
     it('should handle different export formats', () => {
       const formats = exportManager.exportFormats
-      
+
       expect(Object.keys(formats)).toHaveLength(5)
       expect(formats.sto_keybind).toContain('.txt')
       expect(formats.json_profile).toContain('.json')
@@ -845,15 +912,18 @@ describe('STOExportManager', () => {
 
     it('should validate profile before export', () => {
       app.currentProfile = null
-      
+
       exportManager.showExportOptions()
-      
-      expect(stoUI.showToast).toHaveBeenCalledWith('No profile selected to export', 'warning')
+
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'No profile selected to export',
+        'warning'
+      )
     })
 
     it('should provide format-specific options', () => {
       const profile = app.getCurrentProfile()
-      
+
       // Each format should have specific handling
       expect(() => exportManager.exportSTOKeybindFile(profile)).not.toThrow()
       expect(() => exportManager.exportJSONProfile(profile)).not.toThrow()
@@ -864,32 +934,35 @@ describe('STOExportManager', () => {
 
   describe('alias export functionality', () => {
     it('should export aliases to file', () => {
-      const mockAnchor = { 
-        click: vi.fn(), 
+      const mockAnchor = {
+        click: vi.fn(),
         download: '',
-        href: ''
+        href: '',
       }
       vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
       vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
       vi.spyOn(document.body, 'removeChild').mockImplementation(() => {})
-      
+
       const profile = app.getCurrentProfile()
       exportManager.exportAliases(profile)
-      
+
       expect(mockAnchor.click).toHaveBeenCalled()
       expect(mockAnchor.download).toContain('aliases')
       expect(mockAnchor.download).toContain('.txt')
-      expect(stoUI.showToast).toHaveBeenCalledWith('Aliases exported successfully', 'success')
+      expect(stoUI.showToast).toHaveBeenCalledWith(
+        'Aliases exported successfully',
+        'success'
+      )
     })
 
     it('should generate alias filename with proper format', () => {
       const profile = {
         name: 'Test Profile',
-        mode: 'space'
+        mode: 'space',
       }
-      
+
       const filename = exportManager.generateAliasFileName(profile, 'txt')
-      
+
       expect(filename).toContain('Test_Profile')
       expect(filename).toContain('aliases')
       expect(filename).toContain('space')
@@ -900,11 +973,11 @@ describe('STOExportManager', () => {
       const profile = {
         name: 'Empty Profile',
         mode: 'space',
-        aliases: {}
+        aliases: {},
       }
-      
+
       const content = exportManager.generateAliasFile(profile)
-      
+
       expect(content).toContain('No aliases defined')
       expect(content).toContain('Total aliases: 0')
     })
@@ -913,14 +986,14 @@ describe('STOExportManager', () => {
   describe('UI elements', () => {
     it('should have export aliases button', () => {
       const exportBtn = document.getElementById('exportAliasesBtn')
-      
+
       expect(exportBtn).toBeTruthy()
       expect(exportBtn.id).toBe('exportAliasesBtn')
     })
 
     it('should have import aliases button', () => {
       const importBtn = document.getElementById('importAliasesBtn')
-      
+
       expect(importBtn).toBeTruthy()
       expect(importBtn.id).toBe('importAliasesBtn')
     })
@@ -928,12 +1001,12 @@ describe('STOExportManager', () => {
 
   describe('execution order stabilization export', () => {
     let mockAnchor
-    
+
     beforeEach(() => {
-      mockAnchor = { 
+      mockAnchor = {
         click: vi.fn(),
         href: '',
-        download: ''
+        download: '',
       }
       vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
       vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
@@ -948,19 +1021,21 @@ describe('STOExportManager', () => {
           F1: [
             { command: '+TrayExecByTray 9 0' },
             { command: '+TrayExecByTray 9 1' },
-            { command: '+TrayExecByTray 9 2' }
-          ]
+            { command: '+TrayExecByTray 9 2' },
+          ],
         },
         aliases: {},
         // No keybindMetadata, so no per-key stabilization
       }
-      
+
       const options = { stabilizeExecutionOrder: false }
       const content = exportManager.generateSTOKeybindFile(profile, options)
-      
+
       // Should contain normal command chain (no per-key metadata to trigger mirroring)
-      expect(content).toContain('F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2"')
-      
+      expect(content).toContain(
+        'F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2"'
+      )
+
       // Should not contain stabilization header
       expect(content).not.toContain('EXECUTION ORDER STABILIZATION: ON')
     })
@@ -973,28 +1048,28 @@ describe('STOExportManager', () => {
           F1: [
             { command: '+TrayExecByTray 9 0' },
             { command: '+TrayExecByTray 9 1' },
-            { command: '+TrayExecByTray 9 2' }
+            { command: '+TrayExecByTray 9 2' },
           ],
-          F2: [
-            { command: 'FirePhasers' }
-          ]
+          F2: [{ command: 'FirePhasers' }],
         },
         aliases: {},
         keybindMetadata: {
-          F1: { stabilizeExecutionOrder: true }
+          F1: { stabilizeExecutionOrder: true },
           // F2 has no metadata
-        }
+        },
       }
-      
+
       const options = { stabilizeExecutionOrder: false }
       const content = exportManager.generateSTOKeybindFile(profile, options)
-      
+
       // F1 should be mirrored due to per-key metadata
-      expect(content).toContain('F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"')
-      
+      expect(content).toContain(
+        'F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"'
+      )
+
       // F2 should not be mirrored (no metadata)
       expect(content).toContain('F2 "FirePhasers"')
-      
+
       // Should not contain global stabilization header
       expect(content).not.toContain('EXECUTION ORDER STABILIZATION: ON')
     })
@@ -1007,22 +1082,28 @@ describe('STOExportManager', () => {
           F1: [
             { command: '+TrayExecByTray 9 0' },
             { command: '+TrayExecByTray 9 1' },
-            { command: '+TrayExecByTray 9 2' }
-          ]
+            { command: '+TrayExecByTray 9 2' },
+          ],
         },
-        aliases: {}
+        aliases: {},
       }
-      
+
       const options = { stabilizeExecutionOrder: true }
       const content = exportManager.generateSTOKeybindFile(profile, options)
-      
+
       // Should contain stabilization header
       expect(content).toContain('EXECUTION ORDER STABILIZATION: ON')
-      expect(content).toContain('Commands are mirrored to ensure consistent execution order')
-      expect(content).toContain('Phase 1: left-to-right, Phase 2: right-to-left')
-      
+      expect(content).toContain(
+        'Commands are mirrored to ensure consistent execution order'
+      )
+      expect(content).toContain(
+        'Phase 1: left-to-right, Phase 2: right-to-left'
+      )
+
       // Should contain mirrored command chain
-      expect(content).toContain('F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"')
+      expect(content).toContain(
+        'F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"'
+      )
     })
 
     it('should not mirror single commands', () => {
@@ -1030,14 +1111,14 @@ describe('STOExportManager', () => {
         name: 'Test Profile',
         mode: 'space',
         keys: {
-          F1: [{ command: 'FirePhasers' }]
+          F1: [{ command: 'FirePhasers' }],
         },
-        aliases: {}
+        aliases: {},
       }
-      
+
       const options = { stabilizeExecutionOrder: true }
       const content = exportManager.generateSTOKeybindFile(profile, options)
-      
+
       // Single command should not be mirrored
       expect(content).toContain('F1 "FirePhasers"')
       expect(content).not.toContain('FirePhasers $$ FirePhasers')
@@ -1051,20 +1132,22 @@ describe('STOExportManager', () => {
           F1: [{ command: 'FirePhasers' }], // Single command
           F2: [
             { command: '+TrayExecByTray 9 0' },
-            { command: '+TrayExecByTray 9 1' }
-          ] // Multi-command
+            { command: '+TrayExecByTray 9 1' },
+          ], // Multi-command
         },
-        aliases: {}
+        aliases: {},
       }
-      
+
       const options = { stabilizeExecutionOrder: true }
       const content = exportManager.generateSTOKeybindFile(profile, options)
-      
+
       // Single command should not be mirrored
       expect(content).toContain('F1 "FirePhasers"')
-      
+
       // Multi-command should be mirrored
-      expect(content).toContain('F2 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"')
+      expect(content).toContain(
+        'F2 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"'
+      )
     })
 
     it('should handle stabilization with different command types', () => {
@@ -1075,17 +1158,19 @@ describe('STOExportManager', () => {
           F1: [
             { command: 'FirePhasers' },
             { command: 'target_nearest_enemy' },
-            { command: '+power_exec Distribute_Shields' }
-          ]
+            { command: '+power_exec Distribute_Shields' },
+          ],
         },
-        aliases: {}
+        aliases: {},
       }
-      
+
       const options = { stabilizeExecutionOrder: true }
       const content = exportManager.generateSTOKeybindFile(profile, options)
-      
+
       // Should contain mirrored command chain with mixed command types
-      expect(content).toContain('F1 "FirePhasers $$ target_nearest_enemy $$ +power_exec Distribute_Shields $$ target_nearest_enemy $$ FirePhasers"')
+      expect(content).toContain(
+        'F1 "FirePhasers $$ target_nearest_enemy $$ +power_exec Distribute_Shields $$ target_nearest_enemy $$ FirePhasers"'
+      )
     })
 
     it('should include documentation example pattern', () => {
@@ -1094,20 +1179,21 @@ describe('STOExportManager', () => {
       for (let i = 0; i <= 9; i++) {
         commands.push({ command: `+TrayExecByTray 9 ${i}` })
       }
-      
+
       const profile = {
         name: 'Tray Test',
         mode: 'space',
         keys: { numpad0: commands },
-        aliases: {}
+        aliases: {},
       }
-      
+
       const options = { stabilizeExecutionOrder: true }
       const content = exportManager.generateSTOKeybindFile(profile, options)
-      
+
       // Should contain the mirrored tray sequence
-      const expectedPattern = '+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 3 $$ +TrayExecByTray 9 4 $$ +TrayExecByTray 9 5 $$ +TrayExecByTray 9 6 $$ +TrayExecByTray 9 7 $$ +TrayExecByTray 9 8 $$ +TrayExecByTray 9 9 $$ +TrayExecByTray 9 8 $$ +TrayExecByTray 9 7 $$ +TrayExecByTray 9 6 $$ +TrayExecByTray 9 5 $$ +TrayExecByTray 9 4 $$ +TrayExecByTray 9 3 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0'
-      
+      const expectedPattern =
+        '+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 3 $$ +TrayExecByTray 9 4 $$ +TrayExecByTray 9 5 $$ +TrayExecByTray 9 6 $$ +TrayExecByTray 9 7 $$ +TrayExecByTray 9 8 $$ +TrayExecByTray 9 9 $$ +TrayExecByTray 9 8 $$ +TrayExecByTray 9 7 $$ +TrayExecByTray 9 6 $$ +TrayExecByTray 9 5 $$ +TrayExecByTray 9 4 $$ +TrayExecByTray 9 3 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0'
+
       expect(content).toContain(`numpad0 "${expectedPattern}"`)
     })
 
@@ -1121,19 +1207,20 @@ describe('STOExportManager', () => {
             { command: '+TrayExecByTray 9 8' },
             { command: 'FirePhasers' },
             { command: '+TrayExecByTray 9 7' },
-            { command: '+TrayExecByTray 9 6' }
-          ]
+            { command: '+TrayExecByTray 9 6' },
+          ],
         },
-        aliases: {}
+        aliases: {},
       }
-      
+
       const options = { stabilizeExecutionOrder: true }
       const content = exportManager.generateSTOKeybindFile(profile, options)
-      
+
       // Should create proper mirror with central FirePhasers command
-      const expectedPattern = '+TrayExecByTray 9 9 $$ +TrayExecByTray 9 8 $$ FirePhasers $$ +TrayExecByTray 9 7 $$ +TrayExecByTray 9 6 $$ +TrayExecByTray 9 7 $$ FirePhasers $$ +TrayExecByTray 9 8 $$ +TrayExecByTray 9 9'
-      
+      const expectedPattern =
+        '+TrayExecByTray 9 9 $$ +TrayExecByTray 9 8 $$ FirePhasers $$ +TrayExecByTray 9 7 $$ +TrayExecByTray 9 6 $$ +TrayExecByTray 9 7 $$ FirePhasers $$ +TrayExecByTray 9 8 $$ +TrayExecByTray 9 9'
+
       expect(content).toContain(`Space "${expectedPattern}"`)
     })
   })
-}) 
+})

--- a/tests/unit/fileexplorer.test.js
+++ b/tests/unit/fileexplorer.test.js
@@ -9,7 +9,10 @@ import STOExportManager from '../../src/js/export.js'
 import STOFileExplorer from '../../src/js/fileexplorer.js'
 
 // Load real HTML
-const htmlContent = readFileSync(resolve(__dirname, '../../src/index.html'), 'utf-8')
+const htmlContent = readFileSync(
+  resolve(__dirname, '../../src/index.html'),
+  'utf-8'
+)
 
 let stoFileExplorer
 let stoUI
@@ -48,13 +51,19 @@ describe('STOFileExplorer', () => {
     stoFileExplorer.buildTree()
 
     // Check for default profiles that exist
-    const profileNode = Array.from(document.querySelectorAll('.tree-node.profile')).find(n => n.textContent.startsWith('Default Space'))
+    const profileNode = Array.from(
+      document.querySelectorAll('.tree-node.profile')
+    ).find((n) => n.textContent.startsWith('Default Space'))
     expect(profileNode).toBeTruthy()
     expect(profileNode.textContent.startsWith('Default Space')).toBe(true)
 
     // Child build nodes
-    const spaceNode = Array.from(profileNode.querySelectorAll('.tree-node.build')).find(n => n.textContent.startsWith('Space'))
-    const groundNode = Array.from(profileNode.querySelectorAll('.tree-node.build')).find(n => n.textContent.startsWith('Ground'))
+    const spaceNode = Array.from(
+      profileNode.querySelectorAll('.tree-node.build')
+    ).find((n) => n.textContent.startsWith('Space'))
+    const groundNode = Array.from(
+      profileNode.querySelectorAll('.tree-node.build')
+    ).find((n) => n.textContent.startsWith('Ground'))
     const aliasNode = profileNode.querySelector('.tree-node.aliases')
 
     expect(spaceNode).toBeTruthy()
@@ -66,8 +75,12 @@ describe('STOFileExplorer', () => {
     stoFileExplorer.openExplorer()
 
     // Click space build node - use default_space profile which already exists
-    const spaceNode = Array.from(document.querySelectorAll('.tree-node.build')).find(n => 
-      n.textContent.startsWith('Space') && n.getAttribute('data-profileid') === 'default_space'
+    const spaceNode = Array.from(
+      document.querySelectorAll('.tree-node.build')
+    ).find(
+      (n) =>
+        n.textContent.startsWith('Space') &&
+        n.getAttribute('data-profileid') === 'default_space'
     )
     expect(spaceNode).toBeTruthy()
     spaceNode.click()
@@ -81,7 +94,9 @@ describe('STOFileExplorer', () => {
     stoFileExplorer.openExplorer()
 
     // Use default_space profile which already exists
-    const aliasNode = Array.from(document.querySelectorAll('.tree-node.aliases')).find(n => n.getAttribute('data-profileid') === 'default_space')
+    const aliasNode = Array.from(
+      document.querySelectorAll('.tree-node.aliases')
+    ).find((n) => n.getAttribute('data-profileid') === 'default_space')
     expect(aliasNode).toBeTruthy()
     aliasNode.click()
 
@@ -94,14 +109,18 @@ describe('STOFileExplorer', () => {
     stoFileExplorer.openExplorer()
 
     // Select alias node to populate preview - use default_space profile
-    const aliasNode = Array.from(document.querySelectorAll('.tree-node.aliases')).find(n => n.getAttribute('data-profileid') === 'default_space')
+    const aliasNode = Array.from(
+      document.querySelectorAll('.tree-node.aliases')
+    ).find((n) => n.getAttribute('data-profileid') === 'default_space')
     expect(aliasNode).toBeTruthy()
     aliasNode.click()
 
-    const copySpy = vi.spyOn(stoUI, 'copyToClipboard').mockImplementation(() => {})
+    const copySpy = vi
+      .spyOn(stoUI, 'copyToClipboard')
+      .mockImplementation(() => {})
 
     document.getElementById('copyFileContentBtn').click()
 
     expect(copySpy).toHaveBeenCalled()
   })
-}) 
+})

--- a/tests/unit/keybinds.test.js
+++ b/tests/unit/keybinds.test.js
@@ -16,19 +16,19 @@ beforeEach(() => {
   global.window = global.window || {}
   global.stoStorage = new STOStorage()
   global.stoCommands = new STOCommandManager()
-  
+
   // Mock only the UI methods that would show actual UI
   global.stoUI = {
-    showToast: vi.fn()
+    showToast: vi.fn(),
   }
-  
+
   // Mock only the app methods that would modify actual DOM
   global.app = {
     getCurrentProfile: vi.fn(() => ({
       keys: {},
       aliases: {},
       name: 'Test Profile',
-      mode: 'Space'
+      mode: 'Space',
     })),
     currentProfile: 'test-profile',
     currentEnvironment: 'space',
@@ -37,7 +37,7 @@ beforeEach(() => {
     renderKeyGrid: vi.fn(),
     renderCommandChain: vi.fn(),
     saveCurrentBuild: vi.fn(),
-    saveProfile: vi.fn()
+    saveProfile: vi.fn(),
   }
 
   store.currentProfile = 'test-profile'
@@ -48,9 +48,9 @@ beforeEach(() => {
     name: 'Test Profile',
     builds: {
       space: { keys: {} },
-      ground: { keys: {} }
+      ground: { keys: {} },
     },
-    aliases: {}
+    aliases: {},
   }))
 
   global.stoStorage.saveProfile = vi.fn()
@@ -111,7 +111,7 @@ describe('STOKeybindFileManager', () => {
     it('should parse standard keybind format', () => {
       const content = 'F1 "say hello" ""'
       const result = keybindManager.parseKeybindFile(content)
-      
+
       expect(result.keybinds).toHaveProperty('F1')
       expect(result.keybinds.F1.key).toBe('F1')
       expect(result.keybinds.F1.commands).toHaveLength(1)
@@ -121,7 +121,7 @@ describe('STOKeybindFileManager', () => {
     it('should parse bind command format', () => {
       const content = '/bind F2 "say world"'
       const result = keybindManager.parseKeybindFile(content)
-      
+
       expect(result.keybinds).toHaveProperty('F2')
       expect(result.keybinds.F2.key).toBe('F2')
       expect(result.keybinds.F2.commands[0].command).toBe('say world')
@@ -130,16 +130,17 @@ describe('STOKeybindFileManager', () => {
     it('should parse alias definitions', () => {
       const content = 'alias TestAlias "say test"'
       const result = keybindManager.parseKeybindFile(content)
-      
+
       expect(result.aliases).toHaveProperty('TestAlias')
       expect(result.aliases.TestAlias.name).toBe('TestAlias')
       expect(result.aliases.TestAlias.commands).toBe('say test')
     })
 
     it('should skip comment lines', () => {
-      const content = '# This is a comment\n; Another comment\nF1 "say hello" ""'
+      const content =
+        '# This is a comment\n; Another comment\nF1 "say hello" ""'
       const result = keybindManager.parseKeybindFile(content)
-      
+
       expect(result.comments).toHaveLength(2)
       expect(result.comments[0].content).toBe('# This is a comment')
       expect(result.comments[1].content).toBe('; Another comment')
@@ -147,9 +148,10 @@ describe('STOKeybindFileManager', () => {
     })
 
     it('should handle multi-line files', () => {
-      const content = 'F1 "say hello" ""\nF2 "say world" ""\nalias Test "say test"'
+      const content =
+        'F1 "say hello" ""\nF2 "say world" ""\nalias Test "say test"'
       const result = keybindManager.parseKeybindFile(content)
-      
+
       expect(Object.keys(result.keybinds)).toHaveLength(2)
       expect(Object.keys(result.aliases)).toHaveLength(1)
     })
@@ -157,7 +159,7 @@ describe('STOKeybindFileManager', () => {
     it('should collect parsing errors', () => {
       const content = 'invalid line format\nF1 "say hello" ""'
       const result = keybindManager.parseKeybindFile(content)
-      
+
       expect(result.errors).toHaveLength(1)
       expect(result.errors[0].line).toBe(1)
       expect(result.errors[0].error).toBe('Invalid keybind format')
@@ -166,7 +168,7 @@ describe('STOKeybindFileManager', () => {
     it('should handle empty lines gracefully', () => {
       const content = '\n\nF1 "say hello" ""\n\n'
       const result = keybindManager.parseKeybindFile(content)
-      
+
       expect(result.keybinds).toHaveProperty('F1')
       expect(result.errors).toHaveLength(0)
     })
@@ -175,34 +177,40 @@ describe('STOKeybindFileManager', () => {
       const content = `alias test_quoted "say hello world"
 alias test_bracket <& say hello world &>
 alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2" &>`
-      
+
       const result = keybindManager.parseKeybindFile(content)
-      
+
       expect(result.aliases).toHaveProperty('test_quoted')
       expect(result.aliases.test_quoted.commands).toBe('say hello world')
-      
+
       expect(result.aliases).toHaveProperty('test_bracket')
       expect(result.aliases.test_bracket.commands).toBe('say hello world')
-      
+
       expect(result.aliases).toHaveProperty('complex_bracket')
-      expect(result.aliases.complex_bracket.commands).toBe('TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2"')
-      
+      expect(result.aliases.complex_bracket.commands).toBe(
+        'TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2"'
+      )
+
       expect(Object.keys(result.aliases)).toHaveLength(3)
     })
   })
 
   describe('command string parsing', () => {
     it('should split commands by $$ delimiter', () => {
-      const commands = keybindManager.parseCommandString('say hello $$ emote wave')
-      
+      const commands = keybindManager.parseCommandString(
+        'say hello $$ emote wave'
+      )
+
       expect(commands).toHaveLength(2)
       expect(commands[0].command).toBe('say hello')
       expect(commands[1].command).toBe('emote wave')
     })
 
     it('should detect tray execution commands', () => {
-      const commands = keybindManager.parseCommandString('+STOTrayExecByTray 0 1')
-      
+      const commands = keybindManager.parseCommandString(
+        '+STOTrayExecByTray 0 1'
+      )
+
       expect(commands).toHaveLength(1)
       expect(commands[0].command).toBe('+STOTrayExecByTray 0 1')
       expect(commands[0].type).toBe('tray')
@@ -210,8 +218,10 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
     })
 
     it('should extract tray parameters', () => {
-      const commands = keybindManager.parseCommandString('+STOTrayExecByTray 2 5')
-      
+      const commands = keybindManager.parseCommandString(
+        '+STOTrayExecByTray 2 5'
+      )
+
       expect(commands[0].parameters.tray).toBe(2)
       expect(commands[0].parameters.slot).toBe(5)
       expect(commands[0].text).toBe('Execute Tray 3 Slot 6')
@@ -219,7 +229,7 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
 
     it('should handle communication commands', () => {
       const commands = keybindManager.parseCommandString('say hello world')
-      
+
       expect(commands[0].command).toBe('say hello world')
       expect(commands[0].type).toBe('communication')
       expect(commands[0].icon).toBe('💬')
@@ -227,13 +237,13 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
 
     it('should generate command IDs', () => {
       const commands = keybindManager.parseCommandString('say hello')
-      
+
       expect(commands[0].id).toMatch(/^imported_\d+_0$/)
     })
 
     it('should set command types and icons', () => {
       const commands = keybindManager.parseCommandString('say hello')
-      
+
       expect(commands[0].type).toBe('communication')
       expect(commands[0].icon).toBe('💬')
     })
@@ -245,7 +255,7 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
         keys: { F1: [{ command: 'existing' }] },
         aliases: {},
         name: 'Test Profile',
-        mode: 'Space'
+        mode: 'Space',
       })
       global.app.saveProfile = vi.fn()
       global.app.renderKeyGrid = vi.fn()
@@ -254,7 +264,7 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
     it('should import valid keybind file content', () => {
       const content = 'F2 "say hello" ""'
       const result = keybindManager.importKeybindFile(content)
-      
+
       expect(result.success).toBe(true)
       expect(result.imported.keys).toBe(1)
       expect(stoStorage.saveProfile).toHaveBeenCalled()
@@ -263,7 +273,7 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
     it('should merge with existing profile data', () => {
       const content = 'F2 "say hello" ""'
       const result = keybindManager.importKeybindFile(content)
-      
+
       expect(result.success).toBe(true)
       expect(result.imported.keys).toBe(1)
       // Test that the import function succeeded
@@ -273,7 +283,7 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
     it('should handle duplicate key bindings', () => {
       const content = 'F1 "say new" ""'
       const result = keybindManager.importKeybindFile(content)
-      
+
       expect(result.success).toBe(true)
       expect(result.imported.keys).toBe(1)
       // Test that the import function succeeded
@@ -283,7 +293,7 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
     it('should preserve existing commands when merging', () => {
       const content = 'F2 "say hello" ""'
       const result = keybindManager.importKeybindFile(content)
-      
+
       expect(result.success).toBe(true)
       expect(result.imported.keys).toBe(1)
       // Test that the import function succeeded
@@ -293,14 +303,14 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
     it('should update profile modification timestamp', () => {
       const content = 'F1 "say hello" ""'
       keybindManager.importKeybindFile(content)
-      
+
       expect(app.setModified).toHaveBeenCalledWith(true)
     })
 
     it('should show import summary', () => {
       const content = 'F1 "say hello" ""\nalias Test "say test"'
       keybindManager.importKeybindFile(content)
-      
+
       expect(stoUI.showToast).toHaveBeenCalledWith(
         'Import completed: 1 keybinds (1 aliases ignored - use Import Aliases)',
         'success'
@@ -312,12 +322,12 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
         name: 'Test',
         mode: 'Space',
         keys: {},
-        aliases: {}
+        aliases: {},
       }
-      
+
       const content = 'F1 "say hello"\nalias TestAlias "say test"'
       const result = keybindManager.importKeybindFile(content)
-      
+
       // Should only import keybinds, not aliases
       expect(result.success).toBe(true)
       expect(result.imported.keys).toBe(1)
@@ -329,13 +339,13 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
         name: 'Test',
         mode: 'Space',
         keys: {},
-        aliases: {}
+        aliases: {},
       }
       global.app.getCurrentProfile.mockReturnValue(profile)
-      
+
       const content = 'F1 "say hello"\nalias TestAlias "say test"'
       const result = keybindManager.importAliasFile(content)
-      
+
       // Should only import aliases, not keybinds
       expect(result.success).toBe(true)
       expect(result.imported.aliases).toBe(1)
@@ -349,11 +359,11 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
         name: 'Test Profile',
         mode: 'Space',
         keys: { F1: [{ command: 'say hello' }] },
-        aliases: {}
+        aliases: {},
       }
-      
+
       const output = keybindManager.exportProfile(profile)
-      
+
       expect(output).toContain('# Test Profile - Space mode')
       expect(output).toContain('F1 "say hello" ""')
     })
@@ -363,16 +373,16 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
         name: 'Test',
         mode: 'Space',
         keys: {
-          'A': [{ command: 'say a' }],
-          'F1': [{ command: 'say f1' }],
-          '1': [{ command: 'say 1' }]
+          A: [{ command: 'say a' }],
+          F1: [{ command: 'say f1' }],
+          1: [{ command: 'say 1' }],
         },
-        aliases: {}
+        aliases: {},
       }
-      
+
       const output = keybindManager.exportProfile(profile)
-      const lines = output.split('\n').filter(line => line.match(/^[FA1]/))
-      
+      const lines = output.split('\n').filter((line) => line.match(/^[FA1]/))
+
       expect(lines[0]).toContain('F1')
       expect(lines[1]).toContain('1')
       expect(lines[2]).toContain('A')
@@ -383,11 +393,11 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
         name: 'Test',
         mode: 'Space',
         keys: { F1: [{ command: 'say hello world' }] },
-        aliases: {}
+        aliases: {},
       }
-      
+
       const output = keybindManager.exportProfile(profile)
-      
+
       expect(output).toContain('F1 "say hello world" ""')
     })
 
@@ -396,17 +406,17 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
         name: 'Test',
         mode: 'Space',
         keys: {
-          'F1': [{ command: 'say f1' }],
-          'F2': [{ command: 'say f2' }],
-          'A': [{ command: 'say a' }],
-          'B': [{ command: 'say b' }]
+          F1: [{ command: 'say f1' }],
+          F2: [{ command: 'say f2' }],
+          A: [{ command: 'say a' }],
+          B: [{ command: 'say b' }],
         },
-        aliases: {}
+        aliases: {},
       }
-      
+
       const output = keybindManager.exportProfile(profile)
-      const lines = output.split('\n').filter(line => line.match(/^[FAB]/))
-      
+      const lines = output.split('\n').filter((line) => line.match(/^[FAB]/))
+
       expect(lines[0]).toContain('F1')
       expect(lines[1]).toContain('F2')
       expect(lines[2]).toContain('A')
@@ -418,11 +428,11 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
         name: 'Test Profile',
         mode: 'Ground',
         keys: {},
-        aliases: {}
+        aliases: {},
       }
-      
+
       const output = keybindManager.exportProfile(profile)
-      
+
       expect(output).toContain('# Test Profile - Ground mode')
       expect(output).toContain('# Generated by STO Tools Keybind Manager')
       expect(output).toMatch(/# \d{1,2}\/\d{1,2}\/\d{4}/)
@@ -433,9 +443,9 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
         name: 'Test',
         mode: 'Space',
         keys: { F1: [{ command: 'say hello' }] },
-        aliases: { TestAlias: { commands: 'say test' } }
+        aliases: { TestAlias: { commands: 'say test' } },
       }
-      
+
       const output = keybindManager.exportProfile(profile)
       expect(output).toContain('F1 "say hello"')
       expect(output).not.toContain('alias TestAlias')
@@ -505,37 +515,43 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
 
   describe('keybind validation', () => {
     it('should validate keybind key and commands', () => {
-      const result = keybindManager.validateKeybind('F1', [{ command: 'say hello' }])
-      
+      const result = keybindManager.validateKeybind('F1', [
+        { command: 'say hello' },
+      ])
+
       expect(result.valid).toBe(true)
       expect(result.errors).toHaveLength(0)
     })
 
     it('should detect empty command sequences', () => {
       const result = keybindManager.validateKeybind('F1', [])
-      
+
       expect(result.valid).toBe(false)
       expect(result.errors).toContain('At least one command is required')
     })
 
     it('should validate command syntax', () => {
       const result = keybindManager.validateKeybind('F1', [{ command: '' }])
-      
+
       expect(result.valid).toBe(false)
       expect(result.errors).toContain('Command 1 is empty')
     })
 
     it('should check for command count limits', () => {
-      const commands = Array(25).fill(0).map((_, i) => ({ command: `command${i}` }))
+      const commands = Array(25)
+        .fill(0)
+        .map((_, i) => ({ command: `command${i}` }))
       const result = keybindManager.validateKeybind('F1', commands)
-      
+
       expect(result.valid).toBe(false)
       expect(result.errors).toContain('Too many commands (max 20)')
     })
 
     it('should validate key names', () => {
-      const result = keybindManager.validateKeybind('InvalidKey', [{ command: 'say hello' }])
-      
+      const result = keybindManager.validateKeybind('InvalidKey', [
+        { command: 'say hello' },
+      ])
+
       expect(result.valid).toBe(false)
       expect(result.errors).toContain('Invalid key name: InvalidKey')
     })
@@ -544,27 +560,29 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
   describe('key suggestions', () => {
     it('should suggest keys based on filter', () => {
       const suggestions = keybindManager.suggestKeys('F1')
-      
-      expect(suggestions.some(key => key.includes('F1'))).toBe(true)
-      expect(suggestions.every(key => key.toLowerCase().includes('f1'))).toBe(true)
+
+      expect(suggestions.some((key) => key.includes('F1'))).toBe(true)
+      expect(suggestions.every((key) => key.toLowerCase().includes('f1'))).toBe(
+        true
+      )
       expect(suggestions.length).toBeLessThanOrEqual(20)
     })
 
     it('should filter keys case-insensitively', () => {
       const suggestions = keybindManager.suggestKeys('ctrl')
-      
-      expect(suggestions.some(key => key.includes('Ctrl'))).toBe(true)
+
+      expect(suggestions.some((key) => key.includes('Ctrl'))).toBe(true)
     })
 
     it('should limit suggestion count', () => {
       const suggestions = keybindManager.suggestKeys('')
-      
+
       expect(suggestions.length).toBeLessThanOrEqual(20)
     })
 
     it('should return empty array for no matches', () => {
       const suggestions = keybindManager.suggestKeys('InvalidKeyPattern')
-      
+
       expect(suggestions).toHaveLength(0)
     })
   })
@@ -572,7 +590,7 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
   describe('common keys', () => {
     it('should return list of commonly used keys', () => {
       const commonKeys = keybindManager.getCommonKeys()
-      
+
       expect(commonKeys).toContain('Space')
       expect(commonKeys).toContain('F1')
       expect(commonKeys).toContain('Ctrl+1')
@@ -584,7 +602,7 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
     it('should generate unique keybind IDs', () => {
       const id1 = keybindManager.generateKeybindId()
       const id2 = keybindManager.generateKeybindId()
-      
+
       expect(id1).toMatch(/^keybind_\d+_[a-z0-9]+$/)
       expect(id2).toMatch(/^keybind_\d+_[a-z0-9]+$/)
       expect(id1).not.toBe(id2)
@@ -593,11 +611,11 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
     it('should clone keybind objects', () => {
       const original = {
         key: 'F1',
-        commands: [{ command: 'say hello' }]
+        commands: [{ command: 'say hello' }],
       }
-      
+
       const cloned = keybindManager.cloneKeybind(original)
-      
+
       expect(cloned).toEqual(original)
       expect(cloned).not.toBe(original)
       expect(cloned.commands).not.toBe(original.commands)
@@ -609,15 +627,15 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
       const profile = {
         keys: {
           F1: [{ command: 'say hello', type: 'communication' }],
-          F2: [{ command: 'emote wave', type: 'custom' }]
+          F2: [{ command: 'emote wave', type: 'custom' }],
         },
         aliases: {
-          TestAlias: { commands: 'say test' }
-        }
+          TestAlias: { commands: 'say test' },
+        },
       }
-      
+
       const stats = keybindManager.getProfileStats(profile)
-      
+
       expect(stats.totalKeys).toBe(2)
       expect(stats.totalCommands).toBe(2)
       expect(stats.totalAliases).toBe(1)
@@ -629,24 +647,24 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
       const profile = {
         keys: {
           F1: [{ command: 'say hello', type: 'communication' }],
-          F2: [{ command: 'say hello', type: 'communication' }]
+          F2: [{ command: 'say hello', type: 'communication' }],
         },
-        aliases: {}
+        aliases: {},
       }
-      
+
       const stats = keybindManager.getProfileStats(profile)
-      
+
       expect(stats.mostUsedCommands['say hello']).toBe(2)
     })
 
     it('should handle empty profiles', () => {
       const profile = {
         keys: {},
-        aliases: {}
+        aliases: {},
       }
-      
+
       const stats = keybindManager.getProfileStats(profile)
-      
+
       expect(stats.totalKeys).toBe(0)
       expect(stats.totalCommands).toBe(0)
       expect(stats.totalAliases).toBe(0)
@@ -657,35 +675,35 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
     it('should sort function keys numerically', () => {
       const keys = ['F10', 'F2', 'F1']
       const sorted = keys.sort(keybindManager.compareKeys.bind(keybindManager))
-      
+
       expect(sorted).toEqual(['F1', 'F2', 'F10'])
     })
 
     it('should prioritize function keys over other keys', () => {
       const keys = ['A', 'F1', '1']
       const sorted = keys.sort(keybindManager.compareKeys.bind(keybindManager))
-      
+
       expect(sorted[0]).toBe('F1')
     })
 
     it('should sort numbers after function keys', () => {
       const keys = ['A', '2', 'F1', '1']
       const sorted = keys.sort(keybindManager.compareKeys.bind(keybindManager))
-      
+
       expect(sorted).toEqual(['F1', '1', '2', 'A'])
     })
 
     it('should sort letters after numbers', () => {
       const keys = ['Z', '1', 'A']
       const sorted = keys.sort(keybindManager.compareKeys.bind(keybindManager))
-      
+
       expect(sorted).toEqual(['1', 'A', 'Z'])
     })
 
     it('should handle special keys', () => {
       const keys = ['Enter', 'Space', 'Tab', 'Escape']
       const sorted = keys.sort(keybindManager.compareKeys.bind(keybindManager))
-      
+
       expect(sorted).toEqual(['Space', 'Tab', 'Enter', 'Escape'])
     })
   })
@@ -698,20 +716,22 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
     })
 
     it('should handle file input changes', () => {
-      const mockFile = new File(['F1 "say hello" ""'], 'test.txt', { type: 'text/plain' })
+      const mockFile = new File(['F1 "say hello" ""'], 'test.txt', {
+        type: 'text/plain',
+      })
       const mockEvent = {
         target: {
           id: 'fileInput',
           accept: '.txt',
           files: [mockFile],
-          value: 'test.txt'
-        }
+          value: 'test.txt',
+        },
       }
-      
+
       const readAsTextSpy = vi.spyOn(FileReader.prototype, 'readAsText')
-      
+
       keybindManager.handleKeybindFileImport(mockEvent)
-      
+
       expect(readAsTextSpy).toHaveBeenCalledWith(mockFile)
       expect(mockEvent.target.value).toBe('')
     })
@@ -723,7 +743,7 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
         keys: {},
         aliases: {},
         name: 'Test Profile',
-        mode: 'Space'
+        mode: 'Space',
       })
       global.app.saveProfile = vi.fn()
       global.app.setModified = vi.fn()
@@ -732,7 +752,7 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
     it('should import alias file content successfully', () => {
       const content = 'alias TestAlias "say hello $$ emote wave"'
       const result = keybindManager.importAliasFile(content)
-      
+
       expect(result.success).toBe(true)
       expect(result.imported.aliases).toBe(1)
     })
@@ -741,7 +761,7 @@ alias complex_bracket <& TrayExecByTray 1 3 0 $$ alias cone_attack "cone_attack2
       const content = `alias Attack "target_nearest_enemy $$ FireAll"
 alias Heal "target_self $$ +power_exec Distribute_Shields"`
       const result = keybindManager.importAliasFile(content)
-      
+
       expect(result.success).toBe(true)
       expect(result.imported.aliases).toBe(2)
     })
@@ -751,7 +771,7 @@ alias Heal "target_self $$ +power_exec Distribute_Shields"`
 alias TestAlias "say test"
 F2 "say world"`
       const result = keybindManager.importAliasFile(content)
-      
+
       expect(result.success).toBe(true)
       expect(result.imported.aliases).toBe(1)
       expect(result.imported).not.toHaveProperty('keys')
@@ -760,7 +780,7 @@ F2 "say world"`
     it('should warn when no aliases found', () => {
       const content = 'F1 "say hello"\nF2 "say world"'
       const result = keybindManager.importAliasFile(content)
-      
+
       expect(result.success).toBe(false)
       expect(result.error).toBe('No aliases found')
     })
@@ -768,7 +788,7 @@ F2 "say world"`
     it('should handle empty alias files', () => {
       const content = ''
       const result = keybindManager.importAliasFile(content)
-      
+
       expect(result.success).toBe(false)
       expect(result.error).toBe('No aliases found')
     })
@@ -778,16 +798,16 @@ F2 "say world"`
         keys: {},
         aliases: { ExistingAlias: { commands: 'existing command' } },
         name: 'Test Profile',
-        mode: 'Space'
+        mode: 'Space',
       }
       global.app.getCurrentProfile.mockReturnValue(profile)
-      
+
       // Mock stoStorage.getProfile to return the same profile that will be modified
       global.stoStorage.getProfile.mockReturnValue(profile)
-      
+
       const content = 'alias NewAlias "new command"'
       keybindManager.importAliasFile(content)
-      
+
       expect(profile.aliases).toHaveProperty('ExistingAlias')
       expect(profile.aliases).toHaveProperty('NewAlias')
     })
@@ -795,7 +815,7 @@ F2 "say world"`
     it('should update profile modification status', () => {
       const content = 'alias TestAlias "say test"'
       keybindManager.importAliasFile(content)
-      
+
       expect(stoStorage.saveProfile).toHaveBeenCalled()
       expect(app.setModified).toHaveBeenCalledWith(true)
     })
@@ -806,30 +826,30 @@ F2 "say world"`
       const commands = [
         { command: '+TrayExecByTray 9 0' },
         { command: '+TrayExecByTray 9 1' },
-        { command: '+TrayExecByTray 9 2' }
+        { command: '+TrayExecByTray 9 2' },
       ]
-      
+
       const result = keybindManager.generateMirroredCommandString(commands)
-      
+
       // Should be: reverse + original = [2,1,0] + [0,1,2]
-      expect(result).toBe('+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0')
+      expect(result).toBe(
+        '+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0'
+      )
     })
 
     it('should handle single command without mirroring', () => {
-      const commands = [
-        { command: '+TrayExecByTray 9 0' }
-      ]
-      
+      const commands = [{ command: '+TrayExecByTray 9 0' }]
+
       const result = keybindManager.generateMirroredCommandString(commands)
-      
+
       expect(result).toBe('+TrayExecByTray 9 0')
     })
 
     it('should handle empty command list', () => {
       const commands = []
-      
+
       const result = keybindManager.generateMirroredCommandString(commands)
-      
+
       expect(result).toBe('')
     })
 
@@ -837,22 +857,21 @@ F2 "say world"`
       const commands = [
         'FirePhasers',
         '+TrayExecByTray 9 0',
-        '+TrayExecByTray 9 1'
+        '+TrayExecByTray 9 1',
       ]
-      
+
       const result = keybindManager.generateMirroredCommandString(commands)
-      
-      expect(result).toBe('FirePhasers $$ +TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0 $$ FirePhasers')
+
+      expect(result).toBe(
+        'FirePhasers $$ +TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0 $$ FirePhasers'
+      )
     })
 
     it('should handle two commands correctly', () => {
-      const commands = [
-        { command: 'FirePhasers' },
-        { command: 'FireTorpedos' }
-      ]
-      
+      const commands = [{ command: 'FirePhasers' }, { command: 'FireTorpedos' }]
+
       const result = keybindManager.generateMirroredCommandString(commands)
-      
+
       expect(result).toBe('FirePhasers $$ FireTorpedos $$ FirePhasers')
     })
 
@@ -861,11 +880,11 @@ F2 "say world"`
         { command: 'A' },
         { command: 'B' },
         { command: 'C' },
-        { command: 'D' }
+        { command: 'D' },
       ]
-      
+
       const result = keybindManager.generateMirroredCommandString(commands)
-      
+
       expect(result).toBe('A $$ B $$ C $$ D $$ C $$ B $$ A')
     })
 
@@ -873,56 +892,60 @@ F2 "say world"`
       const commands = [
         'StringCommand',
         { command: 'ObjectCommand1' },
-        { command: 'ObjectCommand2' }
+        { command: 'ObjectCommand2' },
       ]
-      
+
       const result = keybindManager.generateMirroredCommandString(commands)
-      
-      expect(result).toBe('StringCommand $$ ObjectCommand1 $$ ObjectCommand2 $$ ObjectCommand1 $$ StringCommand')
+
+      expect(result).toBe(
+        'StringCommand $$ ObjectCommand1 $$ ObjectCommand2 $$ ObjectCommand1 $$ StringCommand'
+      )
     })
   })
 
   describe('mirroring detection', () => {
     it('should detect mirrored commands and extract originals', () => {
-      const mirroredCommand = '+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0'
-      
+      const mirroredCommand =
+        '+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0'
+
       const result = keybindManager.detectAndUnmirrorCommands(mirroredCommand)
-      
+
       expect(result.isMirrored).toBe(true)
       expect(result.originalCommands).toEqual([
         '+TrayExecByTray 9 0',
-        '+TrayExecByTray 9 1', 
-        '+TrayExecByTray 9 2'
+        '+TrayExecByTray 9 1',
+        '+TrayExecByTray 9 2',
       ])
     })
 
     it('should not detect non-mirrored commands as mirrored', () => {
-      const normalCommand = '+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2'
-      
+      const normalCommand =
+        '+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2'
+
       const result = keybindManager.detectAndUnmirrorCommands(normalCommand)
-      
+
       expect(result.isMirrored).toBe(false)
       expect(result.originalCommands).toEqual([
         '+TrayExecByTray 9 0',
         '+TrayExecByTray 9 1',
-        '+TrayExecByTray 9 2'
+        '+TrayExecByTray 9 2',
       ])
     })
 
     it('should detect two-command mirroring pattern', () => {
       const mirroredCommand = 'FirePhasers $$ FireTorpedos $$ FirePhasers'
-      
+
       const result = keybindManager.detectAndUnmirrorCommands(mirroredCommand)
-      
+
       expect(result.isMirrored).toBe(true)
       expect(result.originalCommands).toEqual(['FirePhasers', 'FireTorpedos'])
     })
 
     it('should handle single commands as non-mirrored', () => {
       const singleCommand = 'FirePhasers'
-      
+
       const result = keybindManager.detectAndUnmirrorCommands(singleCommand)
-      
+
       expect(result.isMirrored).toBe(false)
       expect(result.originalCommands).toEqual(['FirePhasers'])
     })
@@ -931,60 +954,71 @@ F2 "say world"`
       const result1 = keybindManager.detectAndUnmirrorCommands('')
       const result2 = keybindManager.detectAndUnmirrorCommands(null)
       const result3 = keybindManager.detectAndUnmirrorCommands(undefined)
-      
+
       expect(result1.isMirrored).toBe(false)
       expect(result1.originalCommands).toEqual([])
-      
+
       expect(result2.isMirrored).toBe(false)
       expect(result2.originalCommands).toEqual([])
-      
+
       expect(result3.isMirrored).toBe(false)
       expect(result3.originalCommands).toEqual([])
     })
 
     it('should not detect even-length sequences as mirrored', () => {
       const evenSequence = 'A $$ B $$ C $$ D'
-      
+
       const result = keybindManager.detectAndUnmirrorCommands(evenSequence)
-      
+
       expect(result.isMirrored).toBe(false)
       expect(result.originalCommands).toEqual(['A', 'B', 'C', 'D'])
     })
 
     it('should not detect sequences shorter than 3 as mirrored', () => {
       const twoCommands = 'A $$ B'
-      
+
       const result = keybindManager.detectAndUnmirrorCommands(twoCommands)
-      
+
       expect(result.isMirrored).toBe(false)
       expect(result.originalCommands).toEqual(['A', 'B'])
     })
 
     it('should detect complex mirrored pattern', () => {
-      const complexMirrored = 'cmd1 $$ cmd2 $$ cmd3 $$ cmd4 $$ cmd5 $$ cmd4 $$ cmd3 $$ cmd2 $$ cmd1'
-      
+      const complexMirrored =
+        'cmd1 $$ cmd2 $$ cmd3 $$ cmd4 $$ cmd5 $$ cmd4 $$ cmd3 $$ cmd2 $$ cmd1'
+
       const result = keybindManager.detectAndUnmirrorCommands(complexMirrored)
-      
+
       expect(result.isMirrored).toBe(true)
-      expect(result.originalCommands).toEqual(['cmd1', 'cmd2', 'cmd3', 'cmd4', 'cmd5'])
+      expect(result.originalCommands).toEqual([
+        'cmd1',
+        'cmd2',
+        'cmd3',
+        'cmd4',
+        'cmd5',
+      ])
     })
 
     it('should not detect partial mirrors as mirrored', () => {
       const partialMirror = 'A $$ B $$ C $$ B $$ D' // Should be A-B-C-B-A
-      
+
       const result = keybindManager.detectAndUnmirrorCommands(partialMirror)
-      
+
       expect(result.isMirrored).toBe(false)
       expect(result.originalCommands).toEqual(['A', 'B', 'C', 'B', 'D'])
     })
 
     it('should handle commands with spaces and special characters', () => {
-      const specialCommand = '+power_exec Distribute_Shields $$ target_nearest_enemy $$ +power_exec Distribute_Shields'
-      
+      const specialCommand =
+        '+power_exec Distribute_Shields $$ target_nearest_enemy $$ +power_exec Distribute_Shields'
+
       const result = keybindManager.detectAndUnmirrorCommands(specialCommand)
-      
+
       expect(result.isMirrored).toBe(true)
-      expect(result.originalCommands).toEqual(['+power_exec Distribute_Shields', 'target_nearest_enemy'])
+      expect(result.originalCommands).toEqual([
+        '+power_exec Distribute_Shields',
+        'target_nearest_enemy',
+      ])
     })
   })
 
@@ -996,68 +1030,68 @@ F2 "say world"`
       resetStore()
       // Create real storage instance for integration testing
       realStorage = new STOStorage()
-      
+
       // Create a real app implementation
       realApp = {
         currentProfile: 'test-profile',
         currentEnvironment: 'space',
         setModified: vi.fn(),
         renderKeyGrid: vi.fn(),
-        
+
         getCurrentProfile() {
           const profile = realStorage.getProfile(this.currentProfile)
           if (!profile) return null
-          
+
           // Ensure builds structure exists
           if (!profile.builds) {
             profile.builds = {
               space: { keys: {} },
-              ground: { keys: {} }
+              ground: { keys: {} },
             }
           }
-          
+
           if (!profile.builds[this.currentEnvironment]) {
             profile.builds[this.currentEnvironment] = { keys: {} }
           }
-          
+
           // Ensure the build keys object exists
           if (!profile.builds[this.currentEnvironment].keys) {
             profile.builds[this.currentEnvironment].keys = {}
           }
-          
+
           // Return a profile-like object with current build data
           // IMPORTANT: keys must be a direct reference, not a copy
           return {
             ...profile,
             keys: profile.builds[this.currentEnvironment].keys, // Direct reference
             aliases: profile.aliases || {},
-            mode: this.currentEnvironment === 'space' ? 'Space' : 'Ground'
+            mode: this.currentEnvironment === 'space' ? 'Space' : 'Ground',
           }
-        }
+        },
       }
-      
+
       // Set up a test profile
       const testProfile = {
         name: 'Test Profile',
         builds: {
           space: { keys: {} },
-          ground: { keys: {} }
+          ground: { keys: {} },
         },
         aliases: {},
         created: new Date().toISOString(),
         lastModified: new Date().toISOString(),
-        currentEnvironment: 'space'
+        currentEnvironment: 'space',
       }
-      
+
       realStorage.saveProfile('test-profile', testProfile)
-      
+
       // Override global app and storage for this test
       global.app = realApp
       global.stoStorage = realStorage
       store.currentProfile = 'test-profile'
       store.currentEnvironment = 'space'
     })
-    
+
     afterEach(() => {
       // Clean up test data
       realStorage.deleteProfile('test-profile')
@@ -1066,41 +1100,51 @@ F2 "say world"`
     it('should detect and unmirror commands during import', () => {
       const keybindContent = `F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"
 F2 "FirePhasers $$ FireTorpedos $$ FirePhasers"`
-      
+
       const result = keybindManager.importKeybindFile(keybindContent)
-      
+
       expect(result.success).toBe(true)
       expect(result.imported.keys).toBe(2)
-      
+
       // Check that the profile was updated with original commands
       const savedProfile = realStorage.getProfile('test-profile')
       expect(savedProfile.builds.space.keys.F1).toHaveLength(3)
-      expect(savedProfile.builds.space.keys.F1[0].command).toBe('+TrayExecByTray 9 0')
-      expect(savedProfile.builds.space.keys.F1[1].command).toBe('+TrayExecByTray 9 1')
-      expect(savedProfile.builds.space.keys.F1[2].command).toBe('+TrayExecByTray 9 2')
-      
+      expect(savedProfile.builds.space.keys.F1[0].command).toBe(
+        '+TrayExecByTray 9 0'
+      )
+      expect(savedProfile.builds.space.keys.F1[1].command).toBe(
+        '+TrayExecByTray 9 1'
+      )
+      expect(savedProfile.builds.space.keys.F1[2].command).toBe(
+        '+TrayExecByTray 9 2'
+      )
+
       expect(savedProfile.builds.space.keys.F2).toHaveLength(2)
       expect(savedProfile.builds.space.keys.F2[0].command).toBe('FirePhasers')
       expect(savedProfile.builds.space.keys.F2[1].command).toBe('FireTorpedos')
-      
+
       // Check that stabilization metadata was set
-      expect(savedProfile.keybindMetadata.space.F1.stabilizeExecutionOrder).toBe(true)
-      expect(savedProfile.keybindMetadata.space.F2.stabilizeExecutionOrder).toBe(true)
+      expect(
+        savedProfile.keybindMetadata.space.F1.stabilizeExecutionOrder
+      ).toBe(true)
+      expect(
+        savedProfile.keybindMetadata.space.F2.stabilizeExecutionOrder
+      ).toBe(true)
     })
 
     it('should not set stabilization metadata for non-mirrored commands', () => {
       const keybindContent = `F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2"
 F2 "FirePhasers"`
-      
+
       const result = keybindManager.importKeybindFile(keybindContent)
-      
+
       expect(result.success).toBe(true)
-      
+
       // Check that commands are stored normally
       const savedProfile = realStorage.getProfile('test-profile')
       expect(savedProfile.builds.space.keys.F1).toHaveLength(3)
       expect(savedProfile.builds.space.keys.F2).toHaveLength(1)
-      
+
       // Check that no stabilization metadata was set
       expect(savedProfile.keybindMetadata?.space?.F1).toBeUndefined()
       expect(savedProfile.keybindMetadata?.space?.F2).toBeUndefined()
@@ -1110,21 +1154,23 @@ F2 "FirePhasers"`
       const keybindContent = `F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"
 F2 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1"
 F3 "SingleCommand"`
-      
+
       const result = keybindManager.importKeybindFile(keybindContent)
-      
+
       expect(result.success).toBe(true)
-      
+
       const savedProfile = realStorage.getProfile('test-profile')
-      
+
       // F1 is mirrored
       expect(savedProfile.builds.space.keys.F1).toHaveLength(2)
-      expect(savedProfile.keybindMetadata.space.F1.stabilizeExecutionOrder).toBe(true)
-      
+      expect(
+        savedProfile.keybindMetadata.space.F1.stabilizeExecutionOrder
+      ).toBe(true)
+
       // F2 is not mirrored
       expect(savedProfile.builds.space.keys.F2).toHaveLength(2)
       expect(savedProfile.keybindMetadata?.space?.F2).toBeUndefined()
-      
+
       // F3 is single command
       expect(savedProfile.builds.space.keys.F3).toHaveLength(1)
       expect(savedProfile.keybindMetadata?.space?.F3).toBeUndefined()
@@ -1133,11 +1179,11 @@ F3 "SingleCommand"`
     it('should handle empty command chains', () => {
       const keybindContent = `F1 ""
 F2 " "`
-      
+
       const result = keybindManager.importKeybindFile(keybindContent)
-      
+
       expect(result.success).toBe(true)
-      
+
       const savedProfile = realStorage.getProfile('test-profile')
       // Empty strings still get parsed as command objects but with empty command strings
       expect(savedProfile.builds.space.keys.F1).toHaveLength(1)
@@ -1152,37 +1198,47 @@ F2 " "`
       // Set up profile with existing metadata
       const testProfile = realStorage.getProfile('test-profile')
       testProfile.keybindMetadata = {
-        space: { F3: { stabilizeExecutionOrder: false } }
+        space: { F3: { stabilizeExecutionOrder: false } },
       }
       realStorage.saveProfile('test-profile', testProfile)
-      
+
       const keybindContent = `F1 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"`
-      
+
       const result = keybindManager.importKeybindFile(keybindContent)
-      
+
       expect(result.success).toBe(true)
-      
+
       const savedProfile = realStorage.getProfile('test-profile')
-      
+
       // Should preserve existing metadata
-      expect(savedProfile.keybindMetadata.space.F3.stabilizeExecutionOrder).toBe(false)
-      
+      expect(
+        savedProfile.keybindMetadata.space.F3.stabilizeExecutionOrder
+      ).toBe(false)
+
       // Should add new metadata
-      expect(savedProfile.keybindMetadata.space.F1.stabilizeExecutionOrder).toBe(true)
+      expect(
+        savedProfile.keybindMetadata.space.F1.stabilizeExecutionOrder
+      ).toBe(true)
     })
 
     it('should handle complex mirrored patterns', () => {
       const keybindContent = `numpad0 "+TrayExecByTray 9 0 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 3 $$ +TrayExecByTray 9 4 $$ +TrayExecByTray 9 3 $$ +TrayExecByTray 9 2 $$ +TrayExecByTray 9 1 $$ +TrayExecByTray 9 0"`
-      
+
       const result = keybindManager.importKeybindFile(keybindContent)
-      
+
       expect(result.success).toBe(true)
-      
+
       const savedProfile = realStorage.getProfile('test-profile')
       expect(savedProfile.builds.space.keys.numpad0).toHaveLength(5)
-      expect(savedProfile.builds.space.keys.numpad0[0].command).toBe('+TrayExecByTray 9 0')
-      expect(savedProfile.builds.space.keys.numpad0[4].command).toBe('+TrayExecByTray 9 4')
-      expect(savedProfile.keybindMetadata.space.numpad0.stabilizeExecutionOrder).toBe(true)
+      expect(savedProfile.builds.space.keys.numpad0[0].command).toBe(
+        '+TrayExecByTray 9 0'
+      )
+      expect(savedProfile.builds.space.keys.numpad0[4].command).toBe(
+        '+TrayExecByTray 9 4'
+      )
+      expect(
+        savedProfile.keybindMetadata.space.numpad0.stabilizeExecutionOrder
+      ).toBe(true)
     })
 
     it('should merge with existing profile data', () => {
@@ -1190,12 +1246,12 @@ F2 " "`
       const testProfile = realStorage.getProfile('test-profile')
       testProfile.builds.space.keys = { F1: [{ command: 'existing' }] }
       realStorage.saveProfile('test-profile', testProfile)
-      
+
       const content = 'F2 "say hello" ""'
       const result = keybindManager.importKeybindFile(content)
-      
+
       expect(result.success).toBe(true)
-      
+
       const savedProfile = realStorage.getProfile('test-profile')
       expect(savedProfile.builds.space.keys).toHaveProperty('F1')
       expect(savedProfile.builds.space.keys).toHaveProperty('F2')
@@ -1208,12 +1264,12 @@ F2 " "`
       const testProfile = realStorage.getProfile('test-profile')
       testProfile.builds.space.keys = { F1: [{ command: 'existing' }] }
       realStorage.saveProfile('test-profile', testProfile)
-      
+
       const content = 'F1 "say new" ""'
       const result = keybindManager.importKeybindFile(content)
-      
+
       expect(result.success).toBe(true)
-      
+
       const savedProfile = realStorage.getProfile('test-profile')
       expect(savedProfile.builds.space.keys.F1).toHaveLength(1)
       expect(savedProfile.builds.space.keys.F1[0].command).toBe('say new')
@@ -1224,12 +1280,12 @@ F2 " "`
       const testProfile = realStorage.getProfile('test-profile')
       testProfile.builds.space.keys = { F1: [{ command: 'existing' }] }
       realStorage.saveProfile('test-profile', testProfile)
-      
+
       const content = 'F2 "say hello" ""'
       const result = keybindManager.importKeybindFile(content)
-      
+
       expect(result.success).toBe(true)
-      
+
       const savedProfile = realStorage.getProfile('test-profile')
       expect(savedProfile.builds.space.keys.F1).toHaveLength(1)
       expect(savedProfile.builds.space.keys.F1[0].command).toBe('existing')
@@ -1239,17 +1295,17 @@ F2 " "`
     it('should import aliases separately', () => {
       const content = 'F1 "say hello"\nalias TestAlias "say test"'
       const result = keybindManager.importAliasFile(content)
-      
+
       // Should only import aliases, not keybinds
       expect(result.success).toBe(true)
       expect(result.imported.aliases).toBe(1)
       expect(result.imported).not.toHaveProperty('keys')
-      
+
       // Verify alias was actually saved
       const savedProfile = realStorage.getProfile('test-profile')
       expect(savedProfile.aliases).toHaveProperty('TestAlias')
       expect(savedProfile.aliases.TestAlias.commands).toBe('say test')
-      
+
       // Verify keybind was not imported
       expect(savedProfile.builds.space.keys).not.toHaveProperty('F1')
     })
@@ -1258,11 +1314,11 @@ F2 " "`
   describe('real keybind import integration', () => {
     let realStorage
     let realApp
-    
+
     beforeEach(() => {
       // Create real storage instance for integration testing
       realStorage = new STOStorage()
-      
+
       // Create a minimal real app implementation
       realApp = {
         currentProfile: 'test-profile',
@@ -1270,121 +1326,123 @@ F2 " "`
         setModified: vi.fn(),
         renderKeyGrid: vi.fn(),
         renderCommandChain: vi.fn(),
-        
+
         getCurrentProfile() {
           const profile = realStorage.getProfile(this.currentProfile)
           if (!profile) return null
-          
+
           return this.getCurrentBuild(profile)
         },
-        
+
         getCurrentBuild(profile) {
           if (!profile.builds) {
             profile.builds = {
               space: { keys: {} },
-              ground: { keys: {} }
+              ground: { keys: {} },
             }
           }
-          
+
           const build = profile.builds[this.currentEnvironment] || { keys: {} }
-          
+
           return {
             ...profile,
             keys: build.keys || {},
-            mode: this.currentEnvironment === 'space' ? 'Space' : 'Ground'
+            mode: this.currentEnvironment === 'space' ? 'Space' : 'Ground',
           }
         },
-        
+
         saveCurrentBuild() {
           const profile = realStorage.getProfile(this.currentProfile)
           const currentBuild = this.getCurrentProfile()
-          
+
           if (profile && currentBuild) {
             if (!profile.builds) {
               profile.builds = {
                 space: { keys: {} },
-                ground: { keys: {} }
+                ground: { keys: {} },
               }
             }
-            
+
             profile.builds[this.currentEnvironment] = {
-              keys: currentBuild.keys || {}
+              keys: currentBuild.keys || {},
             }
-            
+
             realStorage.saveProfile(this.currentProfile, profile)
           }
         },
-        
+
         saveProfile() {
           const virtualProfile = this.getCurrentProfile()
-          
+
           if (!virtualProfile) {
             return
           }
-          
+
           this.saveCurrentBuild()
-          
+
           const actualProfile = realStorage.getProfile(this.currentProfile)
           if (!actualProfile) {
             return
           }
-          
+
           const updatedProfile = {
             ...actualProfile,
             name: virtualProfile.name,
-            description: virtualProfile.description || actualProfile.description,
+            description:
+              virtualProfile.description || actualProfile.description,
             aliases: virtualProfile.aliases || {},
-            keybindMetadata: virtualProfile.keybindMetadata || actualProfile.keybindMetadata,
+            keybindMetadata:
+              virtualProfile.keybindMetadata || actualProfile.keybindMetadata,
             created: actualProfile.created,
             lastModified: new Date().toISOString(),
-            currentEnvironment: this.currentEnvironment
+            currentEnvironment: this.currentEnvironment,
           }
-          
+
           realStorage.saveProfile(this.currentProfile, updatedProfile)
-        }
+        },
       }
-      
+
       // Set up a test profile
       const testProfile = {
         name: 'Test Profile',
         builds: {
           space: { keys: {} },
-          ground: { keys: {} }
+          ground: { keys: {} },
         },
         aliases: {},
         created: new Date().toISOString(),
         lastModified: new Date().toISOString(),
-        currentEnvironment: 'space'
+        currentEnvironment: 'space',
       }
-      
+
       realStorage.saveProfile('test-profile', testProfile)
-      
+
       // Override global app and storage for this test
       global.app = realApp
       global.stoStorage = realStorage
       store.currentProfile = 'test-profile'
       store.currentEnvironment = 'space'
     })
-    
+
     afterEach(() => {
       // Clean up test data
       realStorage.deleteProfile('test-profile')
     })
-    
+
     it('should actually import keybinds and save them to the correct build structure', () => {
       const content = 'F2 "say hello" ""\nF3 "emote wave" ""'
-      
+
       // Verify profile starts empty
       const initialProfile = realStorage.getProfile('test-profile')
       expect(initialProfile.builds.space.keys).toEqual({})
-      
+
       // Import keybinds
       const result = keybindManager.importKeybindFile(content)
-      
+
       // Verify import was successful
       expect(result.success).toBe(true)
       expect(result.imported.keys).toBe(2)
-      
+
       // Verify keybinds were actually saved to storage
       const savedProfile = realStorage.getProfile('test-profile')
       expect(savedProfile.builds.space.keys).toHaveProperty('F2')
@@ -1392,52 +1450,56 @@ F2 " "`
       expect(savedProfile.builds.space.keys.F2).toHaveLength(1)
       expect(savedProfile.builds.space.keys.F2[0].command).toBe('say hello')
       expect(savedProfile.builds.space.keys.F3[0].command).toBe('emote wave')
-      
+
       // Verify they show up in getCurrentProfile
       const currentProfile = realApp.getCurrentProfile()
       expect(currentProfile.keys).toHaveProperty('F2')
       expect(currentProfile.keys).toHaveProperty('F3')
     })
-    
+
     it('should import keybinds to the correct environment', () => {
       const content = 'F1 "ground command" ""'
-      
+
       // Switch to ground environment
       realApp.currentEnvironment = 'ground'
       store.currentEnvironment = 'ground'
-      
+
       // Import keybinds
       const result = keybindManager.importKeybindFile(content)
       expect(result.success).toBe(true)
-      
+
       // Verify keybind was saved to ground build, not space
       const savedProfile = realStorage.getProfile('test-profile')
       expect(savedProfile.builds.ground.keys).toHaveProperty('F1')
       expect(savedProfile.builds.space.keys).not.toHaveProperty('F1')
-      
+
       // Verify it shows up when in ground mode
       const currentProfile = realApp.getCurrentProfile()
       expect(currentProfile.keys).toHaveProperty('F1')
       expect(currentProfile.mode).toBe('Ground')
     })
-    
+
     it('should merge with existing keybinds without overwriting', () => {
       // Add initial keybind
       const initialContent = 'F1 "initial command" ""'
       keybindManager.importKeybindFile(initialContent)
-      
+
       // Add more keybinds
       const additionalContent = 'F2 "additional command" ""'
       const result = keybindManager.importKeybindFile(additionalContent)
-      
+
       expect(result.success).toBe(true)
-      
+
       // Verify both keybinds exist
       const savedProfile = realStorage.getProfile('test-profile')
       expect(savedProfile.builds.space.keys).toHaveProperty('F1')
       expect(savedProfile.builds.space.keys).toHaveProperty('F2')
-      expect(savedProfile.builds.space.keys.F1[0].command).toBe('initial command')
-      expect(savedProfile.builds.space.keys.F2[0].command).toBe('additional command')
+      expect(savedProfile.builds.space.keys.F1[0].command).toBe(
+        'initial command'
+      )
+      expect(savedProfile.builds.space.keys.F2[0].command).toBe(
+        'additional command'
+      )
     })
   })
-}) 
+})

--- a/tests/unit/profiles.test.js
+++ b/tests/unit/profiles.test.js
@@ -16,13 +16,13 @@ describe('STOProfileManager', () => {
   beforeEach(async () => {
     // Reset localStorage
     localStorage.clear()
-    
+
     // Set up global environment
     global.window = global.window || {}
-    
+
     // Import real modules
     const { STO_DATA } = await import('../../src/js/data.js')
-    
+
     // Setup DOM elements needed for tests
     document.body.innerHTML = `
       <select id="profileSelect"></select>
@@ -48,46 +48,50 @@ describe('STOProfileManager', () => {
 
     // Create real storage instance
     mockStorage = new STOStorage()
-    
+
     // Mock app object with necessary methods
     mockApp = {
       currentProfile: 'default',
       currentEnvironment: 'space',
-      generateProfileId: vi.fn((name) => name.toLowerCase().replace(/[^a-z0-9]/g, '_')),
+      generateProfileId: vi.fn((name) =>
+        name.toLowerCase().replace(/[^a-z0-9]/g, '_')
+      ),
       generateCommandId: vi.fn(() => 'cmd_' + Date.now()),
       getCurrentProfile: vi.fn(() => ({
         name: 'Test Profile',
         description: 'Test Description',
         mode: 'space',
-        keys: { 'Space': [{ command: 'test', type: 'test' }] },
-        aliases: {}
+        keys: { Space: [{ command: 'test', type: 'test' }] },
+        aliases: {},
       })),
       switchProfile: vi.fn(),
       renderProfiles: vi.fn(),
       setModified: vi.fn(),
-      deleteProfile: vi.fn(() => true)
+      deleteProfile: vi.fn(() => true),
     }
-    
+
     // Mock UI object
     mockUI = {
       showModal: vi.fn(),
       hideModal: vi.fn(),
       showToast: vi.fn(),
-      confirm: vi.fn(() => Promise.resolve(true))
+      confirm: vi.fn(() => Promise.resolve(true)),
     }
 
     global.modalManager = {
       show: vi.fn(),
-      hide: vi.fn()
+      hide: vi.fn(),
     }
-    
+
     // Setup global objects
     global.app = mockApp
     global.stoStorage = mockStorage
     global.stoUI = mockUI
-    
+
     // Load the profiles module as ES module and instantiate
-    const { default: STOProfileManager } = await import('../../src/js/profiles.js')
+    const { default: STOProfileManager } = await import(
+      '../../src/js/profiles.js'
+    )
     profileManager = new STOProfileManager()
     profileManager.init()
   })
@@ -109,10 +113,10 @@ describe('STOProfileManager', () => {
     it('should setup event listeners on init', () => {
       const profileSelect = document.getElementById('profileSelect')
       const newProfileBtn = document.getElementById('newProfileBtn')
-      
+
       expect(profileSelect).toBeTruthy()
       expect(newProfileBtn).toBeTruthy()
-      
+
       // Test that event listeners are attached by triggering events
       newProfileBtn.click()
       expect(modalManager.show).toHaveBeenCalledWith('profileModal')
@@ -121,7 +125,7 @@ describe('STOProfileManager', () => {
     it('should handle missing DOM elements gracefully', () => {
       document.body.innerHTML = ''
       const newManager = new (class extends profileManager.constructor {})()
-      
+
       expect(() => newManager.init()).not.toThrow()
     })
   })
@@ -129,13 +133,13 @@ describe('STOProfileManager', () => {
   describe('Profile modal management', () => {
     it('should show new profile modal with correct setup', () => {
       profileManager.showNewProfileModal()
-      
+
       expect(modalManager.show).toHaveBeenCalledWith('profileModal')
       expect(profileManager.currentModal).toBe('new')
-      
+
       const title = document.getElementById('profileModalTitle')
       const nameInput = document.getElementById('profileName')
-      
+
       expect(title.textContent).toBe('New Profile')
       expect(nameInput.value).toBe('')
       expect(nameInput.placeholder).toBe('Enter profile name')
@@ -143,14 +147,14 @@ describe('STOProfileManager', () => {
 
     it('should show clone profile modal with current profile data', () => {
       profileManager.showCloneProfileModal()
-      
+
       expect(modalManager.show).toHaveBeenCalledWith('profileModal')
       expect(profileManager.currentModal).toBe('clone')
-      
+
       const title = document.getElementById('profileModalTitle')
       const nameInput = document.getElementById('profileName')
       const descInput = document.getElementById('profileDescription')
-      
+
       expect(title.textContent).toBe('Clone Profile')
       expect(nameInput.value).toBe('Test Profile Copy')
       expect(descInput.value).toBe('Copy of Test Profile')
@@ -158,32 +162,38 @@ describe('STOProfileManager', () => {
 
     it('should show rename profile modal with existing data', () => {
       profileManager.showRenameProfileModal()
-      
+
       expect(modalManager.show).toHaveBeenCalledWith('profileModal')
       expect(profileManager.currentModal).toBe('rename')
-      
+
       const title = document.getElementById('profileModalTitle')
       const nameInput = document.getElementById('profileName')
-      
+
       expect(title.textContent).toBe('Rename Profile')
       expect(nameInput.value).toBe('Test Profile')
     })
 
     it('should handle missing current profile for clone', () => {
       mockApp.getCurrentProfile.mockReturnValue(null)
-      
+
       profileManager.showCloneProfileModal()
-      
-      expect(mockUI.showToast).toHaveBeenCalledWith('No profile selected to clone', 'warning')
+
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        'No profile selected to clone',
+        'warning'
+      )
       expect(modalManager.show).not.toHaveBeenCalled()
     })
 
     it('should handle missing current profile for rename', () => {
       mockApp.getCurrentProfile.mockReturnValue(null)
-      
+
       profileManager.showRenameProfileModal()
-      
-      expect(mockUI.showToast).toHaveBeenCalledWith('No profile selected to rename', 'warning')
+
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        'No profile selected to rename',
+        'warning'
+      )
       expect(modalManager.show).not.toHaveBeenCalled()
     })
   })
@@ -196,67 +206,82 @@ describe('STOProfileManager', () => {
     it('should validate required profile name', () => {
       const nameInput = document.getElementById('profileName')
       nameInput.value = ''
-      
+
       profileManager.handleProfileSave()
-      
-      expect(mockUI.showToast).toHaveBeenCalledWith('Profile name is required', 'error')
+
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        'Profile name is required',
+        'error'
+      )
       expect(mockUI.hideModal).not.toHaveBeenCalled()
     })
 
     it('should validate profile name length', () => {
       const nameInput = document.getElementById('profileName')
       nameInput.value = 'a'.repeat(51) // 51 characters
-      
+
       profileManager.handleProfileSave()
-      
-      expect(mockUI.showToast).toHaveBeenCalledWith('Profile name is too long (max 50 characters)', 'error')
+
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        'Profile name is too long (max 50 characters)',
+        'error'
+      )
       expect(mockUI.hideModal).not.toHaveBeenCalled()
     })
 
     it('should prevent duplicate profile names for new profiles', () => {
       // Setup existing profile in storage
       mockStorage.saveProfile('existing', { name: 'Existing Profile' })
-      
+
       // Mock getAllData to return the profile we just saved
       vi.spyOn(mockStorage, 'getAllData').mockReturnValue({
         profiles: {
-          'existing': { name: 'Existing Profile' }
-        }
+          existing: { name: 'Existing Profile' },
+        },
       })
-      
+
       const nameInput = document.getElementById('profileName')
       nameInput.value = 'Existing Profile'
-      
+
       profileManager.handleProfileSave()
-      
-      expect(mockUI.showToast).toHaveBeenCalledWith('A profile with this name already exists', 'error')
+
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        'A profile with this name already exists',
+        'error'
+      )
       expect(mockUI.hideModal).not.toHaveBeenCalled()
     })
 
     it('should allow same name when renaming current profile', () => {
       profileManager.currentModal = 'rename'
       mockApp.getCurrentProfile.mockReturnValue({ name: 'Current Profile' })
-      
+
       const nameInput = document.getElementById('profileName')
       nameInput.value = 'Current Profile'
-      
+
       profileManager.handleProfileSave()
-      
-      expect(mockUI.showToast).not.toHaveBeenCalledWith(expect.stringContaining('already exists'), 'error')
+
+      expect(mockUI.showToast).not.toHaveBeenCalledWith(
+        expect.stringContaining('already exists'),
+        'error'
+      )
     })
 
     it('should handle save errors gracefully', () => {
       const nameInput = document.getElementById('profileName')
       nameInput.value = 'Valid Name'
-      
+
       // Mock profile creation to throw error
       vi.spyOn(profileManager, 'createNewProfile').mockImplementation(() => {
         throw new Error('Save failed')
       })
-      
+
       profileManager.handleProfileSave()
-      
-      expect(mockUI.showToast).toHaveBeenCalledWith('Failed to save profile: Save failed', 'error')
+
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        'Failed to save profile: Save failed',
+        'error'
+      )
       expect(mockUI.hideModal).not.toHaveBeenCalled()
     })
   })
@@ -265,41 +290,50 @@ describe('STOProfileManager', () => {
     it('should create new profile with default structure', () => {
       const name = 'New Test Profile'
       const description = 'Test description'
-      
+
       profileManager.createNewProfile(name, description)
-      
+
       expect(mockApp.generateProfileId).toHaveBeenCalledWith(name)
       expect(mockApp.switchProfile).toHaveBeenCalled()
       expect(mockApp.renderProfiles).toHaveBeenCalled()
-      expect(mockUI.showToast).toHaveBeenCalledWith(`Profile "${name}" created`, 'success')
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        `Profile "${name}" created`,
+        'success'
+      )
     })
 
     it('should clone current profile with all data', () => {
       const name = 'Cloned Profile'
       const description = 'Cloned description'
-      
+
       profileManager.cloneCurrentProfile(name, description)
-      
+
       expect(mockApp.generateProfileId).toHaveBeenCalledWith(name)
       expect(mockApp.switchProfile).toHaveBeenCalled()
       expect(mockApp.renderProfiles).toHaveBeenCalled()
-      expect(mockUI.showToast).toHaveBeenCalledWith(`Profile "${name}" created from "Test Profile"`, 'success')
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        `Profile "${name}" created from "Test Profile"`,
+        'success'
+      )
     })
 
     it('should rename current profile', () => {
       const name = 'Renamed Profile'
       const description = 'New description'
-      
+
       profileManager.renameCurrentProfile(name, description)
-      
+
       expect(mockApp.renderProfiles).toHaveBeenCalled()
       expect(mockApp.setModified).toHaveBeenCalledWith(true)
-      expect(mockUI.showToast).toHaveBeenCalledWith(`Profile renamed from "Test Profile" to "${name}"`, 'success')
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        `Profile renamed from "Test Profile" to "${name}"`,
+        'success'
+      )
     })
 
     it('should handle clone error when no current profile', () => {
       mockApp.getCurrentProfile.mockReturnValue(null)
-      
+
       expect(() => {
         profileManager.cloneCurrentProfile('Test', 'Test')
       }).toThrow('No profile to clone')
@@ -307,7 +341,7 @@ describe('STOProfileManager', () => {
 
     it('should handle rename error when no current profile', () => {
       mockApp.getCurrentProfile.mockReturnValue(null)
-      
+
       expect(() => {
         profileManager.renameCurrentProfile('Test', 'Test')
       }).toThrow('No profile to rename')
@@ -318,16 +352,18 @@ describe('STOProfileManager', () => {
     it('should confirm before deleting profile', async () => {
       // Mock multiple profiles so deletion is allowed
       mockStorage.getAllData = vi.fn(() => ({
-        profiles: { 
-          'profile1': { name: 'Profile 1' },
-          'profile2': { name: 'Profile 2' }
-        }
+        profiles: {
+          profile1: { name: 'Profile 1' },
+          profile2: { name: 'Profile 2' },
+        },
       }))
-      
+
       await profileManager.confirmDeleteProfile()
-      
+
       expect(mockUI.confirm).toHaveBeenCalledWith(
-        expect.stringContaining('Are you sure you want to delete the profile "Test Profile"?'),
+        expect.stringContaining(
+          'Are you sure you want to delete the profile "Test Profile"?'
+        ),
         'Delete Profile',
         'danger'
       )
@@ -336,47 +372,59 @@ describe('STOProfileManager', () => {
     it('should prevent deletion of last profile', async () => {
       // Mock only one profile exists
       mockStorage.getAllData = vi.fn(() => ({
-        profiles: { 'only_profile': { name: 'Only Profile' } }
+        profiles: { only_profile: { name: 'Only Profile' } },
       }))
-      
+
       await profileManager.confirmDeleteProfile()
-      
-      expect(mockUI.showToast).toHaveBeenCalledWith('Cannot delete the last profile', 'warning')
+
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        'Cannot delete the last profile',
+        'warning'
+      )
       expect(mockUI.confirm).not.toHaveBeenCalled()
     })
 
     it('should handle missing current profile for deletion', async () => {
       mockApp.getCurrentProfile.mockReturnValue(null)
-      
+
       await profileManager.confirmDeleteProfile()
-      
-      expect(mockUI.showToast).toHaveBeenCalledWith('No profile selected to delete', 'warning')
+
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        'No profile selected to delete',
+        'warning'
+      )
       expect(mockUI.confirm).not.toHaveBeenCalled()
     })
 
     it('should delete current profile when confirmed', async () => {
       // Mock multiple profiles so deletion is allowed
       mockStorage.getAllData = vi.fn(() => ({
-        profiles: { 
-          'profile1': { name: 'Profile 1' },
-          'profile2': { name: 'Profile 2' }
-        }
+        profiles: {
+          profile1: { name: 'Profile 1' },
+          profile2: { name: 'Profile 2' },
+        },
       }))
-      
+
       mockUI.confirm.mockResolvedValue(true)
-      
+
       await profileManager.confirmDeleteProfile()
-      
+
       expect(mockApp.deleteProfile).toHaveBeenCalledWith(mockApp.currentProfile)
-      expect(mockUI.showToast).toHaveBeenCalledWith('Profile "Test Profile" deleted', 'success')
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        'Profile "Test Profile" deleted',
+        'success'
+      )
     })
 
     it('should handle deletion failure', () => {
       mockApp.deleteProfile.mockReturnValue(false)
-      
+
       profileManager.deleteCurrentProfile()
-      
-      expect(mockUI.showToast).toHaveBeenCalledWith('Failed to delete profile', 'error')
+
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        'Failed to delete profile',
+        'error'
+      )
     })
   })
 
@@ -384,10 +432,10 @@ describe('STOProfileManager', () => {
     it('should toggle settings dropdown menu', () => {
       const settingsBtn = document.getElementById('settingsBtn')
       const dropdown = settingsBtn.closest('.dropdown')
-      
+
       profileManager.toggleSettingsMenu()
       expect(dropdown.classList.contains('active')).toBe(true)
-      
+
       profileManager.toggleSettingsMenu()
       expect(dropdown.classList.contains('active')).toBe(false)
     })
@@ -396,14 +444,14 @@ describe('STOProfileManager', () => {
       const settingsBtn = document.getElementById('settingsBtn')
       const dropdown = settingsBtn.closest('.dropdown')
       dropdown.classList.add('active')
-      
+
       profileManager.closeSettingsMenu()
       expect(dropdown.classList.contains('active')).toBe(false)
     })
 
     it('should handle missing settings elements gracefully', () => {
       document.getElementById('settingsBtn').remove()
-      
+
       // The actual implementation should handle null gracefully, but our test needs to be realistic
       // Since the button is removed, the methods will encounter null - let's test they handle it
       expect(() => profileManager.toggleSettingsMenu()).not.toThrow()
@@ -415,18 +463,20 @@ describe('STOProfileManager', () => {
     it('should trigger keybind file import', () => {
       const fileInput = document.getElementById('fileInput')
       const clickSpy = vi.spyOn(fileInput, 'click')
-      
+
       profileManager.importKeybinds()
-      
+
       expect(fileInput.accept).toBe('.txt')
       expect(clickSpy).toHaveBeenCalled()
     })
 
     it('should confirm before resetting application', async () => {
       await profileManager.confirmResetApp()
-      
+
       expect(mockUI.confirm).toHaveBeenCalledWith(
-        expect.stringContaining('Are you sure you want to reset the application?'),
+        expect.stringContaining(
+          'Are you sure you want to reset the application?'
+        ),
         'Reset Application',
         'danger'
       )
@@ -434,17 +484,19 @@ describe('STOProfileManager', () => {
 
     it('should reset application when confirmed', async () => {
       mockUI.confirm.mockResolvedValue(true)
-      
+
       // Mock the resetApplication method instead of window.location.reload
-      const resetSpy = vi.spyOn(profileManager, 'resetApplication').mockImplementation(() => {
-        // Mock the clearAllData call
-        mockStorage.clearAllData()
-      })
-      
+      const resetSpy = vi
+        .spyOn(profileManager, 'resetApplication')
+        .mockImplementation(() => {
+          // Mock the clearAllData call
+          mockStorage.clearAllData()
+        })
+
       await profileManager.confirmResetApp()
-      
+
       expect(resetSpy).toHaveBeenCalled()
-      
+
       resetSpy.mockRestore()
     })
 
@@ -452,10 +504,13 @@ describe('STOProfileManager', () => {
       mockStorage.clearAllData = vi.fn(() => {
         throw new Error('Clear failed')
       })
-      
+
       profileManager.resetApplication()
-      
-      expect(mockUI.showToast).toHaveBeenCalledWith('Failed to reset application: Clear failed', 'error')
+
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        'Failed to reset application: Clear failed',
+        'error'
+      )
     })
   })
 
@@ -463,20 +518,20 @@ describe('STOProfileManager', () => {
     it('should analyze profile statistics correctly', () => {
       const testProfile = {
         keys: {
-          'Space': [
+          Space: [
             { command: 'FireAll', type: 'combat' },
-            { command: 'target_nearest_enemy', type: 'targeting' }
+            { command: 'target_nearest_enemy', type: 'targeting' },
           ],
-          'F1': [{ command: 'target_self', type: 'targeting' }],
-          'Ctrl+A': [{ command: 'test', type: 'power' }]
+          F1: [{ command: 'target_self', type: 'targeting' }],
+          'Ctrl+A': [{ command: 'test', type: 'power' }],
         },
         aliases: {
-          'TestAlias': { name: 'TestAlias' }
-        }
+          TestAlias: { name: 'TestAlias' },
+        },
       }
-      
+
       const analysis = profileManager.getProfileAnalysis(testProfile)
-      
+
       expect(analysis.keyCount).toBe(3)
       expect(analysis.commandCount).toBe(4)
       expect(analysis.aliasCount).toBe(1)
@@ -488,17 +543,17 @@ describe('STOProfileManager', () => {
     it('should categorize key types correctly', () => {
       const testProfile = {
         keys: {
-          'F1': [{ command: 'test', type: 'test' }],
-          'A': [{ command: 'test', type: 'test' }],
-          '1': [{ command: 'test', type: 'test' }],
+          F1: [{ command: 'test', type: 'test' }],
+          A: [{ command: 'test', type: 'test' }],
+          1: [{ command: 'test', type: 'test' }],
           'Ctrl+Space': [{ command: 'test', type: 'test' }],
-          'Tab': [{ command: 'test', type: 'test' }]
+          Tab: [{ command: 'test', type: 'test' }],
         },
-        aliases: {}
+        aliases: {},
       }
-      
+
       const analysis = profileManager.getProfileAnalysis(testProfile)
-      
+
       expect(analysis.keyTypes.function).toBe(1) // F1
       expect(analysis.keyTypes.letter).toBe(1) // A
       expect(analysis.keyTypes.number).toBe(1) // 1
@@ -508,28 +563,42 @@ describe('STOProfileManager', () => {
 
     it('should determine profile complexity correctly', () => {
       const simpleProfile = { keys: {}, aliases: {} }
-      const moderateProfile = { 
-        keys: Object.fromEntries(Array(25).fill().map((_, i) => [`Key${i}`, [{ command: 'test', type: 'test' }]])),
-        aliases: {} 
+      const moderateProfile = {
+        keys: Object.fromEntries(
+          Array(25)
+            .fill()
+            .map((_, i) => [`Key${i}`, [{ command: 'test', type: 'test' }]])
+        ),
+        aliases: {},
       }
-      const complexProfile = { 
-        keys: Object.fromEntries(Array(60).fill().map((_, i) => [`Key${i}`, [{ command: 'test', type: 'test' }]])),
-        aliases: {} 
+      const complexProfile = {
+        keys: Object.fromEntries(
+          Array(60)
+            .fill()
+            .map((_, i) => [`Key${i}`, [{ command: 'test', type: 'test' }]])
+        ),
+        aliases: {},
       }
-      
-      expect(profileManager.getProfileAnalysis(simpleProfile).complexity).toBe('Simple')
-      expect(profileManager.getProfileAnalysis(moderateProfile).complexity).toBe('Moderate')
-      expect(profileManager.getProfileAnalysis(complexProfile).complexity).toBe('Complex')
+
+      expect(profileManager.getProfileAnalysis(simpleProfile).complexity).toBe(
+        'Simple'
+      )
+      expect(
+        profileManager.getProfileAnalysis(moderateProfile).complexity
+      ).toBe('Moderate')
+      expect(profileManager.getProfileAnalysis(complexProfile).complexity).toBe(
+        'Complex'
+      )
     })
 
     it('should generate helpful recommendations', () => {
       const basicProfile = { keys: {}, aliases: {} }
       const analysis = profileManager.getProfileAnalysis(basicProfile)
-      
+
       expect(analysis.recommendations).toBeInstanceOf(Array)
       expect(analysis.recommendations.length).toBeGreaterThan(0)
-      
-      const combatRec = analysis.recommendations.find(r => r.type === 'setup')
+
+      const combatRec = analysis.recommendations.find((r) => r.type === 'setup')
       expect(combatRec).toBeTruthy()
       expect(combatRec.title).toContain('Combat')
     })
@@ -538,12 +607,12 @@ describe('STOProfileManager', () => {
   describe('Profile templates', () => {
     it('should provide predefined profile templates', () => {
       const templates = profileManager.getProfileTemplates()
-      
+
       expect(templates).toBeInstanceOf(Object)
       expect(templates.basic_space).toBeTruthy()
       expect(templates.advanced_tactical).toBeTruthy()
       expect(templates.ground_combat).toBeTruthy()
-      
+
       expect(templates.basic_space.name).toBe('Basic Space Combat')
       expect(templates.basic_space.mode).toBe('space')
       expect(templates.basic_space.keys).toBeInstanceOf(Object)
@@ -551,8 +620,10 @@ describe('STOProfileManager', () => {
 
     it('should create profile from template', () => {
       profileManager.createProfileFromTemplate('basic_space')
-      
-      expect(mockApp.generateProfileId).toHaveBeenCalledWith('Basic Space Combat')
+
+      expect(mockApp.generateProfileId).toHaveBeenCalledWith(
+        'Basic Space Combat'
+      )
       expect(mockApp.switchProfile).toHaveBeenCalled()
       expect(mockApp.renderProfiles).toHaveBeenCalled()
       expect(mockUI.showToast).toHaveBeenCalledWith(
@@ -564,18 +635,23 @@ describe('STOProfileManager', () => {
     it('should handle duplicate template names', () => {
       // Mock existing profile with same name
       mockStorage.getAllData = vi.fn(() => ({
-        profiles: { 'existing': { name: 'Basic Space Combat' } }
+        profiles: { existing: { name: 'Basic Space Combat' } },
       }))
-      
+
       profileManager.createProfileFromTemplate('basic_space')
-      
-      expect(mockApp.generateProfileId).toHaveBeenCalledWith('Basic Space Combat 1')
+
+      expect(mockApp.generateProfileId).toHaveBeenCalledWith(
+        'Basic Space Combat 1'
+      )
     })
 
     it('should handle invalid template ID', () => {
       profileManager.createProfileFromTemplate('nonexistent_template')
-      
-      expect(mockUI.showToast).toHaveBeenCalledWith('Template not found', 'error')
+
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        'Template not found',
+        'error'
+      )
       expect(mockApp.switchProfile).not.toHaveBeenCalled()
     })
   })
@@ -584,11 +660,11 @@ describe('STOProfileManager', () => {
     it('should export profile as JSON', () => {
       const testProfile = {
         name: 'Test Profile',
-        keys: { 'Space': [{ command: 'test', type: 'test' }] },
-        aliases: {}
+        keys: { Space: [{ command: 'test', type: 'test' }] },
+        aliases: {},
       }
       mockStorage.getProfile = vi.fn(() => testProfile)
-      
+
       // Mock URL and DOM methods
       global.URL.createObjectURL = vi.fn(() => 'blob:test')
       global.URL.revokeObjectURL = vi.fn()
@@ -596,22 +672,28 @@ describe('STOProfileManager', () => {
       vi.spyOn(document, 'createElement').mockReturnValue({
         href: '',
         download: '',
-        click: mockClick
+        click: mockClick,
       })
-      
+
       profileManager.exportProfile('test_profile')
-      
+
       expect(mockStorage.getProfile).toHaveBeenCalledWith('test_profile')
       expect(mockClick).toHaveBeenCalled()
-      expect(mockUI.showToast).toHaveBeenCalledWith('Profile "Test Profile" exported', 'success')
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        'Profile "Test Profile" exported',
+        'success'
+      )
     })
 
     it('should handle export of missing profile', () => {
       mockStorage.getProfile = vi.fn(() => null)
-      
+
       profileManager.exportProfile('nonexistent')
-      
-      expect(mockUI.showToast).toHaveBeenCalledWith('Profile not found', 'error')
+
+      expect(mockUI.showToast).toHaveBeenCalledWith(
+        'Profile not found',
+        'error'
+      )
     })
 
     it('should import valid profile JSON', async () => {
@@ -619,13 +701,13 @@ describe('STOProfileManager', () => {
         version: '1.0.0',
         profile: {
           name: 'Imported Profile',
-          keys: { 'Space': [{ command: 'test', type: 'test' }] },
-          aliases: {}
-        }
+          keys: { Space: [{ command: 'test', type: 'test' }] },
+          aliases: {},
+        },
       })
-      
+
       const result = await profileManager.importProfile(validJson)
-      
+
       expect(result).toBe(true)
       expect(mockApp.renderProfiles).toHaveBeenCalled()
       expect(mockUI.showToast).toHaveBeenCalledWith(
@@ -636,19 +718,19 @@ describe('STOProfileManager', () => {
 
     it('should handle duplicate names during import', async () => {
       mockStorage.getAllData = vi.fn(() => ({
-        profiles: { 'existing': { name: 'Imported Profile' } }
+        profiles: { existing: { name: 'Imported Profile' } },
       }))
-      
+
       const validJson = JSON.stringify({
         profile: {
           name: 'Imported Profile',
           keys: {},
-          aliases: {}
-        }
+          aliases: {},
+        },
       })
-      
+
       await profileManager.importProfile(validJson)
-      
+
       expect(mockUI.showToast).toHaveBeenCalledWith(
         expect.stringContaining('Imported Profile (1)'),
         'success'
@@ -657,7 +739,7 @@ describe('STOProfileManager', () => {
 
     it('should handle invalid JSON during import', async () => {
       const result = await profileManager.importProfile('invalid json')
-      
+
       expect(result).toBe(false)
       expect(mockUI.showToast).toHaveBeenCalledWith(
         expect.stringContaining('Failed to import profile'),
@@ -667,12 +749,12 @@ describe('STOProfileManager', () => {
 
     it('should validate imported profile structure', async () => {
       const invalidJson = JSON.stringify({
-        version: '1.0.0'
+        version: '1.0.0',
         // Missing profile property
       })
-      
+
       const result = await profileManager.importProfile(invalidJson)
-      
+
       expect(result).toBe(false)
       expect(mockUI.showToast).toHaveBeenCalledWith(
         expect.stringContaining('Invalid profile file format'),

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -4,9 +4,9 @@ import '../../src/js/data.js'
 
 /**
  * Unit Tests for STOStorage
- * 
+ *
  * Tests the localStorage persistence layer for the STO Keybind Manager.
- * 
+ *
  * TESTING APPROACH:
  * ✅ Import actual modules (STOStorage, STO_DATA)
  * ✅ Test real behavior with real localStorage
@@ -14,7 +14,7 @@ import '../../src/js/data.js'
  * ✅ Test actual data persistence
  * ✅ Minimal, targeted mocking only when necessary
  * ✅ Test isolation through proper cleanup
- * 
+ *
  * ANTI-PATTERNS AVOIDED:
  * ❌ Global mocking (global.STO_DATA)
  * ❌ Over-mocking localStorage
@@ -36,7 +36,7 @@ describe('STOStorage', () => {
   beforeEach(() => {
     // Clear localStorage before each test for isolation
     localStorage.clear()
-    
+
     // Create a fresh STOStorage instance
     storage = new STOStorage()
   })
@@ -56,7 +56,7 @@ describe('STOStorage', () => {
 
     it('should return default data structure when no data exists', () => {
       const data = storage.getAllData()
-      
+
       expect(data).toHaveProperty('profiles')
       expect(data).toHaveProperty('currentProfile')
       expect(data).toHaveProperty('globalAliases')
@@ -68,10 +68,14 @@ describe('STOStorage', () => {
 
     it('should use real STO_DATA for default profiles', () => {
       const data = storage.getAllData()
-      
+
       // Verify it's using actual STO_DATA
-      expect(data.profiles.default_space.name).toBe(STO_DATA.defaultProfiles.default_space.name)
-      expect(data.profiles.tactical_space.name).toBe(STO_DATA.defaultProfiles.tactical_space.name)
+      expect(data.profiles.default_space.name).toBe(
+        STO_DATA.defaultProfiles.default_space.name
+      )
+      expect(data.profiles.tactical_space.name).toBe(
+        STO_DATA.defaultProfiles.tactical_space.name
+      )
     })
   })
 
@@ -83,21 +87,21 @@ describe('STOStorage', () => {
           test_profile: {
             name: 'Test Profile',
             builds: {
-              space: { keys: { 'a': [{ command: 'Target_Enemy_Near' }] } },
-              ground: { keys: {} }
-            }
-          }
+              space: { keys: { a: [{ command: 'Target_Enemy_Near' }] } },
+              ground: { keys: {} },
+            },
+          },
         },
-        globalAliases: {}
+        globalAliases: {},
       }
-      
+
       const saveResult = storage.saveAllData(testData)
       expect(saveResult).toBe(true)
-      
+
       // Verify data was actually saved to localStorage
       const savedItem = localStorage.getItem('sto_keybind_manager')
       expect(savedItem).toBeTruthy()
-      
+
       const retrievedData = storage.getAllData()
       expect(retrievedData.currentProfile).toBe('test_profile')
       expect(retrievedData.profiles.test_profile.name).toBe('Test Profile')
@@ -108,9 +112,9 @@ describe('STOStorage', () => {
     it('should handle corrupted JSON gracefully', () => {
       // Manually corrupt the localStorage data
       localStorage.setItem('sto_keybind_manager', 'invalid json{')
-      
+
       const data = storage.getAllData()
-      
+
       // Should fallback to default data
       expect(data.currentProfile).toBe('default_space')
       expect(data.profiles.default_space).toBeDefined()
@@ -118,36 +122,36 @@ describe('STOStorage', () => {
 
     it('should create backup before saving', () => {
       // Save initial data
-      const initialData = { 
+      const initialData = {
         currentProfile: 'initial',
         profiles: {
           initial: {
             name: 'Initial Profile',
-            builds: { space: { keys: {} } }
-          }
+            builds: { space: { keys: {} } },
+          },
         },
-        globalAliases: {}
+        globalAliases: {},
       }
       storage.saveAllData(initialData)
-      
+
       // Save new data (should trigger backup)
       const newData = {
         currentProfile: 'new_profile',
         profiles: {
           new_profile: {
             name: 'New Profile',
-            builds: { space: { keys: { 'x': [{ command: 'Target_Self' }] } } }
-          }
+            builds: { space: { keys: { x: [{ command: 'Target_Self' }] } } },
+          },
         },
-        globalAliases: {}
+        globalAliases: {},
       }
-      
+
       storage.saveAllData(newData)
-      
+
       // Verify backup was created
       const backup = localStorage.getItem('sto_keybind_manager_backup')
       expect(backup).toBeTruthy()
-      
+
       const parsedBackup = JSON.parse(backup)
       expect(parsedBackup.data).toBeDefined()
       expect(parsedBackup.timestamp).toBeDefined()
@@ -159,21 +163,24 @@ describe('STOStorage', () => {
       const largeProfile = {
         name: 'Large Profile',
         builds: {
-          space: { 
+          space: {
             keys: Object.fromEntries(
-              Array.from({length: 1000}, (_, i) => [`key${i}`, [{ command: `command${i}` }]])
-            )
+              Array.from({ length: 1000 }, (_, i) => [
+                `key${i}`,
+                [{ command: `command${i}` }],
+              ])
+            ),
           },
-          ground: { keys: {} }
-        }
+          ground: { keys: {} },
+        },
       }
-      
+
       const largeData = {
         currentProfile: 'large_profile',
         profiles: { large_profile: largeProfile },
-        globalAliases: {}
+        globalAliases: {},
       }
-      
+
       // This should either succeed or fail gracefully (return boolean, not throw)
       const result = storage.saveAllData(largeData)
       expect(typeof result).toBe('boolean')
@@ -190,26 +197,26 @@ describe('STOStorage', () => {
           profile1: {
             name: 'Profile 1',
             builds: {
-              space: { keys: { 'a': [{ command: 'Target_Enemy_Near' }] } },
-              ground: { keys: {} }
-            }
+              space: { keys: { a: [{ command: 'Target_Enemy_Near' }] } },
+              ground: { keys: {} },
+            },
           },
           profile2: {
             name: 'Profile 2',
             builds: {
               space: { keys: {} },
-              ground: { keys: { 'b': [{ command: 'FireAll' }] } }
-            }
-          }
+              ground: { keys: { b: [{ command: 'FireAll' }] } },
+            },
+          },
         },
-        globalAliases: {}
+        globalAliases: {},
       }
       localStorage.setItem('sto_keybind_manager', JSON.stringify(testData))
     })
 
     it('should retrieve existing profile', () => {
       const profile = storage.getProfile('profile1')
-      
+
       expect(profile).toBeDefined()
       expect(profile.name).toBe('Profile 1')
       expect(profile.builds.space.keys.a).toBeDefined()
@@ -225,19 +232,19 @@ describe('STOStorage', () => {
       const newProfile = {
         name: 'Updated Profile',
         builds: {
-          space: { keys: { 'c': [{ command: 'FireAll' }] } },
-          ground: { keys: {} }
-        }
+          space: { keys: { c: [{ command: 'FireAll' }] } },
+          ground: { keys: {} },
+        },
       }
-      
+
       const result = storage.saveProfile('profile1', newProfile)
       expect(result).toBe(true)
-      
+
       const savedProfile = storage.getProfile('profile1')
       expect(savedProfile.name).toBe('Updated Profile')
       expect(savedProfile.lastModified).toBeDefined()
       expect(typeof savedProfile.lastModified).toBe('string')
-      
+
       // Verify timestamp is recent (within last 5 seconds)
       const timestamp = new Date(savedProfile.lastModified)
       const now = new Date()
@@ -247,10 +254,10 @@ describe('STOStorage', () => {
     it('should delete profile and update current profile', () => {
       const result = storage.deleteProfile('profile1')
       expect(result).toBe(true)
-      
+
       const deletedProfile = storage.getProfile('profile1')
       expect(deletedProfile).toBeNull()
-      
+
       const data = storage.getAllData()
       expect(data.currentProfile).toBe('profile2')
     })
@@ -264,7 +271,7 @@ describe('STOStorage', () => {
   describe('settings management', () => {
     it('should return default settings when none exist', () => {
       const settings = storage.getSettings()
-      
+
       expect(settings.theme).toBe('default')
       expect(settings.autoSave).toBe(true)
       expect(settings.showTooltips).toBe(true)
@@ -276,12 +283,12 @@ describe('STOStorage', () => {
         theme: 'dark',
         autoSave: false,
         showTooltips: false,
-        maxUndoSteps: 25
+        maxUndoSteps: 25,
       }
-      
+
       const saveResult = storage.saveSettings(customSettings)
       expect(saveResult).toBe(true)
-      
+
       const retrievedSettings = storage.getSettings()
       expect(retrievedSettings.theme).toBe('dark')
       expect(retrievedSettings.autoSave).toBe(false)
@@ -290,9 +297,9 @@ describe('STOStorage', () => {
 
     it('should handle corrupted settings gracefully', () => {
       localStorage.setItem('sto_keybind_settings', 'invalid json{')
-      
+
       const settings = storage.getSettings()
-      
+
       // Should return default settings
       expect(settings.theme).toBe('default')
       expect(settings.autoSave).toBe(true)
@@ -301,28 +308,31 @@ describe('STOStorage', () => {
 
   describe('backup and restore', () => {
     it('should restore data from backup', () => {
-      const originalData = { 
+      const originalData = {
         currentProfile: 'original',
         profiles: {
           original: {
             name: 'Original Profile',
-            builds: { space: { keys: { 'x': [{ command: 'Target_Self' }] } } }
-          }
+            builds: { space: { keys: { x: [{ command: 'Target_Self' }] } } },
+          },
         },
-        globalAliases: {}
+        globalAliases: {},
       }
-      
+
       // Create backup manually
       const backupData = {
         data: JSON.stringify(originalData),
         timestamp: new Date().toISOString(),
-        version: '1.0.0'
+        version: '1.0.0',
       }
-      localStorage.setItem('sto_keybind_manager_backup', JSON.stringify(backupData))
-      
+      localStorage.setItem(
+        'sto_keybind_manager_backup',
+        JSON.stringify(backupData)
+      )
+
       const result = storage.restoreFromBackup()
       expect(result).toBe(true)
-      
+
       const restoredData = storage.getAllData()
       expect(restoredData.currentProfile).toBe('original')
       expect(restoredData.profiles.original.name).toBe('Original Profile')
@@ -335,7 +345,7 @@ describe('STOStorage', () => {
 
     it('should handle corrupted backup gracefully', () => {
       localStorage.setItem('sto_keybind_manager_backup', 'invalid json{')
-      
+
       const result = storage.restoreFromBackup()
       expect(result).toBe(false)
     })
@@ -349,23 +359,23 @@ describe('STOStorage', () => {
           export_test: {
             name: 'Export Test Profile',
             builds: {
-              space: { keys: { 'f': [{ command: 'FireAll' }] } },
-              ground: { keys: {} }
-            }
-          }
+              space: { keys: { f: [{ command: 'FireAll' }] } },
+              ground: { keys: {} },
+            },
+          },
         },
-        globalAliases: {}
+        globalAliases: {},
       }
       storage.saveAllData(testData)
-      
+
       const exportedData = storage.exportData()
-      
+
       expect(typeof exportedData).toBe('string')
-      
+
       const parsedData = JSON.parse(exportedData)
       expect(parsedData.currentProfile).toBe('export_test')
       expect(parsedData.profiles.export_test.name).toBe('Export Test Profile')
-      
+
       // Verify it's formatted (has indentation)
       expect(exportedData).toContain('\n  ')
     })
@@ -378,17 +388,17 @@ describe('STOStorage', () => {
           imported_profile: {
             name: 'Imported Profile',
             builds: {
-              space: { keys: { 'x': [{ command: 'Target_Enemy_Near' }] } },
-              ground: { keys: {} }
-            }
-          }
+              space: { keys: { x: [{ command: 'Target_Enemy_Near' }] } },
+              ground: { keys: {} },
+            },
+          },
         },
-        globalAliases: {}
+        globalAliases: {},
       }
-      
+
       const result = storage.importData(JSON.stringify(importData))
       expect(result).toBe(true)
-      
+
       const data = storage.getAllData()
       expect(data.currentProfile).toBe('imported_profile')
       expect(data.profiles.imported_profile.name).toBe('Imported Profile')
@@ -415,13 +425,13 @@ describe('STOStorage', () => {
             name: 'Test Profile',
             builds: {
               space: { keys: {} },
-              ground: { keys: {} }
-            }
-          }
+              ground: { keys: {} },
+            },
+          },
         },
-        globalAliases: {}
+        globalAliases: {},
       }
-      
+
       const result = storage.importData(JSON.stringify(validData))
       expect(result).toBe(true)
     })
@@ -433,17 +443,17 @@ describe('STOStorage', () => {
           new_format: {
             name: 'New Format Profile',
             builds: {
-              space: { keys: { 'a': [{ command: 'Target_Self' }] } },
-              ground: { keys: {} }
-            }
-          }
+              space: { keys: { a: [{ command: 'Target_Self' }] } },
+              ground: { keys: {} },
+            },
+          },
         },
-        globalAliases: {}
+        globalAliases: {},
       }
-      
+
       const result = storage.importData(JSON.stringify(newFormatData))
       expect(result).toBe(true)
-      
+
       const savedData = storage.getAllData()
       expect(savedData.profiles.new_format.name).toBe('New Format Profile')
     })
@@ -455,16 +465,16 @@ describe('STOStorage', () => {
           legacy_profile: {
             name: 'Legacy Profile',
             mode: 'space',
-            keys: { 'a': [{ command: 'Target_Self' }] },
-            aliases: {}
-          }
+            keys: { a: [{ command: 'Target_Self' }] },
+            aliases: {},
+          },
         },
-        globalAliases: {}
+        globalAliases: {},
       }
-      
+
       const result = storage.importData(JSON.stringify(legacyData))
       expect(result).toBe(true)
-      
+
       const savedData = storage.getAllData()
       expect(savedData.profiles.legacy_profile.name).toBe('Legacy Profile')
     })
@@ -475,54 +485,56 @@ describe('STOStorage', () => {
       // Add some data to storage
       const testData = {
         currentProfile: 'test',
-        profiles: { 
-          test: { 
+        profiles: {
+          test: {
             name: 'Test Profile',
-            builds: { 
-              space: { 
-                keys: { 
-                  'a': [{ command: 'Target_Enemy_Near' }],
-                  'b': [{ command: 'FireAll' }]
-                }
+            builds: {
+              space: {
+                keys: {
+                  a: [{ command: 'Target_Enemy_Near' }],
+                  b: [{ command: 'FireAll' }],
+                },
               },
-              ground: { keys: {} }
-            }
-          }
+              ground: { keys: {} },
+            },
+          },
         },
-        globalAliases: {}
+        globalAliases: {},
       }
       storage.saveAllData(testData)
       storage.saveSettings({ theme: 'dark', autoSave: false })
-      
+
       const info = storage.getStorageInfo()
-      
+
       expect(info).toBeDefined()
       expect(info.totalSize).toBeGreaterThan(0)
       expect(info.dataSize).toBeGreaterThan(0)
       expect(info.available).toBeGreaterThan(0)
-      
+
       // Verify the sizes are realistic
       expect(info.dataSize).toBeGreaterThan(100) // At least 100 bytes
-      expect(info.totalSize).toBe(info.dataSize + info.backupSize + info.settingsSize)
+      expect(info.totalSize).toBe(
+        info.dataSize + info.backupSize + info.settingsSize
+      )
     })
 
     it('should clear all data', () => {
       // Add some data first
-      storage.saveAllData({ 
+      storage.saveAllData({
         currentProfile: 'test',
         profiles: { test: { name: 'Test', builds: { space: { keys: {} } } } },
-        globalAliases: {}
+        globalAliases: {},
       })
       storage.saveSettings({ theme: 'dark' })
       storage.createBackup()
-      
+
       const result = storage.clearAllData()
       expect(result).toBe(true)
-      
+
       // Verify all data is cleared
       expect(localStorage.getItem('sto_keybind_manager')).toBeNull()
       expect(localStorage.getItem('sto_keybind_manager_backup')).toBeNull()
       expect(localStorage.getItem('sto_keybind_settings')).toBeNull()
     })
   })
-}) 
+})

--- a/tests/unit/ui.test.js
+++ b/tests/unit/ui.test.js
@@ -3,7 +3,10 @@ import { readFileSync } from 'fs'
 import { resolve } from 'path'
 
 // Load the real HTML content
-const htmlContent = readFileSync(resolve(__dirname, '../../src/index.html'), 'utf-8')
+const htmlContent = readFileSync(
+  resolve(__dirname, '../../src/index.html'),
+  'utf-8'
+)
 
 // Import modules in dependency order
 let stoUI
@@ -12,19 +15,19 @@ describe('STOUIManager', () => {
   beforeEach(async () => {
     // Set up DOM with real HTML content
     document.documentElement.innerHTML = htmlContent
-    
+
     // Import the UI class and create an instance
     const { default: STOUIManager } = await import('../../src/js/ui.js')
     stoUI = new STOUIManager()
     window.stoUI = stoUI
-    
+
     // Add required containers to DOM if not present
     if (!document.getElementById('toastContainer')) {
       const toastContainer = document.createElement('div')
       toastContainer.id = 'toastContainer'
       document.body.appendChild(toastContainer)
     }
-    
+
     if (!document.getElementById('modalOverlay')) {
       const modalOverlay = document.createElement('div')
       modalOverlay.id = 'modalOverlay'
@@ -52,7 +55,7 @@ describe('STOUIManager', () => {
       expect(stoUI.dragState).toEqual({
         isDragging: false,
         dragElement: null,
-        dragData: null
+        dragData: null,
       })
     })
 
@@ -68,7 +71,7 @@ describe('STOUIManager', () => {
   describe('Toast Notifications', () => {
     it('should show toast with default parameters', () => {
       stoUI.showToast('Test message')
-      
+
       const toasts = document.querySelectorAll('.toast')
       expect(toasts.length).toBe(1)
       expect(toasts[0].textContent).toContain('Test message')
@@ -76,7 +79,7 @@ describe('STOUIManager', () => {
 
     it('should show toast with custom type and duration', () => {
       stoUI.showToast('Success message', 'success', 5000)
-      
+
       const toast = document.querySelector('.toast')
       expect(toast.classList.contains('toast-success')).toBe(true)
       expect(toast.querySelector('.fa-check-circle')).toBeTruthy()
@@ -84,21 +87,19 @@ describe('STOUIManager', () => {
 
     it('should create toast with correct icon for type', () => {
       stoUI.showToast('Error message', 'error')
-      
+
       const toast = document.querySelector('.toast')
       expect(toast.querySelector('.fa-exclamation-circle')).toBeTruthy()
     })
 
-
-
     it('should handle toast close button click', () => {
       stoUI.showToast('Test message')
-      
+
       const closeBtn = document.querySelector('.toast-close')
       expect(closeBtn).toBeTruthy()
-      
+
       closeBtn.click()
-      
+
       // Toast should be marked for removal
       const toast = document.querySelector('.toast')
       expect(toast.classList.contains('removing')).toBe(true)
@@ -107,9 +108,9 @@ describe('STOUIManager', () => {
     it('should hide specific toast', () => {
       stoUI.showToast('Test message')
       const toast = document.querySelector('.toast')
-      
+
       stoUI.hideToast(toast)
-      
+
       expect(toast.classList.contains('removing')).toBe(true)
     })
 
@@ -117,7 +118,7 @@ describe('STOUIManager', () => {
       // Remove toast container
       const container = document.getElementById('toastContainer')
       container.remove()
-      
+
       // Should not throw error
       expect(() => {
         stoUI.showToast('Test message')
@@ -143,16 +144,20 @@ describe('STOUIManager', () => {
 
     it('should show modal with overlay', () => {
       const result = stoUI.showModal('testModal')
-      
+
       expect(result).toBe(true)
-      expect(document.getElementById('modalOverlay').classList.contains('active')).toBe(true)
-      expect(document.getElementById('testModal').classList.contains('active')).toBe(true)
+      expect(
+        document.getElementById('modalOverlay').classList.contains('active')
+      ).toBe(true)
+      expect(
+        document.getElementById('testModal').classList.contains('active')
+      ).toBe(true)
       expect(document.body.classList.contains('modal-open')).toBe(true)
     })
 
     it('should focus first input in modal', async () => {
       stoUI.showModal('testModal')
-      
+
       // Test that modal is shown and input exists
       const firstInput = document.getElementById('testInput')
       expect(firstInput).toBeTruthy()
@@ -162,23 +167,29 @@ describe('STOUIManager', () => {
       const testData = {
         name: 'John Doe',
         email: 'john@example.com',
-        active: true
+        active: true,
       }
-      
+
       stoUI.showModal('testModal', testData)
-      
+
       expect(document.getElementById('testInput').value).toBe('John Doe')
-      expect(document.getElementById('testEmail').value).toBe('john@example.com')
+      expect(document.getElementById('testEmail').value).toBe(
+        'john@example.com'
+      )
       expect(document.getElementById('testCheck').checked).toBe(true)
     })
 
     it('should hide modal and overlay', () => {
       stoUI.showModal('testModal')
       const result = stoUI.hideModal('testModal')
-      
+
       expect(result).toBe(true)
-      expect(document.getElementById('modalOverlay').classList.contains('active')).toBe(false)
-      expect(document.getElementById('testModal').classList.contains('active')).toBe(false)
+      expect(
+        document.getElementById('modalOverlay').classList.contains('active')
+      ).toBe(false)
+      expect(
+        document.getElementById('testModal').classList.contains('active')
+      ).toBe(false)
       expect(document.body.classList.contains('modal-open')).toBe(false)
     })
 
@@ -186,9 +197,9 @@ describe('STOUIManager', () => {
       // Set some data first
       document.getElementById('testInput').value = 'Test Value'
       document.getElementById('testCheck').checked = true
-      
+
       stoUI.hideModal('testModal')
-      
+
       expect(document.getElementById('testInput').value).toBe('')
       expect(document.getElementById('testCheck').checked).toBe(false)
     })
@@ -199,12 +210,14 @@ describe('STOUIManager', () => {
       modal2.id = 'testModal2'
       modal2.className = 'modal active'
       document.body.appendChild(modal2)
-      
+
       stoUI.showModal('testModal')
-      
+
       stoUI.hideAllModals()
-      
-      expect(document.getElementById('modalOverlay').classList.contains('active')).toBe(false)
+
+      expect(
+        document.getElementById('modalOverlay').classList.contains('active')
+      ).toBe(false)
       expect(document.body.classList.contains('modal-open')).toBe(false)
       expect(document.querySelectorAll('.modal.active').length).toBe(0)
     })
@@ -212,7 +225,7 @@ describe('STOUIManager', () => {
     it('should handle missing modal gracefully', () => {
       const result = stoUI.showModal('nonExistentModal')
       expect(result).toBe(false)
-      
+
       const hideResult = stoUI.hideModal('nonExistentModal')
       expect(hideResult).toBe(false)
     })
@@ -224,9 +237,9 @@ describe('STOUIManager', () => {
       testElement.id = 'testButton'
       testElement.innerHTML = 'Click me'
       document.body.appendChild(testElement)
-      
+
       stoUI.showLoading(testElement)
-      
+
       expect(testElement.classList.contains('loading')).toBe(true)
       expect(testElement.innerHTML).toContain('fa-spinner')
       expect(testElement.disabled).toBe(true)
@@ -237,18 +250,18 @@ describe('STOUIManager', () => {
       const testElement = document.createElement('div')
       testElement.id = 'testDiv'
       document.body.appendChild(testElement)
-      
+
       stoUI.showLoading(testElement, 'Processing...')
-      
+
       expect(testElement.innerHTML).toContain('Processing...')
     })
 
     it('should disable element while loading', () => {
       const testElement = document.createElement('button')
       document.body.appendChild(testElement)
-      
+
       stoUI.showLoading(testElement)
-      
+
       expect(testElement.disabled).toBe(true)
     })
 
@@ -256,10 +269,10 @@ describe('STOUIManager', () => {
       const testElement = document.createElement('button')
       testElement.innerHTML = 'Original Content'
       document.body.appendChild(testElement)
-      
+
       stoUI.showLoading(testElement)
       stoUI.hideLoading(testElement)
-      
+
       expect(testElement.classList.contains('loading')).toBe(false)
       expect(testElement.innerHTML).toBe('Original Content')
       expect(testElement.disabled).toBe(false)
@@ -270,11 +283,11 @@ describe('STOUIManager', () => {
       const testElement = document.createElement('div')
       testElement.id = 'testElement'
       document.body.appendChild(testElement)
-      
+
       // Test with string ID
       stoUI.showLoading('testElement')
       expect(testElement.classList.contains('loading')).toBe(true)
-      
+
       stoUI.hideLoading('testElement')
       expect(testElement.classList.contains('loading')).toBe(false)
     })
@@ -283,33 +296,33 @@ describe('STOUIManager', () => {
   describe('Confirmation Dialogs', () => {
     it('should show confirmation dialog with message', async () => {
       const confirmPromise = stoUI.confirm('Are you sure?')
-      
+
       // Check that modal was created
       const confirmModal = document.querySelector('.confirm-modal')
       expect(confirmModal).toBeTruthy()
       expect(confirmModal.textContent).toContain('Are you sure?')
-      
+
       // Simulate clicking yes
       confirmModal.querySelector('.confirm-yes').click()
-      
+
       const result = await confirmPromise
       expect(result).toBe(true)
     })
 
     it('should return promise that resolves with user choice', async () => {
       const confirmPromise = stoUI.confirm('Delete this item?')
-      
+
       // Simulate clicking no
       const confirmModal = document.querySelector('.confirm-modal')
       confirmModal.querySelector('.confirm-no').click()
-      
+
       const result = await confirmPromise
       expect(result).toBe(false)
     })
 
     it('should create confirmation modal with appropriate styling', () => {
       stoUI.confirm('Warning message', 'Warning', 'danger')
-      
+
       const confirmModal = document.querySelector('.confirm-modal')
       expect(confirmModal.querySelector('.fa-exclamation-circle')).toBeTruthy()
       expect(confirmModal.textContent).toContain('Warning')
@@ -317,7 +330,7 @@ describe('STOUIManager', () => {
 
     it('should handle different confirmation types', () => {
       stoUI.confirm('Info message', 'Information', 'info')
-      
+
       const confirmModal = document.querySelector('.confirm-modal')
       expect(confirmModal.querySelector('.fa-info-circle')).toBeTruthy()
     })
@@ -341,11 +354,11 @@ describe('STOUIManager', () => {
       const callbacks = {
         onDragStart: vi.fn(),
         onDragEnd: vi.fn(),
-        onDrop: vi.fn()
+        onDrop: vi.fn(),
       }
-      
+
       stoUI.initDragAndDrop(container, callbacks)
-      
+
       // Test that method exists and can be called
       expect(typeof stoUI.initDragAndDrop).toBe('function')
     })
@@ -353,7 +366,7 @@ describe('STOUIManager', () => {
     it('should track drag state during operation', () => {
       const container = document.getElementById('dragContainer')
       stoUI.initDragAndDrop(container)
-      
+
       // Test that drag state exists and can be accessed
       expect(stoUI.dragState).toBeDefined()
       expect(stoUI.dragState.isDragging).toBe(false)
@@ -363,9 +376,9 @@ describe('STOUIManager', () => {
     it('should handle drag start events', () => {
       const container = document.getElementById('dragContainer')
       const onDragStart = vi.fn()
-      
+
       stoUI.initDragAndDrop(container, { onDragStart })
-      
+
       // Test that callback function is stored
       expect(typeof onDragStart).toBe('function')
     })
@@ -373,9 +386,9 @@ describe('STOUIManager', () => {
     it('should handle drag end events', () => {
       const container = document.getElementById('dragContainer')
       const onDragEnd = vi.fn()
-      
+
       stoUI.initDragAndDrop(container, { onDragEnd })
-      
+
       // Test that callback function is stored
       expect(typeof onDragEnd).toBe('function')
     })
@@ -385,11 +398,11 @@ describe('STOUIManager', () => {
       const callbacks = {
         onDragStart: vi.fn(),
         onDragEnd: vi.fn(),
-        onDrop: vi.fn()
+        onDrop: vi.fn(),
       }
-      
+
       stoUI.initDragAndDrop(container, callbacks)
-      
+
       // Test that callbacks are stored and can be called
       expect(typeof callbacks.onDragStart).toBe('function')
       expect(typeof callbacks.onDragEnd).toBe('function')
@@ -412,10 +425,10 @@ describe('STOUIManager', () => {
 
     it('should validate form and return result', () => {
       const form = document.getElementById('testForm')
-      
+
       // Test with empty required fields
       const result = stoUI.validateForm(form)
-      
+
       expect(result.isValid).toBe(false)
       expect(result.errors.length).toBeGreaterThan(0)
       expect(result.errors).toContain('email is required')
@@ -433,9 +446,9 @@ describe('STOUIManager', () => {
       const form = document.getElementById('testForm')
       const emailInput = document.getElementById('email')
       const nameInput = document.getElementById('name')
-      
+
       stoUI.validateForm(form)
-      
+
       expect(emailInput.classList.contains('error')).toBe(true)
       expect(nameInput.classList.contains('error')).toBe(true)
     })
@@ -444,15 +457,15 @@ describe('STOUIManager', () => {
       const form = document.getElementById('testForm')
       const emailInput = document.getElementById('email')
       const nameInput = document.getElementById('name')
-      
+
       // First validation - should add errors
       stoUI.validateForm(form)
       expect(emailInput.classList.contains('error')).toBe(true)
-      
+
       // Fix the fields
       emailInput.value = 'test@example.com'
       nameInput.value = 'John Doe'
-      
+
       // Second validation - should remove errors
       const result = stoUI.validateForm(form)
       expect(result.isValid).toBe(true)
@@ -466,12 +479,12 @@ describe('STOUIManager', () => {
       // Mock clipboard API
       Object.assign(navigator, {
         clipboard: {
-          writeText: vi.fn().mockResolvedValue(undefined)
-        }
+          writeText: vi.fn().mockResolvedValue(undefined),
+        },
       })
-      
+
       const result = await stoUI.copyToClipboard('Test text')
-      
+
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Test text')
       expect(result).toBe(true)
     })
@@ -480,15 +493,17 @@ describe('STOUIManager', () => {
       // Mock clipboard API failure
       Object.assign(navigator, {
         clipboard: {
-          writeText: vi.fn().mockRejectedValue(new Error('Clipboard not available'))
-        }
+          writeText: vi
+            .fn()
+            .mockRejectedValue(new Error('Clipboard not available')),
+        },
       })
-      
+
       // Mock document.execCommand
       document.execCommand = vi.fn().mockReturnValue(true)
-      
+
       const result = await stoUI.copyToClipboard('Test text')
-      
+
       expect(result).toBe(true)
       expect(document.execCommand).toHaveBeenCalledWith('copy')
     })
@@ -497,16 +512,18 @@ describe('STOUIManager', () => {
       // Mock both clipboard API and execCommand failure
       Object.assign(navigator, {
         clipboard: {
-          writeText: vi.fn().mockRejectedValue(new Error('Clipboard not available'))
-        }
+          writeText: vi
+            .fn()
+            .mockRejectedValue(new Error('Clipboard not available')),
+        },
       })
-      
+
       document.execCommand = vi.fn().mockImplementation(() => {
         throw new Error('execCommand failed')
       })
-      
+
       const result = await stoUI.copyToClipboard('Test text')
-      
+
       expect(result).toBe(false)
     })
   })
@@ -516,9 +533,9 @@ describe('STOUIManager', () => {
       const testElement = document.createElement('div')
       testElement.style.display = 'none'
       document.body.appendChild(testElement)
-      
+
       stoUI.fadeIn(testElement)
-      
+
       expect(testElement.style.display).toBe('block')
       expect(testElement.style.opacity).toBe('0')
     })
@@ -527,9 +544,9 @@ describe('STOUIManager', () => {
       const testElement = document.createElement('div')
       testElement.style.opacity = '1'
       document.body.appendChild(testElement)
-      
+
       stoUI.fadeOut(testElement)
-      
+
       // Test that method exists and can be called
       expect(typeof stoUI.fadeOut).toBe('function')
     })
@@ -537,11 +554,11 @@ describe('STOUIManager', () => {
     it('should respect custom animation duration', () => {
       const testElement = document.createElement('div')
       document.body.appendChild(testElement)
-      
+
       // Test that custom duration can be passed
       stoUI.fadeIn(testElement, 500)
       stoUI.fadeOut(testElement, 500)
-      
+
       // Method should complete without error
       expect(true).toBe(true)
     })
@@ -550,7 +567,7 @@ describe('STOUIManager', () => {
       const testElement = document.createElement('div')
       testElement.style.opacity = '0'
       document.body.appendChild(testElement)
-      
+
       // Should not throw error
       expect(() => {
         stoUI.fadeIn(testElement)
@@ -562,15 +579,15 @@ describe('STOUIManager', () => {
     it('should debounce function calls', () => {
       const mockFn = vi.fn()
       const debouncedFn = stoUI.debounce(mockFn, 100)
-      
+
       // Call multiple times rapidly
       debouncedFn()
       debouncedFn()
       debouncedFn()
-      
+
       // Should not be called immediately
       expect(mockFn).not.toHaveBeenCalled()
-      
+
       // Test that debounced function exists
       expect(typeof debouncedFn).toBe('function')
     })
@@ -578,15 +595,15 @@ describe('STOUIManager', () => {
     it('should throttle function calls', () => {
       const mockFn = vi.fn()
       const throttledFn = stoUI.throttle(mockFn, 100)
-      
+
       // Call multiple times rapidly
       throttledFn()
       throttledFn()
       throttledFn()
-      
+
       // Should be called immediately once
       expect(mockFn).toHaveBeenCalledTimes(1)
-      
+
       // Test that throttled function exists
       expect(typeof throttledFn).toBe('function')
     })
@@ -594,14 +611,14 @@ describe('STOUIManager', () => {
     it('should handle multiple debounced calls', () => {
       const mockFn = vi.fn()
       const debouncedFn = stoUI.debounce(mockFn, 50)
-      
+
       debouncedFn('call1')
       debouncedFn('call2')
       debouncedFn('call3')
-      
+
       // Should not be called immediately
       expect(mockFn).not.toHaveBeenCalled()
-      
+
       // Test that function can be called multiple times
       expect(typeof debouncedFn).toBe('function')
     })
@@ -609,14 +626,14 @@ describe('STOUIManager', () => {
     it('should respect throttle timing', () => {
       const mockFn = vi.fn()
       const throttledFn = stoUI.throttle(mockFn, 100)
-      
+
       throttledFn('call1')
       expect(mockFn).toHaveBeenCalledTimes(1)
-      
+
       // Immediate second call should be ignored
       throttledFn('call2')
       expect(mockFn).toHaveBeenCalledTimes(1)
-      
+
       // Test that throttle respects timing
       expect(typeof throttledFn).toBe('function')
     })
@@ -627,9 +644,9 @@ describe('STOUIManager', () => {
       const testElement = document.createElement('div')
       testElement.setAttribute('title', 'Test tooltip')
       document.body.appendChild(testElement)
-      
+
       stoUI.showTooltip(testElement, 'Test tooltip')
-      
+
       const tooltip = document.getElementById('active-tooltip')
       expect(tooltip).toBeTruthy()
       expect(tooltip.textContent).toBe('Test tooltip')
@@ -643,9 +660,9 @@ describe('STOUIManager', () => {
       testElement.style.width = '50px'
       testElement.style.height = '20px'
       document.body.appendChild(testElement)
-      
+
       stoUI.showTooltip(testElement, 'Positioned tooltip')
-      
+
       const tooltip = document.getElementById('active-tooltip')
       expect(tooltip).toBeTruthy()
       expect(tooltip.style.left).toBeTruthy()
@@ -655,10 +672,10 @@ describe('STOUIManager', () => {
     it('should hide tooltip', () => {
       const testElement = document.createElement('div')
       document.body.appendChild(testElement)
-      
+
       stoUI.showTooltip(testElement, 'Test tooltip')
       expect(document.getElementById('active-tooltip')).toBeTruthy()
-      
+
       stoUI.hideTooltip()
       expect(document.getElementById('active-tooltip')).toBeFalsy()
     })
@@ -666,20 +683,24 @@ describe('STOUIManager', () => {
     it('should handle tooltip content updates', () => {
       const testElement = document.createElement('div')
       document.body.appendChild(testElement)
-      
+
       stoUI.showTooltip(testElement, 'First tooltip')
-      expect(document.getElementById('active-tooltip').textContent).toBe('First tooltip')
-      
+      expect(document.getElementById('active-tooltip').textContent).toBe(
+        'First tooltip'
+      )
+
       stoUI.showTooltip(testElement, 'Updated tooltip')
-      expect(document.getElementById('active-tooltip').textContent).toBe('Updated tooltip')
+      expect(document.getElementById('active-tooltip').textContent).toBe(
+        'Updated tooltip'
+      )
     })
 
     it('should setup tooltip event listeners', () => {
       // Test that method exists and can be called
       expect(typeof stoUI.setupTooltips).toBe('function')
-      
+
       stoUI.setupTooltips()
-      
+
       // Method should complete without error
       expect(true).toBe(true)
     })
@@ -696,39 +717,43 @@ describe('STOUIManager', () => {
 
     it('should handle escape key to close modals', () => {
       stoUI.showModal('testModal')
-      
+
       // Simulate escape key press
       const escapeEvent = new KeyboardEvent('keydown', { key: 'Escape' })
       document.dispatchEvent(escapeEvent)
-      
-      expect(document.getElementById('testModal').classList.contains('active')).toBe(false)
+
+      expect(
+        document.getElementById('testModal').classList.contains('active')
+      ).toBe(false)
     })
 
     it('should handle click outside to close dropdowns', () => {
       stoUI.showModal('testModal')
-      
+
       // Simulate click on modal overlay
       const overlay = document.getElementById('modalOverlay')
       overlay.classList.add('modal-overlay')
-      
+
       const clickEvent = new MouseEvent('click', { bubbles: true })
       Object.defineProperty(clickEvent, 'target', {
-        value: overlay
+        value: overlay,
       })
-      
+
       document.dispatchEvent(clickEvent)
-      
-      expect(document.getElementById('testModal').classList.contains('active')).toBe(false)
+
+      expect(
+        document.getElementById('testModal').classList.contains('active')
+      ).toBe(false)
     })
 
     it('should prevent event bubbling where appropriate', () => {
       // Test that global event listeners are set up
       expect(typeof stoUI.setupGlobalEventListeners).toBe('function')
-      
+
       stoUI.setupGlobalEventListeners()
-      
+
       // Method should complete without error
       expect(true).toBe(true)
     })
   })
-}) 
+})

--- a/tests/unit/vertigo.test.js
+++ b/tests/unit/vertigo.test.js
@@ -1,102 +1,102 @@
 // STO Tools Keybind Manager - Vertigo VFX Manager Tests
 // Tests for the visual effects management functionality
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 // Mock the VERTIGO_EFFECTS and vertigoManager since they're loaded in a different file
 const VERTIGO_EFFECTS = {
-    space: [
-        { label: "Test Space Effect 1", effect: "Fx_Test_Space_Effect_1" },
-        { label: "Test Space Effect 2", effect: "Fx_Test_Space_Effect_2" }
-    ],
-    ground: [
-        { label: "Test Ground Effect 1", effect: "Fx_Test_Ground_Effect_1" },
-        { label: "Test Ground Effect 2", effect: "Fx_Test_Ground_Effect_2" }
-    ]
-};
+  space: [
+    { label: 'Test Space Effect 1', effect: 'Fx_Test_Space_Effect_1' },
+    { label: 'Test Space Effect 2', effect: 'Fx_Test_Space_Effect_2' },
+  ],
+  ground: [
+    { label: 'Test Ground Effect 1', effect: 'Fx_Test_Ground_Effect_1' },
+    { label: 'Test Ground Effect 2', effect: 'Fx_Test_Ground_Effect_2' },
+  ],
+}
 
 class MockVertigoManager {
-    constructor() {
-        this.selectedEffects = {
-            space: new Set(),
-            ground: new Set()
-        };
-        this.showPlayerSay = false;
+  constructor() {
+    this.selectedEffects = {
+      space: new Set(),
+      ground: new Set(),
+    }
+    this.showPlayerSay = false
+  }
+
+  generateAlias(environment) {
+    const effects = Array.from(this.selectedEffects[environment])
+    if (effects.length === 0) return ''
+
+    let aliasName = `dynFxSetFXExlusionList_${environment.charAt(0).toUpperCase() + environment.slice(1)}`
+    let command = `alias ${aliasName} <& dynFxSetFXExlusionList ${effects.join(',')}`
+
+    if (this.showPlayerSay) {
+      command += ' $$ PlayerSay Vertigo VFX Loaded'
     }
 
-    generateAlias(environment) {
-        const effects = Array.from(this.selectedEffects[environment]);
-        if (effects.length === 0) return '';
+    command += ' &>'
+    return command
+  }
 
-        let aliasName = `dynFxSetFXExlusionList_${environment.charAt(0).toUpperCase() + environment.slice(1)}`;
-        let command = `alias ${aliasName} <& dynFxSetFXExlusionList ${effects.join(',')}`;
-        
-        if (this.showPlayerSay) {
-            command += ' $$ PlayerSay Vertigo VFX Loaded';
-        }
-        
-        command += ' &>';
-        return command;
+  toggleEffect(environment, effectName) {
+    if (this.selectedEffects[environment].has(effectName)) {
+      this.selectedEffects[environment].delete(effectName)
+    } else {
+      this.selectedEffects[environment].add(effectName)
     }
+  }
 
-    toggleEffect(environment, effectName) {
-        if (this.selectedEffects[environment].has(effectName)) {
-            this.selectedEffects[environment].delete(effectName);
-        } else {
-            this.selectedEffects[environment].add(effectName);
-        }
-    }
+  clearAllEffects() {
+    this.selectedEffects.space.clear()
+    this.selectedEffects.ground.clear()
+  }
 
-    clearAllEffects() {
-        this.selectedEffects.space.clear();
-        this.selectedEffects.ground.clear();
-    }
+  selectAllEffects(environment) {
+    VERTIGO_EFFECTS[environment].forEach((effect) => {
+      this.selectedEffects[environment].add(effect.effect)
+    })
+  }
 
-    selectAllEffects(environment) {
-        VERTIGO_EFFECTS[environment].forEach(effect => {
-            this.selectedEffects[environment].add(effect.effect);
-        });
-    }
+  getEffectCount(environment) {
+    return this.selectedEffects[environment].size
+  }
 
-    getEffectCount(environment) {
-        return this.selectedEffects[environment].size;
-    }
-
-    isEffectSelected(environment, effectName) {
-        return this.selectedEffects[environment].has(effectName);
-    }
+  isEffectSelected(environment, effectName) {
+    return this.selectedEffects[environment].has(effectName)
+  }
 }
 
 // Mock DOM and global objects
 const mockProfile = {
-    name: 'Test Profile',
-    aliases: {}
-};
+  name: 'Test Profile',
+  aliases: {},
+}
 
 const mockUI = {
-    showModal: vi.fn(),
-    hideModal: vi.fn(),
-    showToast: vi.fn()
-};
+  showModal: vi.fn(),
+  hideModal: vi.fn(),
+  showToast: vi.fn(),
+}
 
 const mockApp = {
-    getCurrentProfile: vi.fn(() => mockProfile),
-    saveProfile: vi.fn(),
-    setModified: vi.fn()
-};
+  getCurrentProfile: vi.fn(() => mockProfile),
+  saveProfile: vi.fn(),
+  setModified: vi.fn(),
+}
 
 // Global setup
 beforeEach(() => {
-    global.VERTIGO_EFFECTS = VERTIGO_EFFECTS;
-    global.vertigoManager = new MockVertigoManager();
-    global.stoUI = mockUI;
-    global.app = mockApp;
-    
-    // Reset all mocks
-    vi.clearAllMocks();
-    
-    // Setup DOM
-    document.body.innerHTML = `
+  global.VERTIGO_EFFECTS = VERTIGO_EFFECTS
+  global.vertigoManager = new MockVertigoManager()
+  global.stoUI = mockUI
+  global.app = mockApp
+
+  // Reset all mocks
+  vi.clearAllMocks()
+
+  // Setup DOM
+  document.body.innerHTML = `
         <div id="vertigoModal">
             <div id="spaceEffectsList"></div>
             <div id="groundEffectsList"></div>
@@ -111,283 +111,315 @@ beforeEach(() => {
             <button id="groundClearAll">Clear All</button>
             <button id="saveVertigoBtn">Generate Aliases</button>
         </div>
-    `;
-});
+    `
+})
 
 afterEach(() => {
-    document.body.innerHTML = '';
-    delete global.VERTIGO_EFFECTS;
-    delete global.vertigoManager;
-    delete global.stoUI;
-    delete global.app;
-});
+  document.body.innerHTML = ''
+  delete global.VERTIGO_EFFECTS
+  delete global.vertigoManager
+  delete global.stoUI
+  delete global.app
+})
 
 describe('VertigoManager', () => {
-    describe('generateAlias', () => {
-        it('should return empty string when no effects selected', () => {
-            const result = vertigoManager.generateAlias('space');
-            expect(result).toBe('');
-        });
+  describe('generateAlias', () => {
+    it('should return empty string when no effects selected', () => {
+      const result = vertigoManager.generateAlias('space')
+      expect(result).toBe('')
+    })
 
-        it('should generate correct alias format for space effects', () => {
-            vertigoManager.selectedEffects.space.add('Fx_Test_Effect_1');
-            vertigoManager.selectedEffects.space.add('Fx_Test_Effect_2');
-            
-            const result = vertigoManager.generateAlias('space');
-            expect(result).toBe('alias dynFxSetFXExlusionList_Space <& dynFxSetFXExlusionList Fx_Test_Effect_1,Fx_Test_Effect_2 &>');
-        });
+    it('should generate correct alias format for space effects', () => {
+      vertigoManager.selectedEffects.space.add('Fx_Test_Effect_1')
+      vertigoManager.selectedEffects.space.add('Fx_Test_Effect_2')
 
-        it('should generate correct alias format for ground effects', () => {
-            vertigoManager.selectedEffects.ground.add('Fx_Test_Effect_Ground');
-            
-            const result = vertigoManager.generateAlias('ground');
-            expect(result).toBe('alias dynFxSetFXExlusionList_Ground <& dynFxSetFXExlusionList Fx_Test_Effect_Ground &>');
-        });
+      const result = vertigoManager.generateAlias('space')
+      expect(result).toBe(
+        'alias dynFxSetFXExlusionList_Space <& dynFxSetFXExlusionList Fx_Test_Effect_1,Fx_Test_Effect_2 &>'
+      )
+    })
 
-        it('should include PlayerSay when showPlayerSay is enabled', () => {
-            vertigoManager.selectedEffects.space.add('Fx_Test_Effect');
-            vertigoManager.showPlayerSay = true;
-            
-            const result = vertigoManager.generateAlias('space');
-            expect(result).toBe('alias dynFxSetFXExlusionList_Space <& dynFxSetFXExlusionList Fx_Test_Effect $$ PlayerSay Vertigo VFX Loaded &>');
-        });
+    it('should generate correct alias format for ground effects', () => {
+      vertigoManager.selectedEffects.ground.add('Fx_Test_Effect_Ground')
 
-        it('should have proper spacing before closing bracket', () => {
-            vertigoManager.selectedEffects.space.add('Fx_Test_Effect');
-            vertigoManager.showPlayerSay = false;
-            
-            const result = vertigoManager.generateAlias('space');
-            // This test will fail with the current bug - should end with ' &>' not '&>'
-            expect(result).toMatch(/ &>$/);
-            expect(result).not.toMatch(/[^ ]&>$/);
-        });
+      const result = vertigoManager.generateAlias('ground')
+      expect(result).toBe(
+        'alias dynFxSetFXExlusionList_Ground <& dynFxSetFXExlusionList Fx_Test_Effect_Ground &>'
+      )
+    })
 
-        it('should have proper spacing before PlayerSay and closing bracket', () => {
-            vertigoManager.selectedEffects.space.add('Fx_Test_Effect');
-            vertigoManager.showPlayerSay = true;
-            
-            const result = vertigoManager.generateAlias('space');
-            // This test will fail with the current bug - should end with ' &>' not '&>'
-            expect(result).toMatch(/ &>$/);
-            expect(result).toMatch(/PlayerSay Vertigo VFX Loaded &>$/);
-        });
-    });
+    it('should include PlayerSay when showPlayerSay is enabled', () => {
+      vertigoManager.selectedEffects.space.add('Fx_Test_Effect')
+      vertigoManager.showPlayerSay = true
 
-    describe('toggleEffect', () => {
-        it('should add effect when not selected', () => {
-            vertigoManager.toggleEffect('space', 'Fx_Test_Effect');
-            expect(vertigoManager.isEffectSelected('space', 'Fx_Test_Effect')).toBe(true);
-        });
+      const result = vertigoManager.generateAlias('space')
+      expect(result).toBe(
+        'alias dynFxSetFXExlusionList_Space <& dynFxSetFXExlusionList Fx_Test_Effect $$ PlayerSay Vertigo VFX Loaded &>'
+      )
+    })
 
-        it('should remove effect when already selected', () => {
-            vertigoManager.selectedEffects.space.add('Fx_Test_Effect');
-            vertigoManager.toggleEffect('space', 'Fx_Test_Effect');
-            expect(vertigoManager.isEffectSelected('space', 'Fx_Test_Effect')).toBe(false);
-        });
-    });
+    it('should have proper spacing before closing bracket', () => {
+      vertigoManager.selectedEffects.space.add('Fx_Test_Effect')
+      vertigoManager.showPlayerSay = false
 
-    describe('selectAllEffects', () => {
-        it('should select all space effects', () => {
-            vertigoManager.selectAllEffects('space');
-            expect(vertigoManager.getEffectCount('space')).toBe(2);
-            expect(vertigoManager.isEffectSelected('space', 'Fx_Test_Space_Effect_1')).toBe(true);
-            expect(vertigoManager.isEffectSelected('space', 'Fx_Test_Space_Effect_2')).toBe(true);
-        });
+      const result = vertigoManager.generateAlias('space')
+      // This test will fail with the current bug - should end with ' &>' not '&>'
+      expect(result).toMatch(/ &>$/)
+      expect(result).not.toMatch(/[^ ]&>$/)
+    })
 
-        it('should select all ground effects', () => {
-            vertigoManager.selectAllEffects('ground');
-            expect(vertigoManager.getEffectCount('ground')).toBe(2);
-            expect(vertigoManager.isEffectSelected('ground', 'Fx_Test_Ground_Effect_1')).toBe(true);
-            expect(vertigoManager.isEffectSelected('ground', 'Fx_Test_Ground_Effect_2')).toBe(true);
-        });
-    });
+    it('should have proper spacing before PlayerSay and closing bracket', () => {
+      vertigoManager.selectedEffects.space.add('Fx_Test_Effect')
+      vertigoManager.showPlayerSay = true
 
-    describe('clearAllEffects', () => {
-        it('should clear all selected effects', () => {
-            vertigoManager.selectAllEffects('space');
-            vertigoManager.selectAllEffects('ground');
-            
-            vertigoManager.clearAllEffects();
-            
-            expect(vertigoManager.getEffectCount('space')).toBe(0);
-            expect(vertigoManager.getEffectCount('ground')).toBe(0);
-        });
-    });
-});
+      const result = vertigoManager.generateAlias('space')
+      // This test will fail with the current bug - should end with ' &>' not '&>'
+      expect(result).toMatch(/ &>$/)
+      expect(result).toMatch(/PlayerSay Vertigo VFX Loaded &>$/)
+    })
+  })
+
+  describe('toggleEffect', () => {
+    it('should add effect when not selected', () => {
+      vertigoManager.toggleEffect('space', 'Fx_Test_Effect')
+      expect(vertigoManager.isEffectSelected('space', 'Fx_Test_Effect')).toBe(
+        true
+      )
+    })
+
+    it('should remove effect when already selected', () => {
+      vertigoManager.selectedEffects.space.add('Fx_Test_Effect')
+      vertigoManager.toggleEffect('space', 'Fx_Test_Effect')
+      expect(vertigoManager.isEffectSelected('space', 'Fx_Test_Effect')).toBe(
+        false
+      )
+    })
+  })
+
+  describe('selectAllEffects', () => {
+    it('should select all space effects', () => {
+      vertigoManager.selectAllEffects('space')
+      expect(vertigoManager.getEffectCount('space')).toBe(2)
+      expect(
+        vertigoManager.isEffectSelected('space', 'Fx_Test_Space_Effect_1')
+      ).toBe(true)
+      expect(
+        vertigoManager.isEffectSelected('space', 'Fx_Test_Space_Effect_2')
+      ).toBe(true)
+    })
+
+    it('should select all ground effects', () => {
+      vertigoManager.selectAllEffects('ground')
+      expect(vertigoManager.getEffectCount('ground')).toBe(2)
+      expect(
+        vertigoManager.isEffectSelected('ground', 'Fx_Test_Ground_Effect_1')
+      ).toBe(true)
+      expect(
+        vertigoManager.isEffectSelected('ground', 'Fx_Test_Ground_Effect_2')
+      ).toBe(true)
+    })
+  })
+
+  describe('clearAllEffects', () => {
+    it('should clear all selected effects', () => {
+      vertigoManager.selectAllEffects('space')
+      vertigoManager.selectAllEffects('ground')
+
+      vertigoManager.clearAllEffects()
+
+      expect(vertigoManager.getEffectCount('space')).toBe(0)
+      expect(vertigoManager.getEffectCount('ground')).toBe(0)
+    })
+  })
+})
 
 describe('Vertigo UI Integration', () => {
-    // Mock app methods that would be used by Vertigo UI
-    const mockVertgoApp = {
-        ...mockApp,
-        showVertigoModal: vi.fn(),
-        populateVertigoModal: vi.fn(),
-        setupVertigoEventListeners: vi.fn(),
-        updateVertigoEffectCounts: vi.fn(),
-        updateVertigoPreview: vi.fn(),
-        generateVertigoAliases: vi.fn()
-    };
+  // Mock app methods that would be used by Vertigo UI
+  const mockVertgoApp = {
+    ...mockApp,
+    showVertigoModal: vi.fn(),
+    populateVertigoModal: vi.fn(),
+    setupVertigoEventListeners: vi.fn(),
+    updateVertigoEffectCounts: vi.fn(),
+    updateVertigoPreview: vi.fn(),
+    generateVertigoAliases: vi.fn(),
+  }
 
-    beforeEach(() => {
-        global.app = mockVertgoApp;
-    });
+  beforeEach(() => {
+    global.app = mockVertgoApp
+  })
 
-    describe('Modal Population', () => {
-        it('should populate space effects list', () => {
-            const spaceList = document.getElementById('spaceEffectsList');
-            expect(spaceList).toBeTruthy();
-            
-            // Mock the effects list population
-            VERTIGO_EFFECTS.space.forEach(effect => {
-                const effectItem = document.createElement('div');
-                effectItem.className = 'effect-item';
-                effectItem.innerHTML = `
+  describe('Modal Population', () => {
+    it('should populate space effects list', () => {
+      const spaceList = document.getElementById('spaceEffectsList')
+      expect(spaceList).toBeTruthy()
+
+      // Mock the effects list population
+      VERTIGO_EFFECTS.space.forEach((effect) => {
+        const effectItem = document.createElement('div')
+        effectItem.className = 'effect-item'
+        effectItem.innerHTML = `
                     <input type="checkbox" data-environment="space" data-effect="${effect.effect}">
                     <label class="effect-label">${effect.label}</label>
-                `;
-                spaceList.appendChild(effectItem);
-            });
-            
-            const checkboxes = spaceList.querySelectorAll('input[type="checkbox"]');
-            expect(checkboxes.length).toBe(2);
-        });
+                `
+        spaceList.appendChild(effectItem)
+      })
 
-        it('should populate ground effects list', () => {
-            const groundList = document.getElementById('groundEffectsList');
-            expect(groundList).toBeTruthy();
-            
-            // Mock the effects list population
-            VERTIGO_EFFECTS.ground.forEach(effect => {
-                const effectItem = document.createElement('div');
-                effectItem.className = 'effect-item';
-                effectItem.innerHTML = `
+      const checkboxes = spaceList.querySelectorAll('input[type="checkbox"]')
+      expect(checkboxes.length).toBe(2)
+    })
+
+    it('should populate ground effects list', () => {
+      const groundList = document.getElementById('groundEffectsList')
+      expect(groundList).toBeTruthy()
+
+      // Mock the effects list population
+      VERTIGO_EFFECTS.ground.forEach((effect) => {
+        const effectItem = document.createElement('div')
+        effectItem.className = 'effect-item'
+        effectItem.innerHTML = `
                     <input type="checkbox" data-environment="ground" data-effect="${effect.effect}">
                     <label class="effect-label">${effect.label}</label>
-                `;
-                groundList.appendChild(effectItem);
-            });
-            
-            const checkboxes = groundList.querySelectorAll('input[type="checkbox"]');
-            expect(checkboxes.length).toBe(2);
-        });
-    });
+                `
+        groundList.appendChild(effectItem)
+      })
 
-    describe('Effect Count Updates', () => {
-        it('should update effect count display', () => {
-            vertigoManager.selectAllEffects('space');
-            
-            const spaceCount = document.getElementById('spaceEffectCount');
-            spaceCount.textContent = `${vertigoManager.getEffectCount('space')} selected`;
-            
-            expect(spaceCount.textContent).toBe('2 selected');
-        });
-    });
+      const checkboxes = groundList.querySelectorAll('input[type="checkbox"]')
+      expect(checkboxes.length).toBe(2)
+    })
+  })
 
-    describe('Preview Updates', () => {
-        it('should update alias preview for space', () => {
-            vertigoManager.selectedEffects.space.add('Fx_Test_Effect');
-            
-            const spacePreview = document.getElementById('spaceAliasCommand');
-            const spaceAlias = vertigoManager.generateAlias('space');
-            spacePreview.textContent = spaceAlias;
-            
-            expect(spacePreview.textContent).toBe('alias dynFxSetFXExlusionList_Space <& dynFxSetFXExlusionList Fx_Test_Effect &>');
-        });
+  describe('Effect Count Updates', () => {
+    it('should update effect count display', () => {
+      vertigoManager.selectAllEffects('space')
 
-        it('should show no effects message when none selected', () => {
-            const spacePreview = document.getElementById('spaceAliasCommand');
-            const spaceAlias = vertigoManager.generateAlias('space');
-            spacePreview.textContent = spaceAlias || 'No space effects selected';
-            
-            expect(spacePreview.textContent).toBe('No space effects selected');
-        });
-    });
+      const spaceCount = document.getElementById('spaceEffectCount')
+      spaceCount.textContent = `${vertigoManager.getEffectCount('space')} selected`
 
-    describe('Alias Generation', () => {
-        beforeEach(() => {
-            mockProfile.aliases = {};
-        });
+      expect(spaceCount.textContent).toBe('2 selected')
+    })
+  })
 
-        it('should generate space alias correctly', () => {
-            vertigoManager.selectedEffects.space.add('Fx_Test_Effect_1');
-            vertigoManager.selectedEffects.space.add('Fx_Test_Effect_2');
-            
-            const spaceAlias = vertigoManager.generateAlias('space');
-            const commands = spaceAlias.replace('alias dynFxSetFXExlusionList_Space <& ', '').replace(' &>', '');
-            
-            mockProfile.aliases['dynFxSetFXExlusionList_Space'] = {
-                name: 'dynFxSetFXExlusionList_Space',
-                description: 'Vertigo - Disable Space Visual Effects',
-                commands: commands
-            };
-            
-            expect(mockProfile.aliases['dynFxSetFXExlusionList_Space']).toBeDefined();
-            expect(mockProfile.aliases['dynFxSetFXExlusionList_Space'].commands).toBe('dynFxSetFXExlusionList Fx_Test_Effect_1,Fx_Test_Effect_2');
-        });
+  describe('Preview Updates', () => {
+    it('should update alias preview for space', () => {
+      vertigoManager.selectedEffects.space.add('Fx_Test_Effect')
 
-        it('should generate ground alias correctly', () => {
-            vertigoManager.selectedEffects.ground.add('Fx_Test_Ground_Effect');
-            
-            const groundAlias = vertigoManager.generateAlias('ground');
-            const commands = groundAlias.replace('alias dynFxSetFXExlusionList_Ground <& ', '').replace(' &>', '');
-            
-            mockProfile.aliases['dynFxSetFXExlusionList_Ground'] = {
-                name: 'dynFxSetFXExlusionList_Ground',
-                description: 'Vertigo - Disable Ground Visual Effects',
-                commands: commands
-            };
-            
-            expect(mockProfile.aliases['dynFxSetFXExlusionList_Ground']).toBeDefined();
-            expect(mockProfile.aliases['dynFxSetFXExlusionList_Ground'].commands).toBe('dynFxSetFXExlusionList Fx_Test_Ground_Effect');
-        });
+      const spacePreview = document.getElementById('spaceAliasCommand')
+      const spaceAlias = vertigoManager.generateAlias('space')
+      spacePreview.textContent = spaceAlias
 
-        it('should include PlayerSay in alias when enabled', () => {
-            vertigoManager.selectedEffects.space.add('Fx_Test_Effect');
-            vertigoManager.showPlayerSay = true;
-            
-            const spaceAlias = vertigoManager.generateAlias('space');
-            const commands = spaceAlias.replace('alias dynFxSetFXExlusionList_Space <& ', '').replace(' &>', '');
-            
-            expect(commands).toBe('dynFxSetFXExlusionList Fx_Test_Effect $$ PlayerSay Vertigo VFX Loaded');
-        });
-    });
-});
+      expect(spacePreview.textContent).toBe(
+        'alias dynFxSetFXExlusionList_Space <& dynFxSetFXExlusionList Fx_Test_Effect &>'
+      )
+    })
+
+    it('should show no effects message when none selected', () => {
+      const spacePreview = document.getElementById('spaceAliasCommand')
+      const spaceAlias = vertigoManager.generateAlias('space')
+      spacePreview.textContent = spaceAlias || 'No space effects selected'
+
+      expect(spacePreview.textContent).toBe('No space effects selected')
+    })
+  })
+
+  describe('Alias Generation', () => {
+    beforeEach(() => {
+      mockProfile.aliases = {}
+    })
+
+    it('should generate space alias correctly', () => {
+      vertigoManager.selectedEffects.space.add('Fx_Test_Effect_1')
+      vertigoManager.selectedEffects.space.add('Fx_Test_Effect_2')
+
+      const spaceAlias = vertigoManager.generateAlias('space')
+      const commands = spaceAlias
+        .replace('alias dynFxSetFXExlusionList_Space <& ', '')
+        .replace(' &>', '')
+
+      mockProfile.aliases['dynFxSetFXExlusionList_Space'] = {
+        name: 'dynFxSetFXExlusionList_Space',
+        description: 'Vertigo - Disable Space Visual Effects',
+        commands: commands,
+      }
+
+      expect(mockProfile.aliases['dynFxSetFXExlusionList_Space']).toBeDefined()
+      expect(mockProfile.aliases['dynFxSetFXExlusionList_Space'].commands).toBe(
+        'dynFxSetFXExlusionList Fx_Test_Effect_1,Fx_Test_Effect_2'
+      )
+    })
+
+    it('should generate ground alias correctly', () => {
+      vertigoManager.selectedEffects.ground.add('Fx_Test_Ground_Effect')
+
+      const groundAlias = vertigoManager.generateAlias('ground')
+      const commands = groundAlias
+        .replace('alias dynFxSetFXExlusionList_Ground <& ', '')
+        .replace(' &>', '')
+
+      mockProfile.aliases['dynFxSetFXExlusionList_Ground'] = {
+        name: 'dynFxSetFXExlusionList_Ground',
+        description: 'Vertigo - Disable Ground Visual Effects',
+        commands: commands,
+      }
+
+      expect(mockProfile.aliases['dynFxSetFXExlusionList_Ground']).toBeDefined()
+      expect(
+        mockProfile.aliases['dynFxSetFXExlusionList_Ground'].commands
+      ).toBe('dynFxSetFXExlusionList Fx_Test_Ground_Effect')
+    })
+
+    it('should include PlayerSay in alias when enabled', () => {
+      vertigoManager.selectedEffects.space.add('Fx_Test_Effect')
+      vertigoManager.showPlayerSay = true
+
+      const spaceAlias = vertigoManager.generateAlias('space')
+      const commands = spaceAlias
+        .replace('alias dynFxSetFXExlusionList_Space <& ', '')
+        .replace(' &>', '')
+
+      expect(commands).toBe(
+        'dynFxSetFXExlusionList Fx_Test_Effect $$ PlayerSay Vertigo VFX Loaded'
+      )
+    })
+  })
+})
 
 describe('Vertigo Data Validation', () => {
-    it('should have valid effect data structure', () => {
-        expect(VERTIGO_EFFECTS).toBeDefined();
-        expect(VERTIGO_EFFECTS.space).toBeInstanceOf(Array);
-        expect(VERTIGO_EFFECTS.ground).toBeInstanceOf(Array);
-    });
+  it('should have valid effect data structure', () => {
+    expect(VERTIGO_EFFECTS).toBeDefined()
+    expect(VERTIGO_EFFECTS.space).toBeInstanceOf(Array)
+    expect(VERTIGO_EFFECTS.ground).toBeInstanceOf(Array)
+  })
 
-    it('should have properly formatted space effects', () => {
-        VERTIGO_EFFECTS.space.forEach(effect => {
-            expect(effect).toHaveProperty('label');
-            expect(effect).toHaveProperty('effect');
-            expect(typeof effect.label).toBe('string');
-            expect(typeof effect.effect).toBe('string');
-            expect(effect.label.length).toBeGreaterThan(0);
-            expect(effect.effect.length).toBeGreaterThan(0);
-        });
-    });
+  it('should have properly formatted space effects', () => {
+    VERTIGO_EFFECTS.space.forEach((effect) => {
+      expect(effect).toHaveProperty('label')
+      expect(effect).toHaveProperty('effect')
+      expect(typeof effect.label).toBe('string')
+      expect(typeof effect.effect).toBe('string')
+      expect(effect.label.length).toBeGreaterThan(0)
+      expect(effect.effect.length).toBeGreaterThan(0)
+    })
+  })
 
-    it('should have properly formatted ground effects', () => {
-        VERTIGO_EFFECTS.ground.forEach(effect => {
-            expect(effect).toHaveProperty('label');
-            expect(effect).toHaveProperty('effect');
-            expect(typeof effect.label).toBe('string');
-            expect(typeof effect.effect).toBe('string');
-            expect(effect.label.length).toBeGreaterThan(0);
-            expect(effect.effect.length).toBeGreaterThan(0);
-        });
-    });
+  it('should have properly formatted ground effects', () => {
+    VERTIGO_EFFECTS.ground.forEach((effect) => {
+      expect(effect).toHaveProperty('label')
+      expect(effect).toHaveProperty('effect')
+      expect(typeof effect.label).toBe('string')
+      expect(typeof effect.effect).toBe('string')
+      expect(effect.label.length).toBeGreaterThan(0)
+      expect(effect.effect.length).toBeGreaterThan(0)
+    })
+  })
 
-    it('should generate valid STO command format', () => {
-        vertigoManager.selectedEffects.space.add('Fx_Test_Effect');
-        const alias = vertigoManager.generateAlias('space');
-        
-        // Validate alias format
-        expect(alias).toMatch(/^alias\s+\w+\s+<&\s+.+\s+&>$/);
-        expect(alias).toContain('dynFxSetFXExlusionList');
-        expect(alias).toContain('Fx_Test_Effect');
-    });
-}); 
+  it('should generate valid STO command format', () => {
+    vertigoManager.selectedEffects.space.add('Fx_Test_Effect')
+    const alias = vertigoManager.generateAlias('space')
+
+    // Validate alias format
+    expect(alias).toMatch(/^alias\s+\w+\s+<&\s+.+\s+&>$/)
+    expect(alias).toContain('dynFxSetFXExlusionList')
+    expect(alias).toContain('Fx_Test_Effect')
+  })
+})


### PR DESCRIPTION
## Summary
- add ESLint and Prettier configs
- add lint and format scripts
- install ESLint/Prettier deps
- run formatting across `src/` and `tests/`

## Testing
- `npm run format`
- `npm run lint` *(fails: 2462 problems)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685501d3853083259605f9a72d7f0877