### PR TITLE
Add sync folder settings

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -95,7 +95,7 @@ const stoUI = new STOUIManager()
 const stoCommands = new STOCommandManager()
 const stoFileExplorer = new STOFileExplorer()
 const vertigoManager = new VertigoManager()
-const stoSync = new STOSyncManager()
+const stoSync = new STOSyncManager(stoStorage)
 Object.assign(window, {
   stoStorage,
   stoProfiles,

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -107,8 +107,10 @@ export default class STOStorage {
   // Get application settings
   getSettings() {
     try {
-      const settings = localStorage.getItem(this.settingsKey)
-      return settings ? JSON.parse(settings) : this.getDefaultSettings()
+      const raw = localStorage.getItem(this.settingsKey)
+      if (!raw) return this.getDefaultSettings()
+      const parsed = JSON.parse(raw)
+      return { ...this.getDefaultSettings(), ...parsed }
     } catch (error) {
       console.error('Error loading settings:', error)
       return this.getDefaultSettings()
@@ -118,7 +120,9 @@ export default class STOStorage {
   // Save application settings
   saveSettings(settings) {
     try {
-      localStorage.setItem(this.settingsKey, JSON.stringify(settings))
+      const current = this.getSettings()
+      const merged = { ...current, ...settings }
+      localStorage.setItem(this.settingsKey, JSON.stringify(merged))
       return true
     } catch (error) {
       console.error('Error saving settings:', error)
@@ -260,6 +264,8 @@ export default class STOStorage {
       defaultMode: 'space',
       compactView: false,
       language: this.detectBrowserLanguage(),
+      syncFolderName: null,
+      autoSync: false,
     }
   }
 

--- a/src/js/sync.js
+++ b/src/js/sync.js
@@ -15,10 +15,20 @@ export async function writeFile(dirHandle, relativePath, contents) {
 }
 
 export default class STOSyncManager {
-  async setSyncFolder() {
+  constructor(storage = null) {
+    this.storage = storage
+  }
+
+  async setSyncFolder(autoSync = false) {
     try {
       const handle = await window.showDirectoryPicker();
       await saveDirectoryHandle(KEY_SYNC_FOLDER, handle);
+      if (this.storage) {
+        const settings = this.storage.getSettings();
+        settings.syncFolderName = handle.name;
+        settings.autoSync = autoSync;
+        this.storage.saveSettings(settings);
+      }
       stoUI.showToast(i18next.t('sync_folder_set'), 'success');
       return handle;
     } catch (error) {

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -276,6 +276,8 @@ describe('STOStorage', () => {
       expect(settings.autoSave).toBe(true)
       expect(settings.showTooltips).toBe(true)
       expect(settings.maxUndoSteps).toBe(50)
+      expect(settings.syncFolderName).toBeNull()
+      expect(settings.autoSync).toBe(false)
     })
 
     it('should save and retrieve custom settings', () => {
@@ -284,6 +286,8 @@ describe('STOStorage', () => {
         autoSave: false,
         showTooltips: false,
         maxUndoSteps: 25,
+        syncFolderName: 'Test',
+        autoSync: true,
       }
 
       const saveResult = storage.saveSettings(customSettings)
@@ -293,6 +297,8 @@ describe('STOStorage', () => {
       expect(retrievedSettings.theme).toBe('dark')
       expect(retrievedSettings.autoSave).toBe(false)
       expect(retrievedSettings.maxUndoSteps).toBe(25)
+      expect(retrievedSettings.syncFolderName).toBe('Test')
+      expect(retrievedSettings.autoSync).toBe(true)
     })
 
     it('should handle corrupted settings gracefully', () => {
@@ -303,6 +309,8 @@ describe('STOStorage', () => {
       // Should return default settings
       expect(settings.theme).toBe('default')
       expect(settings.autoSave).toBe(true)
+      expect(settings.syncFolderName).toBeNull()
+      expect(settings.autoSync).toBe(false)
     })
   })
 

--- a/tests/unit/sync.test.js
+++ b/tests/unit/sync.test.js
@@ -58,11 +58,16 @@ describe('STOSyncManager', () => {
     window.i18next = i18next
     global.stoUI = { showToast: vi.fn() }
     global.stoExport = { syncToFolder: vi.fn() }
-    sync = new STOSyncManager()
+    global.stoStorage = {
+      getSettings: vi.fn().mockReturnValue({}),
+      saveSettings: vi.fn(),
+    }
+    sync = new STOSyncManager(global.stoStorage)
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
+    delete global.stoStorage
   })
 
   it('setSyncFolder stores selected handle', async () => {
@@ -72,6 +77,20 @@ describe('STOSyncManager', () => {
     expect(showDirectoryPicker).toHaveBeenCalled()
     expect(saveDirectoryHandle).toHaveBeenCalledWith('sync-folder', handle)
     expect(stoUI.showToast).toHaveBeenCalled()
+    expect(stoStorage.saveSettings).toHaveBeenCalledWith({
+      syncFolderName: handle.name,
+      autoSync: false,
+    })
+  })
+
+  it('setSyncFolder can enable autoSync', async () => {
+    const handle = new MockDirHandle()
+    global.showDirectoryPicker = vi.fn().mockResolvedValue(handle)
+    await sync.setSyncFolder(true)
+    expect(stoStorage.saveSettings).toHaveBeenCalledWith({
+      syncFolderName: handle.name,
+      autoSync: true,
+    })
   })
 
   it('getSyncFolderHandle retrieves stored handle', async () => {


### PR DESCRIPTION
## Summary
- extend default settings with `syncFolderName` and `autoSync`
- merge settings on save/load
- store folder name & autosync flag when selecting sync folder
- inject storage into `STOSyncManager`
- update unit tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855910f3c98832589a2dafe0dc422f9