### PR TITLE
Add sync status i18n strings

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -500,6 +500,9 @@
   "sync_folder_set": "Sync folder selected",
   "failed_to_set_sync_folder": "Failed to select sync folder: {{error}}",
   "no_sync_folder_selected": "No sync folder selected",
+  "sync_folder_not_set": "No sync folder selected",
+  "sync_complete": "Exported project to sync folder",
+  "sync_error": "Failed to sync project",
   "project_synced_successfully": "Project synchronized successfully",
   "permission_denied_to_folder": "Permission denied to write to folder",
   "failed_to_sync_project": "Failed to sync project: {{error}}"

--- a/src/js/sync.js
+++ b/src/js/sync.js
@@ -68,7 +68,7 @@ export default class STOSyncManager {
   async syncProject() {
     const handle = await this.getSyncFolderHandle();
     if (!handle) {
-      stoUI.showToast(i18next.t('no_sync_folder_selected'), 'warning');
+      stoUI.showToast(i18next.t('sync_folder_not_set'), 'warning');
       return;
     }
     const allowed = await this.ensurePermission(handle);
@@ -78,12 +78,9 @@ export default class STOSyncManager {
     }
     try {
       await stoExport.syncToFolder(handle);
-      stoUI.showToast(i18next.t('project_synced_successfully'), 'success');
+      stoUI.showToast(i18next.t('sync_complete'), 'success');
     } catch (error) {
-      stoUI.showToast(
-        i18next.t('failed_to_sync_project', { error: error.message }),
-        'error'
-      );
+      stoUI.showToast(i18next.t('sync_error'), 'error');
     }
   }
 }


### PR DESCRIPTION
## Summary
- add English translations for sync status messages
- show new i18n sync messages in the sync manager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68559317ed848325b2ba9628d367c0f8