### PR TITLE
Refactor modal manager integration across UI components

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -483,9 +483,7 @@ export default class STOToolsKeybindManager {
   checkAndShowWelcomeMessage() {
     if (this.isFirstTime()) {
       localStorage.setItem('sto_keybind_manager_visited', 'true')
-      if (typeof modalManager !== 'undefined') {
-        modalManager.show('aboutModal')
-      }
+      this.modalManagerService.show('aboutModal')
     }
   }
 }

--- a/src/js/components/services/ModalManagerService.js
+++ b/src/js/components/services/ModalManagerService.js
@@ -16,11 +16,6 @@ export default class ModalManagerService extends ComponentBase {
     this.registerAllModalCallbacks()
     this.setupEventListeners()
 
-    // Register global instance for legacy code paths
-    if (typeof window !== 'undefined') {
-      window.modalManager = this
-    }
-
     // Re-translate currently open modal whenever language changes
     if (typeof window !== 'undefined' && window.i18next) {
       window.i18next.on('languageChanged', () => {

--- a/src/js/components/ui/AliasBrowserUI.js
+++ b/src/js/components/ui/AliasBrowserUI.js
@@ -23,7 +23,7 @@ export default class AliasBrowserUI extends ComponentBase {
                 document = (typeof window !== 'undefined' ? window.document : undefined) } = {}) {
     super(bus)
     this.componentName = 'AliasBrowserUI'
-    this.modalManager = modalManager || (typeof window !== 'undefined' ? window.modalManager : null)
+    this.modalManager = modalManager
     this.confirmDialog = confirmDialog || (typeof window !== 'undefined' ? window.confirmDialog : null)
     this.document = document
   }

--- a/src/js/components/ui/ConfirmDialogUI.js
+++ b/src/js/components/ui/ConfirmDialogUI.js
@@ -9,7 +9,7 @@ export default class ConfirmDialogUI extends ComponentBase {
   constructor({ modalManager = null, i18n = null } = {}) {
     super()
     this.componentName = 'ConfirmDialogUI'
-    this.modalManager = modalManager || (typeof window !== 'undefined' ? window.modalManager : null)
+    this.modalManager = modalManager
     this.i18n = i18n || (typeof i18next !== 'undefined' ? i18next : null)
   }
 

--- a/src/js/components/ui/InputDialogUI.js
+++ b/src/js/components/ui/InputDialogUI.js
@@ -9,7 +9,7 @@ export default class InputDialogUI extends ComponentBase {
   constructor({ modalManager = null, i18n = null } = {}) {
     super()
     this.componentName = 'InputDialogUI'
-    this.modalManager = modalManager || (typeof window !== 'undefined' ? window.modalManager : null)
+    this.modalManager = modalManager
     this.i18n = i18n || (typeof i18next !== 'undefined' ? i18next : null)
   }
 

--- a/src/js/components/ui/KeyBrowserUI.js
+++ b/src/js/components/ui/KeyBrowserUI.js
@@ -15,7 +15,7 @@ export default class KeyBrowserUI extends UIComponentBase {
     super(eventBus)
     this.componentName = 'KeyBrowserUI'
     this.app      = app || (typeof window.app !== 'undefined' ? window.app : null)
-    this.modalManager = modalManager || (typeof window !== 'undefined' ? window.modalManager : null)
+    this.modalManager = modalManager
     this.confirmDialog = confirmDialog || (typeof window !== 'undefined' ? window.confirmDialog : null)
     this.i18n = i18n || (typeof i18next !== 'undefined' ? i18next : null)
     this.document = document

--- a/src/js/components/ui/KeyCaptureUI.js
+++ b/src/js/components/ui/KeyCaptureUI.js
@@ -23,7 +23,7 @@ export default class KeyCaptureUI extends ComponentBase {
     super(eventBus)
     this.componentName = 'KeyCaptureUI'
 
-    this.modalManager = modalManager || (typeof window !== 'undefined' ? window.modalManager : null)
+    this.modalManager = modalManager
     this.app          = app || (typeof window !== 'undefined' ? window.app : null)
     this.document     = document
     this.ui           = ui || (typeof window !== 'undefined' ? window.stoUI : null)


### PR DESCRIPTION
- Updated the `STOToolsKeybindManager` to use the `modalManagerService` directly for showing the welcome message, improving encapsulation.
- Removed legacy global `modalManager` references from `ModalManagerService` to streamline the service's usage.
- Adjusted UI components (`AliasBrowserUI`, `ConfirmDialogUI`, `InputDialogUI`, `KeyBrowserUI`, `KeyCaptureUI`) to directly accept `modalManager` as a parameter, enhancing dependency injection and reducing reliance on global state.