### PR TITLE
Add sync controls to settings menu

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -13,6 +13,8 @@
   "dark_mode": "Dark Mode",
   "load_default_data": "Load Default Data",
   "reset_application": "Reset Application",
+  "set_sync_folder": "Set Sync Folder",
+  "sync_now": "Sync Now",
   "about": "About",
   "new": "New",
   "clone": "Clone",

--- a/src/index.html
+++ b/src/index.html
@@ -132,6 +132,14 @@
                 <i class="fas fa-refresh"></i>
                 <span data-i18n="reset_application"></span>
               </button>
+              <button class="dropdown-item" id="setSyncFolderBtn">
+                <i class="fas fa-folder-open"></i>
+                <span data-i18n="set_sync_folder"></span>
+              </button>
+              <button class="dropdown-item" id="syncNowBtn">
+                <i class="fas fa-sync"></i>
+                <span data-i18n="sync_now"></span>
+              </button>
               <button class="dropdown-item" id="aboutBtn">
                 <i class="fas fa-info-circle"></i>
                 <span data-i18n="about"></span>

--- a/src/js/profiles.js
+++ b/src/js/profiles.js
@@ -92,6 +92,16 @@ export default class STOProfileManager {
       this.closeSettingsMenu()
     })
 
+    eventBus.onDom('setSyncFolderBtn', 'click', 'set-sync-folder', () => {
+      stoSync.setSyncFolder()
+      this.closeSettingsMenu()
+    })
+
+    eventBus.onDom('syncNowBtn', 'click', 'sync-now', () => {
+      stoSync.syncProject()
+      this.closeSettingsMenu()
+    })
+
     eventBus.onDom('aboutBtn', 'click', 'about-open', () => {
       modalManager.show('aboutModal')
     })

--- a/tests/unit/profiles.test.js
+++ b/tests/unit/profiles.test.js
@@ -36,6 +36,8 @@ describe('STOProfileManager', () => {
       </div>
       <button id="importKeybindsBtn"></button>
       <button id="resetAppBtn"></button>
+      <button id="setSyncFolderBtn"></button>
+      <button id="syncNowBtn"></button>
       <button id="aboutBtn"></button>
       <input id="fileInput">
       <div id="profileModal">
@@ -83,6 +85,11 @@ describe('STOProfileManager', () => {
       hide: vi.fn(),
     }
 
+    global.stoSync = {
+      setSyncFolder: vi.fn(),
+      syncProject: vi.fn(),
+    }
+
     // Setup global objects
     global.app = mockApp
     global.stoStorage = mockStorage
@@ -103,6 +110,7 @@ describe('STOProfileManager', () => {
     delete global.stoStorage
     delete global.stoUI
     delete global.modalManager
+    delete global.stoSync
   })
 
   describe('Initialization and setup', () => {
@@ -113,6 +121,8 @@ describe('STOProfileManager', () => {
     it('should setup event listeners on init', () => {
       const profileSelect = document.getElementById('profileSelect')
       const newProfileBtn = document.getElementById('newProfileBtn')
+      const setSyncFolderBtn = document.getElementById('setSyncFolderBtn')
+      const syncNowBtn = document.getElementById('syncNowBtn')
 
       expect(profileSelect).toBeTruthy()
       expect(newProfileBtn).toBeTruthy()
@@ -120,6 +130,12 @@ describe('STOProfileManager', () => {
       // Test that event listeners are attached by triggering events
       newProfileBtn.click()
       expect(modalManager.show).toHaveBeenCalledWith('profileModal')
+
+      setSyncFolderBtn.click()
+      expect(global.stoSync.setSyncFolder).toHaveBeenCalled()
+
+      syncNowBtn.click()
+      expect(global.stoSync.syncProject).toHaveBeenCalled()
     })
 
     it('should handle missing DOM elements gracefully', () => {


### PR DESCRIPTION
## Summary
- add Set Sync Folder and Sync Now buttons to the settings dropdown
- wire buttons to STOSyncManager in profiles
- include text for new buttons in English i18n file
- test sync button events in profile manager unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68556ea505e48325abf618f284b4486c