### PR TITLE
Fix i18n initialization timing and import order

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -7,26 +7,6 @@ import en from '../i18n/en.json'
 import de from '../i18n/de.json'
 import fr from '../i18n/fr.json'
 import es from '../i18n/es.json'
-
-await i18next.init({
-  lng: 'en',
-  fallbackLng: 'en',
-  resources: {
-    en: { translation: en },
-    de: { translation: de },
-    fr: { translation: fr },
-    es: { translation: es },
-  },
-})
-
-document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('[data-i18n]').forEach((el) => {
-    const key = el.getAttribute('data-i18n')
-    if (key) {
-      el.textContent = i18next.t(key)
-    }
-  })
-})
 import STOStorage from './storage.js'
 import STOProfileManager from './profiles.js'
 import STOKeybindFileManager from './keybinds.js'
@@ -39,6 +19,32 @@ import STOFileExplorer from './fileexplorer.js'
 import VertigoManager, { VFX_EFFECTS } from './vertigo_data.js'
 import STOToolsKeybindManager from './app.js'
 import './version.js'
+
+await i18next.init({
+  lng: 'en',
+  fallbackLng: 'en',
+  resources: {
+    en: { translation: en },
+    de: { translation: de },
+    fr: { translation: fr },
+    es: { translation: es },
+  },
+})
+
+function applyTranslations() {
+  document.querySelectorAll('[data-i18n]').forEach((el) => {
+    const key = el.getAttribute('data-i18n')
+    if (key) {
+      el.textContent = i18next.t(key)
+    }
+  })
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', applyTranslations)
+} else {
+  applyTranslations()
+}
 
 const stoStorage = new STOStorage()
 const stoProfiles = new STOProfileManager()
@@ -75,3 +81,4 @@ eventBus.on('sto-app-ready', () => {
   stoExport.init()
   stoFileExplorer.init()
 })
+


### PR DESCRIPTION
## Summary
- ensure all imports in `main.js` are at the top of the module
- initialize i18next after imports and apply translations immediately when DOM is already loaded

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68552622dc3483258750f03daafb3dd5