### PR TITLE
Add export format modal

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -869,6 +869,14 @@ Select an item on the left to preview export</pre
               <option value="json_project">Complete Project (.json)</option>
               <option value="csv_data">CSV Data (.csv)</option>
               <option value="html_report">HTML Report (.html)</option>
+              <option value="alias_file">Alias File (.txt)</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="exportEnvironment">Environment:</label>
+            <select id="exportEnvironment">
+              <option value="space">Space</option>
+              <option value="ground">Ground</option>
             </select>
           </div>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -848,6 +848,34 @@ Select an item on the left to preview export</pre
             Close
           </button>
         </div>
+    </div>
+  </div>
+
+    <!-- Export Options Modal -->
+    <div class="modal" id="exportModal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3>Select Export Format</h3>
+          <button class="modal-close" data-modal="exportModal">
+            <i class="fas fa-times"></i>
+          </button>
+        </div>
+        <div class="modal-body">
+          <div class="form-group">
+            <label for="exportFormat">Export As:</label>
+            <select id="exportFormat">
+              <option value="sto_keybind">STO Keybind File (.txt)</option>
+              <option value="json_profile">JSON Profile (.json)</option>
+              <option value="json_project">Complete Project (.json)</option>
+              <option value="csv_data">CSV Data (.csv)</option>
+              <option value="html_report">HTML Report (.html)</option>
+            </select>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-primary" id="confirmExportBtn">Export</button>
+          <button class="btn btn-secondary" data-modal="exportModal">Cancel</button>
+        </div>
       </div>
     </div>
 

--- a/src/js/export.js
+++ b/src/js/export.js
@@ -79,7 +79,7 @@ export default class STOExportManager {
         this.exportHTMLReport(profile)
         break
       case 'alias_file':
-        this.exportAliases(profile, environment)
+        this.exportAliases(profile)
         break
       default:
         break
@@ -736,12 +736,12 @@ export default class STOExportManager {
   }
 
   // Separate Alias Export
-  exportAliases(profile, environment = profile.mode) {
+  exportAliases(profile) {
     try {
       const content = this.generateAliasFile(profile)
       this.downloadFile(
         content,
-        this.generateAliasFileName(profile, 'txt', environment),
+        this.generateAliasFileName(profile, 'txt'),
         'text/plain'
       )
 
@@ -797,13 +797,10 @@ export default class STOExportManager {
     return content
   }
 
-  generateAliasFileName(
-    profile,
-    extension,
-    environment = profile.mode || 'space'
-  ) {
+  generateAliasFileName(profile, extension) {
     const safeName = profile.name.replace(/[^a-zA-Z0-9\-_]/g, '_')
     const timestamp = new Date().toISOString().split('T')[0]
+    const environment = profile.mode || 'space'
     return `${safeName}_aliases_${environment}_${timestamp}.${extension}`
   }
 }

--- a/src/js/export.js
+++ b/src/js/export.js
@@ -10,6 +10,7 @@ export default class STOExportManager {
       json_project: 'Complete Project (.json)',
       csv_data: 'CSV Data (.csv)',
       html_report: 'HTML Report (.html)',
+      alias_file: 'Alias File (.txt)',
     }
 
     // Don't initialize immediately - wait for app to be ready
@@ -56,10 +57,14 @@ export default class STOExportManager {
 
     const select = document.getElementById('exportFormat')
     const format = select ? select.value : 'sto_keybind'
+    const envSelect = document.getElementById('exportEnvironment')
+    const environment = envSelect
+      ? envSelect.value
+      : profile.mode || 'space'
 
     switch (format) {
       case 'sto_keybind':
-        this.exportSTOKeybindFile(profile)
+        this.exportSTOKeybindFile(profile, environment)
         break
       case 'json_profile':
         this.exportJSONProfile(profile)
@@ -73,6 +78,9 @@ export default class STOExportManager {
       case 'html_report':
         this.exportHTMLReport(profile)
         break
+      case 'alias_file':
+        this.exportAliases(profile, environment)
+        break
       default:
         break
     }
@@ -81,12 +89,12 @@ export default class STOExportManager {
   }
 
   // STO Keybind File Export
-  exportSTOKeybindFile(profile) {
+  exportSTOKeybindFile(profile, environment = profile.mode) {
     try {
-      const content = this.generateSTOKeybindFile(profile)
+      const content = this.generateSTOKeybindFile(profile, { environment })
       this.downloadFile(
         content,
-        this.generateFileName(profile, 'txt'),
+        this.generateFileName(profile, 'txt', environment),
         'text/plain'
       )
 
@@ -623,10 +631,9 @@ export default class STOExportManager {
   }
 
   // Utility Methods
-  generateFileName(profile, extension) {
+  generateFileName(profile, extension, environment = profile.mode || 'space') {
     const safeName = profile.name.replace(/[^a-zA-Z0-9\-_]/g, '_')
     const timestamp = new Date().toISOString().split('T')[0]
-    const environment = profile.mode || 'space' // Use mode for environment
     return `${safeName}_${environment}_${timestamp}.${extension}`
   }
 
@@ -729,12 +736,12 @@ export default class STOExportManager {
   }
 
   // Separate Alias Export
-  exportAliases(profile) {
+  exportAliases(profile, environment = profile.mode) {
     try {
       const content = this.generateAliasFile(profile)
       this.downloadFile(
         content,
-        this.generateAliasFileName(profile, 'txt'),
+        this.generateAliasFileName(profile, 'txt', environment),
         'text/plain'
       )
 
@@ -790,10 +797,13 @@ export default class STOExportManager {
     return content
   }
 
-  generateAliasFileName(profile, extension) {
+  generateAliasFileName(
+    profile,
+    extension,
+    environment = profile.mode || 'space'
+  ) {
     const safeName = profile.name.replace(/[^a-zA-Z0-9\-_]/g, '_')
     const timestamp = new Date().toISOString().split('T')[0]
-    const environment = profile.mode || 'space'
     return `${safeName}_aliases_${environment}_${timestamp}.${extension}`
   }
 }

--- a/src/js/export.js
+++ b/src/js/export.js
@@ -58,7 +58,7 @@ export default class STOExportManager {
     const select = document.getElementById('exportFormat')
     const format = select ? select.value : 'sto_keybind'
     const envSelect = document.getElementById('exportEnvironment')
-    const environment = envSelect
+    const environment = envSelect && envSelect.value
       ? envSelect.value
       : profile.mode || 'space'
 
@@ -67,16 +67,16 @@ export default class STOExportManager {
         this.exportSTOKeybindFile(profile, environment)
         break
       case 'json_profile':
-        this.exportJSONProfile(profile)
+        this.exportJSONProfile(profile, environment)
         break
       case 'json_project':
         this.exportCompleteProject()
         break
       case 'csv_data':
-        this.exportCSVData(profile)
+        this.exportCSVData(profile, environment)
         break
       case 'html_report':
-        this.exportHTMLReport(profile)
+        this.exportHTMLReport(profile, environment)
         break
       case 'alias_file':
         this.exportAliases(profile)
@@ -395,7 +395,7 @@ export default class STOExportManager {
   }
 
   // JSON Profile Export
-  exportJSONProfile(profile) {
+  exportJSONProfile(profile, environment = profile.mode) {
     try {
       const exportData = {
         version: STO_DATA.settings.version,
@@ -407,7 +407,7 @@ export default class STOExportManager {
       const content = JSON.stringify(exportData, null, 2)
       this.downloadFile(
         content,
-        this.generateFileName(profile, 'json'),
+        this.generateFileName(profile, 'json', environment),
         'application/json'
       )
 
@@ -439,12 +439,12 @@ export default class STOExportManager {
   }
 
   // CSV Data Export
-  exportCSVData(profile) {
+  exportCSVData(profile, environment = profile.mode) {
     try {
       const csvContent = this.generateCSVData(profile)
       this.downloadFile(
         csvContent,
-        this.generateFileName(profile, 'csv'),
+        this.generateFileName(profile, 'csv', environment),
         'text/csv'
       )
 
@@ -486,12 +486,12 @@ export default class STOExportManager {
   }
 
   // HTML Report Export
-  exportHTMLReport(profile) {
+  exportHTMLReport(profile, environment = profile.mode) {
     try {
       const htmlContent = this.generateHTMLReport(profile)
       this.downloadFile(
         htmlContent,
-        this.generateFileName(profile, 'html'),
+        this.generateFileName(profile, 'html', environment),
         'text/html'
       )
 
@@ -632,9 +632,10 @@ export default class STOExportManager {
 
   // Utility Methods
   generateFileName(profile, extension, environment = profile.mode || 'space') {
+    const env = environment || profile.mode || 'space'
     const safeName = profile.name.replace(/[^a-zA-Z0-9\-_]/g, '_')
     const timestamp = new Date().toISOString().split('T')[0]
-    return `${safeName}_${environment}_${timestamp}.${extension}`
+    return `${safeName}_${env}_${timestamp}.${extension}`
   }
 
   downloadFile(content, filename, mimeType) {

--- a/src/js/export.js
+++ b/src/js/export.js
@@ -25,6 +25,11 @@ export default class STOExportManager {
       this.showExportOptions()
     })
 
+    // Confirm export
+    eventBus.onDom('confirmExportBtn', 'click', 'export-confirm', () => {
+      this.performExport()
+    })
+
     // Copy command preview
     eventBus.onDom('copyPreviewBtn', 'click', 'copyPreview', () => {
       this.copyCommandPreview()
@@ -39,9 +44,40 @@ export default class STOExportManager {
       return
     }
 
-    // For now, directly export as STO keybind file
-    // TODO: Add export options modal for different formats
-    this.exportSTOKeybindFile(profile)
+    stoUI.showModal('exportModal')
+  }
+
+  performExport() {
+    const profile = app.getCurrentProfile()
+    if (!profile) {
+      stoUI.showToast('No profile selected to export', 'warning')
+      return
+    }
+
+    const select = document.getElementById('exportFormat')
+    const format = select ? select.value : 'sto_keybind'
+
+    switch (format) {
+      case 'sto_keybind':
+        this.exportSTOKeybindFile(profile)
+        break
+      case 'json_profile':
+        this.exportJSONProfile(profile)
+        break
+      case 'json_project':
+        this.exportCompleteProject()
+        break
+      case 'csv_data':
+        this.exportCSVData(profile)
+        break
+      case 'html_report':
+        this.exportHTMLReport(profile)
+        break
+      default:
+        break
+    }
+
+    stoUI.hideModal('exportModal')
   }
 
   // STO Keybind File Export

--- a/tests/unit/export.test.js
+++ b/tests/unit/export.test.js
@@ -895,11 +895,12 @@ describe('STOExportManager', () => {
     it('should handle different export formats', () => {
       const formats = exportManager.exportFormats
 
-      expect(Object.keys(formats)).toHaveLength(5)
+      expect(Object.keys(formats)).toHaveLength(6)
       expect(formats.sto_keybind).toContain('.txt')
       expect(formats.json_profile).toContain('.json')
       expect(formats.csv_data).toContain('.csv')
       expect(formats.html_report).toContain('.html')
+      expect(formats.alias_file).toContain('.txt')
     })
 
     it('should validate profile before export', () => {
@@ -935,6 +936,23 @@ describe('STOExportManager', () => {
       expect(spy).toHaveBeenCalledWith(app.getCurrentProfile())
       expect(stoUI.hideModal).toHaveBeenCalledWith('exportModal')
     })
+
+    it('should pass environment to keybind export', () => {
+      const format = document.getElementById('exportFormat')
+      format.value = 'sto_keybind'
+      const env = document.getElementById('exportEnvironment')
+      env.value = 'ground'
+
+      const spy = vi
+        .spyOn(exportManager, 'exportSTOKeybindFile')
+        .mockImplementation(() => {})
+      vi.spyOn(stoUI, 'hideModal').mockImplementation(() => {})
+
+      exportManager.performExport()
+
+      expect(spy).toHaveBeenCalledWith(app.getCurrentProfile(), 'ground')
+      expect(stoUI.hideModal).toHaveBeenCalledWith('exportModal')
+    })
   })
 
   describe('alias export functionality', () => {
@@ -966,7 +984,7 @@ describe('STOExportManager', () => {
         mode: 'space',
       }
 
-      const filename = exportManager.generateAliasFileName(profile, 'txt')
+      const filename = exportManager.generateAliasFileName(profile, 'txt', 'space')
 
       expect(filename).toContain('Test_Profile')
       expect(filename).toContain('aliases')

--- a/tests/unit/export.test.js
+++ b/tests/unit/export.test.js
@@ -703,6 +703,13 @@ describe('STOExportManager', () => {
       expect(exportManager.generateFileName(profile, 'html')).toMatch(/\.html$/)
     })
 
+    it('should fall back to profile mode when environment missing', () => {
+      const profile = { name: 'Test', mode: 'Space' }
+      const filename = exportManager.generateFileName(profile, 'txt', '')
+
+      expect(filename).toMatch(/^Test_Space_\d{4}-\d{2}-\d{2}\.txt$/)
+    })
+
     it('should trigger file download', () => {
       const mockAnchor = {
         click: vi.fn(),
@@ -927,13 +934,17 @@ describe('STOExportManager', () => {
     it('should trigger selected export action from modal', () => {
       const select = document.getElementById('exportFormat')
       select.value = 'csv_data'
+      const env = document.getElementById('exportEnvironment')
+      env.value = 'ground'
 
-      const spy = vi.spyOn(exportManager, 'exportCSVData').mockImplementation(() => {})
+      const spy = vi
+        .spyOn(exportManager, 'exportCSVData')
+        .mockImplementation(() => {})
       vi.spyOn(stoUI, 'hideModal').mockImplementation(() => {})
 
       exportManager.performExport()
 
-      expect(spy).toHaveBeenCalledWith(app.getCurrentProfile())
+      expect(spy).toHaveBeenCalledWith(app.getCurrentProfile(), 'ground')
       expect(stoUI.hideModal).toHaveBeenCalledWith('exportModal')
     })
 

--- a/tests/unit/export.test.js
+++ b/tests/unit/export.test.js
@@ -984,7 +984,7 @@ describe('STOExportManager', () => {
         mode: 'space',
       }
 
-      const filename = exportManager.generateAliasFileName(profile, 'txt', 'space')
+      const filename = exportManager.generateAliasFileName(profile, 'txt')
 
       expect(filename).toContain('Test_Profile')
       expect(filename).toContain('aliases')

--- a/tests/unit/export.test.js
+++ b/tests/unit/export.test.js
@@ -885,19 +885,11 @@ describe('STOExportManager', () => {
 
   describe('export options and configuration', () => {
     it('should show export options dialog', () => {
-      const mockAnchor = {
-        click: vi.fn(),
-        href: '',
-        download: '',
-      }
-      vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor)
-      vi.spyOn(document.body, 'appendChild').mockImplementation(() => {})
-      vi.spyOn(document.body, 'removeChild').mockImplementation(() => {})
+      const spy = vi.spyOn(stoUI, 'showModal').mockImplementation(() => {})
 
       exportManager.showExportOptions()
 
-      // For now it directly exports, but should show options in future
-      expect(mockAnchor.click).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalledWith('exportModal')
     })
 
     it('should handle different export formats', () => {
@@ -929,6 +921,19 @@ describe('STOExportManager', () => {
       expect(() => exportManager.exportJSONProfile(profile)).not.toThrow()
       expect(() => exportManager.exportCSVData(profile)).not.toThrow()
       expect(() => exportManager.exportHTMLReport(profile)).not.toThrow()
+    })
+
+    it('should trigger selected export action from modal', () => {
+      const select = document.getElementById('exportFormat')
+      select.value = 'csv_data'
+
+      const spy = vi.spyOn(exportManager, 'exportCSVData').mockImplementation(() => {})
+      vi.spyOn(stoUI, 'hideModal').mockImplementation(() => {})
+
+      exportManager.performExport()
+
+      expect(spy).toHaveBeenCalledWith(app.getCurrentProfile())
+      expect(stoUI.hideModal).toHaveBeenCalledWith('exportModal')
     })
   })
 


### PR DESCRIPTION
## Summary
- design export options modal in HTML
- implement modal behaviour for choosing export formats
- test export modal interaction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685506658b2c8325b725e61eabfbc8e0